### PR TITLE
Add Comprehensive Failure Reporting and Enhanced Export Capabilities

### DIFF
--- a/IntuneAssignmentChecker.ps1
+++ b/IntuneAssignmentChecker.ps1
@@ -1771,7 +1771,7 @@ function Show-SaveFileDialog {
         [string]$DefaultFileName
     )
 
-    # If running on macOS, auto-save to a default temp directory
+    # If running on macOS, auto-save to the Downloads/IntuneAssignmentChecker_Reports directory under the user's profile
     if ($IsMacOS) {
         $reportDir = Join-Path -Path ([Environment]::GetFolderPath("UserProfile")) -ChildPath "Downloads/IntuneAssignmentChecker_Reports"
         if (-not (Test-Path $reportDir)) {


### PR DESCRIPTION
# Add Comprehensive Failure Reporting and Enhanced Export Capabilities

Fixes #74

## Summary

This PR introduces a comprehensive suite of reporting functions for Intune assignments, enabling administrators to quickly identify and analyze deployment issues across applications, compliance policies, and configuration policies. The changes also improve cross-platform compatibility with enhanced macOS support. When using command-line parameters, all summary reports show data for all items without filtering, while granular filtering by name remains available in interactive mode.

## What's Changed

### New Reporting Functions

#### Core Summary Functions

1. **Get-AppsInstallSummaryReport** (Lines 1012-1076)
   - Retrieves detailed installation statistics for all or specific applications
   - Calculates success rates, failure counts, and deployment status
   - Supports searching by app name
   - Returns comprehensive metrics including installed, failed, pending, and not installed counts

2. **Get-CompliancePolicyDeviceSummaryReport** (Lines 1078-1228)
   - Generates compliance status summaries for device compliance policies
   - Supports filtering by policy name, ID, or platform (Windows, iOS, Android, macOS)
   - Calculates compliance rates and device counts by status
   - Includes platform-specific filtering capabilities

3. **Get-ConfigurationPolicyDeviceSummaryReport** (Lines 1230-1509)
   - Provides deployment status for configuration policies
   - Handles both Settings Catalog and Device Configuration policies
   - Calculates success rates and failure metrics
   - Supports filtering by policy name or platform

#### Failure Analysis Functions

4. **Get-AppInstallFailuresReport** (Lines 1511-1552)
   - Filters applications with failure rates above configurable threshold (default 60%)
   - Calculates failure rate based on actual FailedCount: `(FailedCount / TotalCount) * 100`
   - Excludes apps with no devices (TotalCount = 0) from analysis
   - Returns results sorted by failure rate (highest first)

5. **Get-CompliancePolicyFailuresReport** (Lines 1554-1594)
   - Identifies compliance policies with high non-compliance rates
   - Supports filtering by policy name and platform
   - Automatically includes all policies when no specific policy is specified
   - Calculates non-compliance rate as `(100 - ComplianceRate)`

6. **Get-ConfigurationPolicyFailuresReport** (Lines 1596-1636)
   - Detects configuration policies with high failure rates
   - Calculates failure rate: `((NonCompliantCount + ErrorCount) / TotalDevices) * 100`
   - Supports filtering by policy name and platform
   - Includes all policies by default when no filter is specified

### 📊 New Menu Options

<img width="424" height="424" alt="image" src="https://github.com/user-attachments/assets/b71ce369-ad79-4596-aed5-eca462c08f0b" />

<img width="757" height="396" alt="image" src="https://github.com/user-attachments/assets/9dc34105-be4c-4d14-ab65-225a2ff04737" />


Added six new reporting options to the main menu (Lines 1748-1753):

- **Option 12**: App Install Summary Report
- **Option 13**: App Install Failures (>60% failure rate)
- **Option 14**: Compliance Policy Deployment Summary
- **Option 15**: Compliance Policy Failures (>60% non-compliance)
- **Option 16**: Configuration Policy Deployment Summary
- **Option 17**: Configuration Policy Failures (>60% failure rate)

### 🎯 Parameter Mode Behavior

When using the script with command-line switches (`-ShowAppInstallSummary`, `-ShowComplianceSummary`, `-ShowConfigurationSummary`):
- Reports automatically show data for **all** apps/policies without filtering
- No name-based filtering parameters are available in parameter mode
- This ensures consistent, comprehensive summaries for automation scenarios

For granular filtering by specific app or policy names, use the interactive mode (menu-driven interface).

### 🖥️ Enhanced macOS Compatibility

#### Updated Export-ResultsIfRequested Function (Lines 1787-1842)

- Added macOS detection using built-in `$IsMacOS` variable
- On macOS, automatically saves to user's Downloads folder: `~/Downloads/IntuneAssignmentChecker_Reports/`
- Bypasses Windows-specific Show-SaveFileDialog on macOS
- Generates timestamped filenames when no default is provided
- Shows export path to user for transparency

### 📁 Export Functionality

All reporting options (12-17) now support CSV export with:

- Interactive export prompt when not using -ExportToCSV parameter
- Proper ArrayList conversion to prevent type conversion errors
- Descriptive default filenames:
  - AppInstallSummary.csv
  - AppInstallFailures.csv
  - CompliancePolicySummary.csv
  - CompliancePolicyFailures.csv
  - ConfigurationPolicySummary.csv
  - ConfigurationPolicyFailures.csv

## Technical Implementation Details

### Key Features of Reporting Functions

1. **Consistent Error Handling**: All functions include try-catch blocks with detailed error messages
2. **Progress Tracking**: Functions use Write-Progress for long-running operations
3. **Flexible Filtering**: Support for name-based and platform-based filtering
4. **Batch Processing**: Optimized API calls for better performance with large datasets
5. **Null Safety**: Proper handling of empty results and missing data

### Data Processing

- All functions return structured PSCustomObjects for consistent data handling
- Automatic calculation of derived metrics (success rates, failure percentages)
- Support for both interactive and parameter-based execution modes

## Testing Recommendations

1. Test all new menu options (12-17) in interactive mode
2. Verify export functionality on both Windows and macOS
3. Test with various failure thresholds (default 60%)
4. Validate parameter mode functionality
5. Test with empty result sets to ensure proper handling
6. Verify platform filtering works correctly
7. Test with large datasets to ensure performance

## Breaking Changes

None - all changes are backward compatible.
## Migration Notes

Users on macOS will now see exports saved to their Downloads folder instead of file dialog prompts. The folder location is: `~/Downloads/IntuneAssignmentChecker_Reports/`