### PR TITLE
Fix HTML report export script loading

### DIFF
--- a/IntuneAssignmentChecker.ps1
+++ b/IntuneAssignmentChecker.ps1
@@ -7062,16 +7062,26 @@ do {
         '7' {
             Write-Host "Generating HTML Report..." -ForegroundColor Green
 
-            # Download html-export.ps1 from GitHub
+            # Prefer the bundled html-export.ps1 and fall back to GitHub only if it is missing
             $htmlExportUrl = "https://raw.githubusercontent.com/ugurkocde/IntuneAssignmentChecker/main/html-export.ps1"
-            # Use cross-platform temp path
+            $localHtmlExportPath = Join-Path $PSScriptRoot 'html-export.ps1'
+            # Use cross-platform temp path only when a download is required
             $tempDir = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR } else { [System.IO.Path]::GetTempPath() }
-            $scriptPath = Join-Path $tempDir 'html-export.ps1'
+            $scriptPath = $null
+            $cleanupScript = $false
 
             try {
-                Write-Host "Downloading html-export.ps1 from GitHub..." -ForegroundColor Yellow
-                Invoke-WebRequest -Uri $htmlExportUrl -OutFile $scriptPath -UseBasicParsing
-                Write-Host "Download complete." -ForegroundColor Green
+                if (Test-Path $localHtmlExportPath) {
+                    $scriptPath = $localHtmlExportPath
+                    Write-Host "Using local html-export.ps1 from the repository..." -ForegroundColor Yellow
+                }
+                else {
+                    $scriptPath = Join-Path $tempDir 'html-export.ps1'
+                    $cleanupScript = $true
+                    Write-Host "Downloading html-export.ps1 from GitHub..." -ForegroundColor Yellow
+                    Invoke-WebRequest -Uri $htmlExportUrl -OutFile $scriptPath -UseBasicParsing
+                    Write-Host "Download complete." -ForegroundColor Green
+                }
 
                 . $scriptPath
 
@@ -7112,7 +7122,7 @@ do {
             }
             finally {
                 # Clean up the downloaded script
-                if ($scriptPath -and (Test-Path $scriptPath -ErrorAction SilentlyContinue)) {
+                if ($cleanupScript -and $scriptPath -and (Test-Path $scriptPath -ErrorAction SilentlyContinue)) {
                     Remove-Item $scriptPath -Force
                     Write-Host "Cleaned up temporary files." -ForegroundColor Gray
                 }

--- a/html-export.ps1
+++ b/html-export.ps1
@@ -552,7 +552,7 @@ function Export-HTMLReport {
                         if (filterValue === 'all') {
                             dataTable.column(colIdx).search('').draw();
                         } else {
-                            var escaped = filterValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                            var escaped = filterValue.replace(/[.*+?^`${}()|[\]\\]/g, '\\$&');
                             dataTable.column(colIdx).search('(?:^|,\\s*)' + escaped + '(?:\\s*,|$)', true, false).draw();
                         }
                     }
@@ -569,7 +569,7 @@ function Export-HTMLReport {
                         if (filterValue === 'all') {
                             dataTable.column(colIdx).search('').draw();
                         } else {
-                            var escaped = filterValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                            var escaped = filterValue.replace(/[.*+?^`${}()|[\]\\]/g, '\\$&');
                             dataTable.column(colIdx).search('^' + escaped + '$', true, false).draw();
                         }
                     }


### PR DESCRIPTION
Escape the embedded JavaScript regex in html-export.ps1 so PowerShell no longer parses ${} as an empty variable reference during HTML report generation.

Also change option 7 in IntuneAssignmentChecker.ps1 to use the bundled html-export.ps1 from the repository first and only download from GitHub as a fallback. This makes local runs deterministic and avoids breaking when the remote copy is out of sync or still contains the parsing bug.

Fix for issue #105