### PR TITLE
Fix README runbook example to use HTMLReportPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ param(
     [string]$TenantId,
     [string]$CertificateThumbprint,
     [string]$ClientSecret,
-    [string]$ExportPath = "C:\\Temp\\IntuneAssignmentReport.html"
+    [string]$HTMLReportPath = "C:\\Temp\\IntuneAssignmentReport.html"
 )
 
 # Ensure IntuneAssignmentChecker is available
@@ -429,7 +429,7 @@ $authParams = @{
     GenerateHTMLReport = $true
     AppId              = $AppId
     TenantId           = $TenantId
-    ExportPath         = $ExportPath
+    HTMLReportPath     = $HTMLReportPath
 }
 
 if ($CertificateThumbprint) {


### PR DESCRIPTION
## Summary

- The example Azure Automation runbook in the README used `ExportPath` (CSV export) instead of `HTMLReportPath` (HTML report output)
- Updated the param declaration and splatted hash to use `HTMLReportPath`

Fixes #118