### PR TITLE
Added assignmenturi's for virtualendpoints and devicemanagement policies

### DIFF
--- a/IntuneAssignmentChecker.ps1
+++ b/IntuneAssignmentChecker.ps1
@@ -625,6 +625,18 @@ function Get-IntuneAssignments {
         # Example: deviceAppManagement/iosManagedAppProtections
         $actualAssignmentsUri = "$GraphEndpoint/beta/$EntityType('$EntityId')/assignments" # EntityType already includes deviceAppManagement
     }
+    elseif ($EntityType -like "virtualEndpoint/provisioningPolicies") {
+        #CloudPC Provisioning Profiles
+        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/virtualEndpoint/provisioningPolicies('$EntityId')?$expand=assignments"
+    }
+    elseif ($EntityType -like "virtualEndpoint/userSettings") {
+        # CloudPC User Settings
+        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/virtualEndpoint/userSettings('$EntityId')?$expand=assignments"
+    }
+    elseif ($EntityType -like "deviceManagement/configurationPolicies") {
+        # Devicemanagement configuration policies
+        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/configurationPolicies('$EntityId')?$expand=assignments"
+    }
     else {
         # General device management entities
         $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/$EntityType('$EntityId')/assignments"


### PR DESCRIPTION
I received an error querying assignments for Windows 365 provisioning policies and user settings and DeviceManagement configurationpolicies.

It's fixed by adding **?expand=assignments**  to those Graph URI's in the Get-IntuneAssignments function.