### PR TITLE
v4.3: Fix issues #123, #124, #125, #126

### DIFF
--- a/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psd1
+++ b/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'IntuneAssignmentChecker.psm1'
-    ModuleVersion     = '4.2.0'
+    ModuleVersion     = '4.3.0'
     GUID              = 'c6e25ec6-5787-45ef-95af-8abeb8a17daf'
     Author            = 'Ugur Koc'
     CompanyName       = 'Community'
@@ -43,6 +43,15 @@
             ProjectUri   = 'https://github.com/ugurkocde/IntuneAssignmentChecker'
             IconUri      = ''
             ReleaseNotes = @'
+Version 4.3.0:
+- Show applications where the checked group is excluded in Get-IntuneGroupAssignment; Compare-IntuneGroupAssignment now marks excluded apps with [EXCLUDED] (issue #126).
+- Rebuild the ten category-walk cmdlets on a shared scan engine: entity sets are fetched once per run (dozens fewer Graph calls), transient per-category failures no longer abort a run, and errors are raised on the error stream for automation (issue #123).
+- Fix App Protection policies showing for every user regardless of group membership, app intent misclassification, broken multi-device input, junk rows in CSV exports, missing pagination past 100 items in group memberships / comparisons / assignment failures, and Get-IntuneEmptyGroup categories that were displayed but never checked.
+- Security hardening: HTML-encode report values, escape OData group-name filters, URL-encode guest UPNs, add -ClientSecretCredential (PSCredential) as the preferred client secret input.
+- Fix EDR policies missing from HTML reports due to a template mapping typo.
+- Switch-Tenant now connects with the correct permission scopes and refreshes cached filter and group lookups.
+- Register-IntuneAssignmentCheckerApp grants all documented permissions, uses a cross-platform temp path, and cleans up its temporary client secret on failure (issue #124).
+
 Version 4.2.0:
 - Add -AccessToken (SecureString) parameter for non-interactive authentication using a pre-fetched Microsoft Graph token (Azure Automation managed identities, Azure Functions, federated credentials, parent-script Connect-MgGraph sessions).
 - Extend Test-IntuneGroupMembership and Test-IntuneGroupRemoval to accept a Device in addition to a User. The simulation now unions user-side and device-side group memberships.

--- a/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psm1
+++ b/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psm1
@@ -18,6 +18,19 @@ $script:IntentTemplateSubtypeToFamily = @{
     'accountProtection'               = 'endpointSecurityAccountProtection'
 }
 
+# Required Microsoft Graph permissions (shared by Connect-IntuneAssignmentChecker and Switch-Tenant)
+$script:RequiredPermissions = @(
+    @{ Permission = "User.Read.All";                         Reason = "Required to read user profile information and check group memberships" }
+    @{ Permission = "Group.Read.All";                        Reason = "Needed to read group information and memberships" }
+    @{ Permission = "DeviceManagementConfiguration.Read.All"; Reason = "Allows reading Intune device configuration policies and their assignments" }
+    @{ Permission = "DeviceManagementApps.Read.All";         Reason = "Necessary to read mobile app management policies and app configurations" }
+    @{ Permission = "DeviceManagementManagedDevices.Read.All"; Reason = "Required to read managed device information and compliance policies" }
+    @{ Permission = "Device.Read.All";                       Reason = "Needed to read device information from Entra ID" }
+    @{ Permission = "DeviceManagementScripts.Read.All";      Reason = "Needed to read device management and health scripts" }
+    @{ Permission = "CloudPC.Read.All";                      Reason = "Required to read Windows 365 Cloud PC provisioning policies and settings (optional if W365 not licensed)" }
+    @{ Permission = "DeviceManagementRBAC.Read.All";         Reason = "Required to read role scope tags for scope tag display and filtering" }
+)
+
 # Dot-source all private functions
 $Private = @(Get-ChildItem -Path "$PSScriptRoot/Private/*.ps1" -ErrorAction SilentlyContinue)
 foreach ($file in $Private) {

--- a/Module/IntuneAssignmentChecker/Private/Add-AppExportData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-AppExportData.ps1
@@ -1,4 +1,5 @@
 function Add-AppExportData {
+    [CmdletBinding()]
     param (
         [System.Collections.ArrayList]$ExportData,
         [string]$Category,

--- a/Module/IntuneAssignmentChecker/Private/Add-CategoryExportData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-CategoryExportData.ps1
@@ -1,0 +1,53 @@
+function Add-CategoryExportData {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.ArrayList]$ExportData,
+
+        # Category registry entries from Get-IntuneCategoryDefinition; export rows are
+        # emitted in registry order so CSV output matches the pre-refactor sequence.
+        [Parameter(Mandatory = $true)]
+        [object[]]$Categories,
+
+        # Bucket hashtable as returned by Invoke-IntuneCategoryScan (possibly filtered).
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Buckets,
+
+        # Passed through to Add-ExportData when provided (string or scriptblock).
+        [Parameter(Mandatory = $false)]
+        [object]$AssignmentReason
+    )
+
+    # Categories may share a bucket (e.g. Compare's ShellScripts feed PlatformScripts);
+    # export each bucket only once, under the first category that declares it.
+    $exportedBucketKeys = [System.Collections.Generic.HashSet[string]]::new()
+
+    foreach ($category in $Categories) {
+        foreach ($bucketKey in $category.BucketKeys) {
+            if (-not $exportedBucketKeys.Add($bucketKey)) { continue }
+
+            $label = if ($category.BucketExportCategories) {
+                $category.BucketExportCategories[$bucketKey]
+            }
+            else {
+                $category.ExportCategory
+            }
+            if (-not $label) { continue }
+
+            $items = if ($Buckets.ContainsKey($bucketKey)) { @($Buckets[$bucketKey]) } else { @() }
+
+            # Empty buckets still go through Add-ExportData as a no-op, matching the
+            # unconditional per-category calls the cmdlets made before the migration.
+            $addParams = @{
+                ExportData = $ExportData
+                Category   = $label
+                Items      = $items
+            }
+            if ($PSBoundParameters.ContainsKey('AssignmentReason')) {
+                $addParams.AssignmentReason = $AssignmentReason
+            }
+            Add-ExportData @addParams
+        }
+    }
+}

--- a/Module/IntuneAssignmentChecker/Private/Add-ExportData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-ExportData.ps1
@@ -1,4 +1,5 @@
 function Add-ExportData {
+    [CmdletBinding()]
     param (
         [System.Collections.ArrayList]$ExportData,
         [string]$Category,

--- a/Module/IntuneAssignmentChecker/Private/Add-IntentTemplateFamilyInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-IntentTemplateFamilyInfo.ps1
@@ -1,4 +1,5 @@
 function Add-IntentTemplateFamilyInfo {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
         $IntentPolicies

--- a/Module/IntuneAssignmentChecker/Private/Export-PolicyData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Export-PolicyData.ps1
@@ -1,4 +1,5 @@
 function Export-PolicyData {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [System.Collections.ArrayList]$ExportData,

--- a/Module/IntuneAssignmentChecker/Private/Export-ResultsIfRequested.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Export-ResultsIfRequested.ps1
@@ -3,7 +3,9 @@ function Export-ResultsIfRequested {
         [System.Collections.ArrayList]$ExportData,
         [string]$DefaultFileName,
         [switch]$ForceExport,
-        [string]$CustomExportPath
+        [string]$CustomExportPath,
+        [switch]$ExportToCSV,
+        [switch]$ParameterMode
     )
 
     if ($ForceExport -or $ExportToCSV) {
@@ -18,7 +20,7 @@ function Export-ResultsIfRequested {
             Export-PolicyData -ExportData $ExportData -FilePath $exportPath
         }
     }
-    elseif (-not $parameterMode) {
+    elseif (-not $ParameterMode) {
         $export = Read-Host "`nWould you like to export the results to CSV? (y/n)"
         if ($export -match '^[Yy]') {
             $exportPath = Show-SaveFileDialog -DefaultFileName $DefaultFileName

--- a/Module/IntuneAssignmentChecker/Private/Export-ResultsIfRequested.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Export-ResultsIfRequested.ps1
@@ -1,4 +1,5 @@
 function Export-ResultsIfRequested {
+    [CmdletBinding()]
     param (
         [System.Collections.ArrayList]$ExportData,
         [string]$DefaultFileName,

--- a/Module/IntuneAssignmentChecker/Private/Filter-ByScopeTag.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Filter-ByScopeTag.ps1
@@ -1,4 +1,5 @@
 function Filter-ByScopeTag {
+    [CmdletBinding()]
     param (
         [object[]]$Items,
         [string]$FilterTag,

--- a/Module/IntuneAssignmentChecker/Private/Format-AssignmentFilter.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Format-AssignmentFilter.ps1
@@ -1,4 +1,5 @@
 function Format-AssignmentFilter {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
         [AllowNull()]

--- a/Module/IntuneAssignmentChecker/Private/Format-AssignmentSummaryLine.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Format-AssignmentSummaryLine.ps1
@@ -1,4 +1,5 @@
 function Format-AssignmentSummaryLine {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [object]$Assignment

--- a/Module/IntuneAssignmentChecker/Private/Get-AllTargetReason.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AllTargetReason.ps1
@@ -1,4 +1,5 @@
 function Get-AllTargetReason {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [AllowNull()]

--- a/Module/IntuneAssignmentChecker/Private/Get-AppProtectionAssignmentUri.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AppProtectionAssignmentUri.ps1
@@ -1,0 +1,20 @@
+function Get-AppProtectionAssignmentUri {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [object]$Policy
+    )
+
+    $specificPolicyTypePath = switch ($Policy.'@odata.type') {
+        "#microsoft.graph.androidManagedAppProtection" { "androidManagedAppProtections" }
+        "#microsoft.graph.iosManagedAppProtection" { "iosManagedAppProtections" }
+        "#microsoft.graph.windowsManagedAppProtection" { "windowsManagedAppProtections" }
+        default { $null }
+    }
+
+    if (-not $specificPolicyTypePath) {
+        return $null
+    }
+
+    return "$script:GraphEndpoint/beta/deviceAppManagement/$specificPolicyTypePath('$($Policy.id)')/assignments"
+}

--- a/Module/IntuneAssignmentChecker/Private/Get-AssignmentFailures.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AssignmentFailures.ps1
@@ -1,4 +1,6 @@
 function Get-AssignmentFailures {
+    [CmdletBinding()]
+    param()
     Write-Host "Fetching assignment failures..." -ForegroundColor Green
 
     $failedAssignments = [System.Collections.ArrayList]::new()

--- a/Module/IntuneAssignmentChecker/Private/Get-AssignmentFailures.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AssignmentFailures.ps1
@@ -77,8 +77,7 @@ function Get-AssignmentFailures {
     # 2. Get Device Configuration Policy Failures
     Write-Host "Checking device configuration policy failures..." -ForegroundColor Yellow
     try {
-        $configPoliciesUri = "$script:GraphEndpoint/beta/deviceManagement/deviceConfigurations"
-        $configPolicies = (Invoke-MgGraphRequest -Uri $configPoliciesUri -Method GET).value
+        $configPolicies = Get-IntuneEntities -EntityType "deviceConfigurations"
 
         foreach ($policy in $configPolicies) {
             $skip = 0
@@ -120,12 +119,18 @@ function Get-AssignmentFailures {
     # 3. Get Compliance Policy Failures
     Write-Host "Checking compliance policy failures..." -ForegroundColor Yellow
     try {
-        $compliancePoliciesUri = "$script:GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies"
-        $compliancePolicies = (Invoke-MgGraphRequest -Uri $compliancePoliciesUri -Method GET).value
+        $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
 
         foreach ($policy in $compliancePolicies) {
+            $statuses = [System.Collections.ArrayList]::new()
             $statusUri = "$script:GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies('$($policy.id)')/deviceStatuses"
-            $statuses = (Invoke-MgGraphRequest -Uri $statusUri -Method GET).value
+            do {
+                $statusResponse = Invoke-MgGraphRequest -Uri $statusUri -Method GET
+                if ($statusResponse -and $null -ne $statusResponse.value) {
+                    $statuses.AddRange([object[]]$statusResponse.value)
+                }
+                $statusUri = $statusResponse.'@odata.nextLink'
+            } while (![string]::IsNullOrEmpty($statusUri))
 
             $failures = $statuses | Where-Object {
                 $_.status -in @("error", "conflict", "notApplicable", "nonCompliant")

--- a/Module/IntuneAssignmentChecker/Private/Get-AssignmentFilterLookup.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AssignmentFilterLookup.ps1
@@ -1,4 +1,6 @@
 function Get-AssignmentFilterLookup {
+    [CmdletBinding()]
+    param()
     $lookup = @{}
     try {
         $uri = "$script:GraphEndpoint/beta/deviceManagement/assignmentFilters?`$select=id,displayName,platform"

--- a/Module/IntuneAssignmentChecker/Private/Get-AssignmentInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-AssignmentInfo.ps1
@@ -1,4 +1,5 @@
 function Get-AssignmentInfo {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [AllowNull()]

--- a/Module/IntuneAssignmentChecker/Private/Get-DeviceInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-DeviceInfo.ps1
@@ -1,4 +1,5 @@
 function Get-DeviceInfo {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$DeviceName

--- a/Module/IntuneAssignmentChecker/Private/Get-DeviceInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-DeviceInfo.ps1
@@ -7,7 +7,7 @@ function Get-DeviceInfo {
 
     $selectProps = "id,displayName,operatingSystem,operatingSystemVersion,managementType,deviceOwnership,trustType,isCompliant,isManaged,approximateLastSignInDateTime,manufacturer,model,enrollmentProfileName"
     $escapedName = $DeviceName -replace "'", "''"
-    $deviceUri = "$GraphEndpoint/beta/devices?`$filter=displayName eq '$escapedName'&`$select=$selectProps"
+    $deviceUri = "$script:GraphEndpoint/beta/devices?`$filter=displayName eq '$escapedName'&`$select=$selectProps"
     try {
         $deviceResponse = Invoke-MgGraphRequest -Uri $deviceUri -Method Get
     }

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupAssignmentReasons.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupAssignmentReasons.ps1
@@ -1,4 +1,5 @@
 function Get-GroupAssignmentReasons {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
@@ -13,7 +13,7 @@ function Get-GroupInfo {
     }
 
     try {
-        $groupUri = "$GraphEndpoint/v1.0/groups/$GroupId"
+        $groupUri = "$script:GraphEndpoint/v1.0/groups/$GroupId"
         $group = Invoke-MgGraphRequest -Uri $groupUri -Method Get
         $result = @{
             Id          = $group.id

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
@@ -4,20 +4,30 @@ function Get-GroupInfo {
         [string]$GroupId
     )
 
+    if ($null -eq $script:GroupInfoCache) {
+        $script:GroupInfoCache = @{}
+    }
+    if ($script:GroupInfoCache.ContainsKey($GroupId)) {
+        return $script:GroupInfoCache[$GroupId]
+    }
+
     try {
         $groupUri = "$GraphEndpoint/v1.0/groups/$GroupId"
         $group = Invoke-MgGraphRequest -Uri $groupUri -Method Get
-        return @{
+        $result = @{
             Id          = $group.id
             DisplayName = $group.displayName
             Success     = $true
         }
     }
     catch {
-        return @{
+        $result = @{
             Id          = $GroupId
             DisplayName = "Unknown Group"
             Success     = $false
         }
     }
+
+    $script:GroupInfoCache[$GroupId] = $result
+    return $result
 }

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
@@ -1,4 +1,5 @@
 function Get-GroupInfo {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$GroupId

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupMemberships.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupMemberships.ps1
@@ -8,11 +8,18 @@ function Get-GroupMemberships {
         [string]$ObjectType
     )
 
-    $uri = "$GraphEndpoint/v1.0/$($ObjectType.ToLower())s/$ObjectId/transitiveMemberOf?`$select=id,displayName"
+    $memberships = [System.Collections.ArrayList]::new()
+    $uri = "$script:GraphEndpoint/v1.0/$($ObjectType.ToLower())s/$ObjectId/transitiveMemberOf?`$select=id,displayName"
 
     try {
-        $response = Invoke-MgGraphRequest -Uri $uri -Method Get
-        return $response.value
+        do {
+            $response = Invoke-MgGraphRequest -Uri $uri -Method Get
+            if ($response -and $null -ne $response.value) {
+                $memberships.AddRange([object[]]$response.value)
+            }
+            $uri = $response.'@odata.nextLink'
+        } while (![string]::IsNullOrEmpty($uri))
+        return $memberships
     }
     catch {
         Write-Warning "Error fetching group memberships for $ObjectType '$ObjectId': $($_.Exception.Message)"

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupMemberships.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupMemberships.ps1
@@ -1,4 +1,5 @@
 function Get-GroupMemberships {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$ObjectId,

--- a/Module/IntuneAssignmentChecker/Private/Get-IntentTemplateFamilyLookup.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntentTemplateFamilyLookup.ps1
@@ -1,4 +1,6 @@
 function Get-IntentTemplateFamilyLookup {
+    [CmdletBinding()]
+    param()
     if ($null -ne $script:TemplateIdToFamilyCache) {
         return $script:TemplateIdToFamilyCache
     }

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
@@ -1,4 +1,5 @@
 function Get-IntuneAssignments {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$EntityType,

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
@@ -28,18 +28,9 @@ function Get-IntuneAssignments {
         $policyDetailsUri = "$GraphEndpoint/beta/deviceAppManagement/managedAppPolicies/$EntityId"
         try {
             $policyDetailsResponse = Invoke-MgGraphRequest -Uri $policyDetailsUri -Method Get
-            $policyODataType = $policyDetailsResponse.'@odata.type'
-            $specificPolicyTypePath = switch ($policyODataType) {
-                "#microsoft.graph.androidManagedAppProtection" { "androidManagedAppProtections" }
-                "#microsoft.graph.iosManagedAppProtection" { "iosManagedAppProtections" }
-                "#microsoft.graph.windowsManagedAppProtection" { "windowsManagedAppProtections" }
-                default { $null }
-            }
-            if ($specificPolicyTypePath) {
-                $actualAssignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/$specificPolicyTypePath('$EntityId')/assignments"
-            }
-            else {
-                Write-Warning "Could not determine specific App Protection Policy type for $EntityId from OData type '$policyODataType'."
+            $actualAssignmentsUri = Get-AppProtectionAssignmentUri -Policy $policyDetailsResponse
+            if (-not $actualAssignmentsUri) {
+                Write-Warning "Could not determine specific App Protection Policy type for $EntityId from OData type '$($policyDetailsResponse.'@odata.type')'."
                 return [System.Collections.ArrayList]::new() # Return empty ArrayList
             }
         }

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
@@ -25,7 +25,7 @@ function Get-IntuneAssignments {
 
     if ($EntityType -eq "deviceAppManagement/managedAppPolicies") {
         # For generic App Protection Policies, determine the specific policy type first
-        $policyDetailsUri = "$GraphEndpoint/beta/deviceAppManagement/managedAppPolicies/$EntityId"
+        $policyDetailsUri = "$script:GraphEndpoint/beta/deviceAppManagement/managedAppPolicies/$EntityId"
         try {
             $policyDetailsResponse = Invoke-MgGraphRequest -Uri $policyDetailsUri -Method Get
             $actualAssignmentsUri = Get-AppProtectionAssignmentUri -Policy $policyDetailsResponse
@@ -40,21 +40,21 @@ function Get-IntuneAssignments {
         }
     }
     elseif ($EntityType -eq "mobileAppConfigurations") {
-        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileAppConfigurations('$EntityId')/assignments"
+        $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileAppConfigurations('$EntityId')/assignments"
     }
     elseif ($EntityType -like "deviceAppManagement/*ManagedAppProtections") {
         # Already specific App Protection Policy type
         # Example: deviceAppManagement/iosManagedAppProtections
-        $actualAssignmentsUri = "$GraphEndpoint/beta/$EntityType('$EntityId')/assignments" # EntityType already includes deviceAppManagement
+        $actualAssignmentsUri = "$script:GraphEndpoint/beta/$EntityType('$EntityId')/assignments" # EntityType already includes deviceAppManagement
     }
     elseif ($EntityType -like "virtualEndpoint/*") {
         # Windows 365 Cloud PC policies use forward slash format instead of OData parentheses
         # Example: virtualEndpoint/provisioningPolicies or virtualEndpoint/userSettings
-        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/$EntityType/$EntityId/assignments"
+        $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/$EntityType/$EntityId/assignments"
     }
     else {
         # General device management entities
-        $actualAssignmentsUri = "$GraphEndpoint/beta/deviceManagement/$EntityType('$EntityId')/assignments"
+        $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/$EntityType('$EntityId')/assignments"
     }
 
     if (-not $actualAssignmentsUri) {

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneCategoryDefinition.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneCategoryDefinition.ps1
@@ -1,0 +1,237 @@
+function Get-IntuneCategoryDefinition {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('UserContext', 'DeviceContext', 'GroupContext', 'AllPolicies', 'Search', 'Compare')]
+        [string]$Audience
+    )
+
+    # Local constructor keeps each category entry terse while guaranteeing a uniform schema.
+    $newCategory = {
+        param([hashtable]$Props)
+        $entry = [ordered]@{
+            Id                     = $null
+            Kind                   = 'Entity'
+            EntityType             = $null
+            AssignmentEntityType   = $null
+            TemplateFamily         = $null
+            EntityFilter           = $null
+            BucketKeys             = @()
+            DisplayName            = $null
+            ExportCategory         = $null
+            OptionalFeature        = $false
+            # BucketOnly categories register their BucketKeys for export parity but are never fetched.
+            BucketOnly             = $false
+            BucketExportCategories = $null
+        }
+        foreach ($key in $Props.Keys) { $entry[$key] = $Props[$key] }
+        if (-not $entry.AssignmentEntityType) { $entry.AssignmentEntityType = $entry.EntityType }
+        [PSCustomObject]$entry
+    }
+
+    # GroupContext Settings Catalog filter, copied verbatim from Get-IntuneGroupAssignment.ps1:157-167.
+    # Exclude Windows-only Endpoint Security policies from this generic Settings Catalog fetch
+    # Allow macOS and cross-platform endpoint security policies through
+    $groupSettingsCatalogFilter = {
+        if ($_.templateReference -and $_.templateReference.templateFamily -like "endpointSecurity*") {
+            $platforms = $_.platforms
+            # Only skip if this is a Windows-only policy (not macOS or other platforms)
+            if ($platforms -and
+                (($platforms -contains "windows10" -or $platforms -contains "windows10AndLater") -and
+                 $platforms -notcontains "macOS")) {
+                return $false
+            }
+        }
+        return $true
+    }
+
+    # Search Settings Catalog filter, copied verbatim from Search-IntunePolicy.ps1:144-146.
+    # Exclude endpoint security policies (they will be handled separately)
+    $searchSettingsCatalogFilter = {
+        -not ($_.templateReference -and $_.templateReference.templateFamily -and $_.templateReference.templateFamily -like 'endpointSecurity*')
+    }
+
+    $espEntityFilter = { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
+    $mobileAppsEntityFilter = { -not ($_.isFeatured -or $_.isBuiltIn) }
+
+    $baseCategories = @{
+        DeviceConfigurations        = @{ Id = 'DeviceConfigurations'; EntityType = 'deviceConfigurations'; BucketKeys = @('DeviceConfigs'); DisplayName = 'Device Configurations'; ExportCategory = 'Device Configuration' }
+        SettingsCatalog             = @{ Id = 'SettingsCatalog'; EntityType = 'configurationPolicies'; BucketKeys = @('SettingsCatalog'); DisplayName = 'Settings Catalog Policies'; ExportCategory = 'Settings Catalog Policy' }
+        CompliancePolicies          = @{ Id = 'CompliancePolicies'; EntityType = 'deviceCompliancePolicies'; BucketKeys = @('CompliancePolicies'); DisplayName = 'Compliance Policies'; ExportCategory = 'Compliance Policy' }
+        AppProtectionPolicies       = @{ Id = 'AppProtectionPolicies'; Kind = 'AppProtection'; EntityType = 'deviceAppManagement/managedAppPolicies'; BucketKeys = @('AppProtectionPolicies'); DisplayName = 'App Protection Policies'; ExportCategory = 'App Protection Policy' }
+        AppConfigurationPolicies    = @{ Id = 'AppConfigurationPolicies'; EntityType = 'deviceAppManagement/mobileAppConfigurations'; AssignmentEntityType = 'mobileAppConfigurations'; BucketKeys = @('AppConfigurationPolicies'); DisplayName = 'App Configuration Policies'; ExportCategory = 'App Configuration Policy' }
+        Applications                = @{ Id = 'Applications'; Kind = 'MobileApps'; EntityType = 'deviceAppManagement/mobileApps'; EntityFilter = $mobileAppsEntityFilter; BucketKeys = @('AppsRequired', 'AppsAvailable', 'AppsUninstall'); BucketExportCategories = @{ AppsRequired = 'Required Apps'; AppsAvailable = 'Available Apps'; AppsUninstall = 'Uninstall Apps' }; DisplayName = 'Applications' }
+        PlatformScripts             = @{ Id = 'PlatformScripts'; EntityType = 'deviceManagementScripts'; BucketKeys = @('PlatformScripts'); DisplayName = 'Platform Scripts'; ExportCategory = 'Platform Scripts' }
+        HealthScripts               = @{ Id = 'HealthScripts'; EntityType = 'deviceHealthScripts'; BucketKeys = @('HealthScripts'); DisplayName = 'Proactive Remediation Scripts'; ExportCategory = 'Proactive Remediation Scripts' }
+        DeploymentProfiles          = @{ Id = 'DeploymentProfiles'; EntityType = 'windowsAutopilotDeploymentProfiles'; BucketKeys = @('DeploymentProfiles'); DisplayName = 'Autopilot Deployment Profiles'; ExportCategory = 'Autopilot Deployment Profile' }
+        ESPProfiles                 = @{ Id = 'ESPProfiles'; EntityType = 'deviceEnrollmentConfigurations'; EntityFilter = $espEntityFilter; BucketKeys = @('ESPProfiles'); DisplayName = 'Enrollment Status Page Profiles'; ExportCategory = 'Enrollment Status Page' }
+        CloudPCProvisioningPolicies = @{ Id = 'CloudPCProvisioningPolicies'; EntityType = 'virtualEndpoint/provisioningPolicies'; BucketKeys = @('CloudPCProvisioningPolicies'); DisplayName = 'Windows 365 Cloud PC Provisioning Policies'; ExportCategory = 'Windows 365 Cloud PC Provisioning Policy'; OptionalFeature = $true }
+        CloudPCUserSettings         = @{ Id = 'CloudPCUserSettings'; EntityType = 'virtualEndpoint/userSettings'; BucketKeys = @('CloudPCUserSettings'); DisplayName = 'Windows 365 Cloud PC User Settings'; ExportCategory = 'Windows 365 Cloud PC User Setting'; OptionalFeature = $true }
+    }
+
+    $use = {
+        param([string]$Name, [hashtable]$Overrides)
+        $props = @{} + $baseCategories[$Name]
+        if ($Overrides) { foreach ($key in $Overrides.Keys) { $props[$key] = $Overrides[$key] } }
+        & $newCategory $props
+    }
+
+    $esFamilies = @(
+        [PSCustomObject]@{ Id = 'ESAntivirus'; Family = 'endpointSecurityAntivirus'; Bucket = 'AntivirusProfiles'; Export = 'Endpoint Security - Antivirus'; Name = 'Antivirus'; ShortName = 'Antivirus' }
+        [PSCustomObject]@{ Id = 'ESDiskEncryption'; Family = 'endpointSecurityDiskEncryption'; Bucket = 'DiskEncryptionProfiles'; Export = 'Endpoint Security - Disk Encryption'; Name = 'Disk Encryption'; ShortName = 'Disk Encryption' }
+        [PSCustomObject]@{ Id = 'ESFirewall'; Family = 'endpointSecurityFirewall'; Bucket = 'FirewallProfiles'; Export = 'Endpoint Security - Firewall'; Name = 'Firewall'; ShortName = 'Firewall' }
+        [PSCustomObject]@{ Id = 'ESEndpointDetection'; Family = 'endpointSecurityEndpointDetectionAndResponse'; Bucket = 'EndpointDetectionProfiles'; Export = 'Endpoint Security - EDR'; Name = 'Endpoint Detection and Response'; ShortName = 'EDR' }
+        [PSCustomObject]@{ Id = 'ESAttackSurface'; Family = 'endpointSecurityAttackSurfaceReduction'; Bucket = 'AttackSurfaceProfiles'; Export = 'Endpoint Security - ASR'; Name = 'Attack Surface Reduction'; ShortName = 'ASR' }
+        [PSCustomObject]@{ Id = 'ESAccountProtection'; Family = 'endpointSecurityAccountProtection'; Bucket = 'AccountProtectionProfiles'; Export = 'Endpoint Security - Account Protection'; Name = 'Account Protection'; ShortName = 'Account Protection' }
+    )
+
+    $newEsCategories = {
+        param([scriptblock]$DisplayNameBuilder, [hashtable]$Overrides)
+        foreach ($family in $esFamilies) {
+            $props = @{
+                Id             = $family.Id
+                Kind           = 'EndpointSecurity'
+                EntityType     = 'configurationPolicies'
+                TemplateFamily = $family.Family
+                BucketKeys     = @($family.Bucket)
+                DisplayName    = (& $DisplayNameBuilder $family)
+                ExportCategory = $family.Export
+            }
+            if ($Overrides) { foreach ($key in $Overrides.Keys) { $props[$key] = $Overrides[$key] } }
+            & $newCategory $props
+        }
+    }
+
+    switch ($Audience) {
+        'UserContext' {
+            # Order and display names from Get-IntuneUserAssignment.ps1 (16 progress steps).
+            $categories = @(
+                & $use 'DeviceConfigurations'
+                # UserContext applies no ES exclusion to Settings Catalog (Get-IntuneUserAssignment.ps1:125-133)
+                & $use 'SettingsCatalog'
+                & $use 'CompliancePolicies'
+                & $use 'AppProtectionPolicies'
+                & $use 'AppConfigurationPolicies'
+                & $use 'Applications'
+                & $use 'PlatformScripts'
+                & $use 'HealthScripts'
+            )
+            $categories += @(& $newEsCategories { param($family) "$($family.Name) Policies" })
+            $categories += @(
+                & $use 'CloudPCProvisioningPolicies'
+                & $use 'CloudPCUserSettings'
+                # Autopilot/ESP buckets exist for export parity but are not fetched for a user
+                # (see $relevantPolicies init in Get-IntuneUserAssignment.ps1:86-107)
+                & $use 'DeploymentProfiles' @{ BucketOnly = $true }
+                & $use 'ESPProfiles' @{ BucketOnly = $true }
+            )
+            return $categories
+        }
+        'DeviceContext' {
+            # Order and display names from Get-IntuneDeviceAssignment.ps1 (16 fetch steps).
+            # Autopilot/ESP are Windows-only conditional fetches there; the migrated cmdlet
+            # decides whether to flip BucketOnly off for Windows devices.
+            $categories = @(
+                & $use 'DeviceConfigurations'
+                # DeviceContext applies no ES exclusion to Settings Catalog (Get-IntuneDeviceAssignment.ps1:171-180)
+                & $use 'SettingsCatalog'
+                & $use 'CompliancePolicies'
+                & $use 'AppProtectionPolicies'
+                & $use 'AppConfigurationPolicies'
+                & $use 'PlatformScripts'
+                & $use 'HealthScripts'
+                & $use 'CloudPCProvisioningPolicies'
+                & $use 'CloudPCUserSettings'
+            )
+            $categories += @(& $newEsCategories { param($family) "$($family.ShortName) Policies" })
+            $categories += @(
+                & $use 'Applications'
+                & $use 'DeploymentProfiles' @{ BucketOnly = $true }
+                & $use 'ESPProfiles' @{ BucketOnly = $true }
+            )
+            return $categories
+        }
+        'GroupContext' {
+            # Order and display names from Get-IntuneGroupAssignment.ps1 (18 fetch steps).
+            $categories = @(
+                & $use 'DeviceConfigurations'
+                & $use 'SettingsCatalog' @{ EntityFilter = $groupSettingsCatalogFilter }
+                & $use 'CompliancePolicies'
+                & $use 'AppProtectionPolicies'
+                & $use 'AppConfigurationPolicies'
+            )
+            $categories += @(& $newEsCategories { param($family) "$($family.Name) Policies for group" })
+            $categories += @(
+                & $use 'Applications'
+                & $use 'PlatformScripts'
+                & $use 'HealthScripts'
+                & $use 'DeploymentProfiles'
+                & $use 'ESPProfiles'
+                & $use 'CloudPCProvisioningPolicies'
+                & $use 'CloudPCUserSettings'
+            )
+            return $categories
+        }
+        'AllPolicies' {
+            # Order and display names from Get-IntuneAllPolicies.ps1 (17 categories, no Applications).
+            $categories = @(
+                & $use 'DeviceConfigurations'
+                # AllPolicies applies no ES exclusion to Settings Catalog (Get-IntuneAllPolicies.ps1:83-92)
+                & $use 'SettingsCatalog'
+                & $use 'CompliancePolicies'
+                & $use 'AppProtectionPolicies'
+                & $use 'AppConfigurationPolicies'
+                & $use 'PlatformScripts'
+                & $use 'HealthScripts'
+                & $use 'DeploymentProfiles'
+                & $use 'ESPProfiles'
+                & $use 'CloudPCProvisioningPolicies'
+                & $use 'CloudPCUserSettings'
+            )
+            $categories += @(& $newEsCategories { param($family) "$($family.ShortName) Policies" })
+            return $categories
+        }
+        'Search' {
+            # Order, display names and export labels from Search-IntunePolicy.ps1 (18 categories).
+            # All Search categories feed one flat SearchResults bucket (grouped rows at display time).
+            $searchBucket = @{ BucketKeys = @('SearchResults'); BucketExportCategories = $null }
+            $categories = @(
+                & $use 'DeviceConfigurations' $searchBucket
+                & $use 'SettingsCatalog' ($searchBucket + @{ EntityFilter = $searchSettingsCatalogFilter; ExportCategory = 'Settings Catalog' })
+                & $use 'CompliancePolicies' $searchBucket
+                & $use 'AppProtectionPolicies' $searchBucket
+                & $use 'AppConfigurationPolicies' $searchBucket
+                & $use 'Applications' ($searchBucket + @{ ExportCategory = 'Application' })
+                & $use 'PlatformScripts' ($searchBucket + @{ ExportCategory = 'Platform Script' })
+                & $use 'HealthScripts' ($searchBucket + @{ ExportCategory = 'Proactive Remediation Script' })
+            )
+            $categories += @(& $newEsCategories { param($family) $family.Export } $searchBucket)
+            $categories += @(
+                & $use 'DeploymentProfiles' $searchBucket
+                & $use 'ESPProfiles' $searchBucket
+                & $use 'CloudPCProvisioningPolicies' ($searchBucket + @{ DisplayName = 'Cloud PC Provisioning Policies'; ExportCategory = 'Cloud PC Provisioning Policy' })
+                & $use 'CloudPCUserSettings' ($searchBucket + @{ DisplayName = 'Cloud PC User Settings'; ExportCategory = 'Cloud PC User Setting' })
+            )
+            return $categories
+        }
+        'Compare' {
+            # Categories Compare-IntuneGroupAssignment.ps1 currently walks (13 fetch categories).
+            # Compare currently checks intents only for ES; the shared EndpointSecurity kind adds
+            # the configurationPolicies phase when Compare is migrated onto the engine.
+            $categories = @(
+                & $use 'DeviceConfigurations' @{ ExportCategory = 'Device Configurations' }
+                # Compare applies no ES exclusion to Settings Catalog (Compare-IntuneGroupAssignment.ps1:214-252)
+                & $use 'SettingsCatalog' @{ ExportCategory = 'Settings Catalog' }
+                & $use 'CompliancePolicies' @{ ExportCategory = 'Compliance Policies' }
+                & $use 'Applications' @{ BucketKeys = @('RequiredApps', 'AvailableApps', 'UninstallApps'); BucketExportCategories = @{ RequiredApps = 'Required Apps'; AvailableApps = 'Available Apps'; UninstallApps = 'Uninstall Apps' } }
+                & $use 'PlatformScripts'
+                # deviceShellScripts assignments live under /groupAssignments in the current Compare code
+                # (Compare-IntuneGroupAssignment.ps1:348-363); the migration must account for that shape.
+                & $newCategory @{ Id = 'ShellScripts'; EntityType = 'deviceShellScripts'; BucketKeys = @('PlatformScripts'); DisplayName = 'Shell Scripts'; ExportCategory = 'Platform Scripts' }
+                & $use 'HealthScripts'
+            )
+            $categories += @(& $newEsCategories { param($family) $family.Export })
+            return $categories
+        }
+    }
+}

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneEntities.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneEntities.ps1
@@ -16,11 +16,11 @@ function Get-IntuneEntities {
 
     # Handle special cases for app management and specific deviceManagement endpoints
     if ($EntityType -like "deviceAppManagement/*" -or $EntityType -eq "deviceManagement/templates" -or $EntityType -eq "deviceManagement/intents") {
-        $baseUri = "$GraphEndpoint/beta"
+        $baseUri = "$script:GraphEndpoint/beta"
         $actualEntityType = $EntityType
     }
     else {
-        $baseUri = "$GraphEndpoint/beta/deviceManagement"
+        $baseUri = "$script:GraphEndpoint/beta/deviceManagement"
         $actualEntityType = "$EntityType"
     }
 

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneEntities.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneEntities.ps1
@@ -1,4 +1,5 @@
 function Get-IntuneEntities {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$EntityType,

--- a/Module/IntuneAssignmentChecker/Private/Get-PolicyPlatform.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-PolicyPlatform.ps1
@@ -1,4 +1,5 @@
 function Get-PolicyPlatform {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [PSObject]$Policy

--- a/Module/IntuneAssignmentChecker/Private/Get-ScopeTagLookup.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-ScopeTagLookup.ps1
@@ -1,4 +1,6 @@
 function Get-ScopeTagLookup {
+    [CmdletBinding()]
+    param()
     $lookup = @{ "0" = "Default" }
     try {
         $uri = "$script:GraphEndpoint/beta/deviceManagement/roleScopeTags?`$select=id,displayName"

--- a/Module/IntuneAssignmentChecker/Private/Get-ScopeTagNames.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-ScopeTagNames.ps1
@@ -1,4 +1,5 @@
 function Get-ScopeTagNames {
+    [CmdletBinding()]
     param (
         [object[]]$ScopeTagIds,
         [hashtable]$ScopeTagLookup

--- a/Module/IntuneAssignmentChecker/Private/Get-Separator.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-Separator.ps1
@@ -1,4 +1,5 @@
 function Get-Separator {
+    [CmdletBinding()]
     param (
         [string]$Character = "-",
         [int]$MinWidth = 80

--- a/Module/IntuneAssignmentChecker/Private/Get-TransitiveGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-TransitiveGroupMembership.ps1
@@ -1,4 +1,5 @@
 function Get-TransitiveGroupMembership {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$GroupId

--- a/Module/IntuneAssignmentChecker/Private/Get-TransitiveGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-TransitiveGroupMembership.ps1
@@ -6,7 +6,7 @@ function Get-TransitiveGroupMembership {
     )
 
     $parentGroups = [System.Collections.ArrayList]::new()
-    $uri = "$GraphEndpoint/v1.0/groups/$GroupId/transitiveMemberOf/microsoft.graph.group?`$select=id,displayName"
+    $uri = "$script:GraphEndpoint/v1.0/groups/$GroupId/transitiveMemberOf/microsoft.graph.group?`$select=id,displayName"
 
     try {
         do {

--- a/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
@@ -6,7 +6,7 @@ function Get-UserInfo {
     )
 
     try {
-        $userUri = "$GraphEndpoint/v1.0/users/$([uri]::EscapeDataString($UserPrincipalName))"
+        $userUri = "$script:GraphEndpoint/v1.0/users/$([uri]::EscapeDataString($UserPrincipalName))"
         $user = Invoke-MgGraphRequest -Uri $userUri -Method Get
         return @{
             Id                = $user.id

--- a/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
@@ -5,7 +5,7 @@ function Get-UserInfo {
     )
 
     try {
-        $userUri = "$GraphEndpoint/v1.0/users/$UserPrincipalName"
+        $userUri = "$GraphEndpoint/v1.0/users/$([uri]::EscapeDataString($UserPrincipalName))"
         $user = Invoke-MgGraphRequest -Uri $userUri -Method Get
         return @{
             Id                = $user.id

--- a/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-UserInfo.ps1
@@ -1,4 +1,5 @@
 function Get-UserInfo {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [string]$UserPrincipalName

--- a/Module/IntuneAssignmentChecker/Private/Invoke-IntuneCategoryScan.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Invoke-IntuneCategoryScan.ps1
@@ -1,0 +1,262 @@
+function Invoke-IntuneCategoryScan {
+    [CmdletBinding()]
+    # PSReviewUnusedParameter cannot trace usage inside the nested helper functions below
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ProcessEntity')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'EntityPreFilter')]
+    param (
+        [Parameter(Mandatory = $true)]
+        [object[]]$Categories,
+
+        # Per-cmdlet plugin. Receives one context object per entity:
+        # {Category, Entity, Assignments (normalized), RawAssignments, Buckets}.
+        # Invoked also for zero-assignment entities.
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$ProcessEntity,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$AssignmentGroupIds = @(),
+
+        # Invoked as: & $EntityPreFilter $entity $category. Entities that do not pass
+        # never trigger an assignment fetch.
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$EntityPreFilter,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ShowProgress,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ProgressVerb = 'Fetching',
+
+        # Caller-owned cache keyed by EntityType string; lets multi-target loops fetch
+        # each entity set once per run.
+        [Parameter(Mandatory = $false)]
+        [hashtable]$EntityCache
+    )
+
+    if ($null -eq $EntityCache) { $EntityCache = @{} }
+
+    $buckets = @{}
+    foreach ($category in $Categories) {
+        foreach ($bucketKey in $category.BucketKeys) {
+            if (-not $buckets.ContainsKey($bucketKey)) {
+                $buckets[$bucketKey] = [System.Collections.Generic.List[object]]::new()
+            }
+        }
+    }
+
+    $scanErrors = [System.Collections.Generic.List[object]]::new()
+
+    function Get-CachedEntitySet {
+        param([string]$EntityType)
+        if (-not $EntityCache.ContainsKey($EntityType)) {
+            $EntityCache[$EntityType] = @(Get-IntuneEntities -EntityType $EntityType)
+        }
+        return , @($EntityCache[$EntityType])
+    }
+
+    function Get-PagedGraphValue {
+        param([string]$Uri)
+        $items = [System.Collections.Generic.List[object]]::new()
+        $currentUri = $Uri
+        do {
+            $response = Invoke-MgGraphRequest -Uri $currentUri -Method Get
+            if ($response -and $null -ne $response.value) {
+                $items.AddRange(@($response.value))
+            }
+            $currentUri = $response.'@odata.nextLink'
+        } while (![string]::IsNullOrEmpty($currentUri))
+        return , $items
+    }
+
+    # Normalizes raw Graph assignment objects to the standard record shape, reproducing
+    # Get-IntuneAssignments' label duality: with AssignmentGroupIds only Direct Assignment /
+    # Direct Exclusion for matching groups (All Users/All Devices suppressed); without them
+    # Group Assignment / Group Exclusion plus All Users / All Devices.
+    function ConvertTo-NormalizedAssignment {
+        param([object[]]$RawAssignments)
+        $normalized = [System.Collections.Generic.List[object]]::new()
+        foreach ($assignment in $RawAssignments) {
+            $reason = $null
+            $targetGroupId = $null
+            $odataType = if ($assignment.target) { $assignment.target.'@odata.type' } else { $null }
+
+            if ($odataType -eq '#microsoft.graph.groupAssignmentTarget') {
+                $targetGroupId = $assignment.target.groupId
+                if ($AssignmentGroupIds.Count -gt 0) {
+                    if ($AssignmentGroupIds -contains $targetGroupId) { $reason = 'Direct Assignment' }
+                }
+                else {
+                    $reason = 'Group Assignment'
+                }
+            }
+            elseif ($odataType -eq '#microsoft.graph.exclusionGroupAssignmentTarget') {
+                $targetGroupId = $assignment.target.groupId
+                if ($AssignmentGroupIds.Count -gt 0) {
+                    if ($AssignmentGroupIds -contains $targetGroupId) { $reason = 'Direct Exclusion' }
+                }
+                else {
+                    $reason = 'Group Exclusion'
+                }
+            }
+            elseif ($AssignmentGroupIds.Count -eq 0) {
+                $reason = switch ($odataType) {
+                    '#microsoft.graph.allLicensedUsersAssignmentTarget' { 'All Users' }
+                    '#microsoft.graph.allDevicesAssignmentTarget' { 'All Devices' }
+                    default { $null }
+                }
+            }
+
+            if ($reason) {
+                $filterId = $null
+                $filterType = $null
+                if ($assignment.target) {
+                    $rawFilterId = $assignment.target.deviceAndAppManagementAssignmentFilterId
+                    $rawFilterType = $assignment.target.deviceAndAppManagementAssignmentFilterType
+                    if ($rawFilterType -and $rawFilterType -ne 'none' -and $rawFilterId -and $rawFilterId -ne '00000000-0000-0000-0000-000000000000') {
+                        $filterId = $rawFilterId
+                        $filterType = $rawFilterType
+                    }
+                }
+
+                $normalized.Add([PSCustomObject]@{
+                        Reason     = $reason
+                        GroupId    = $targetGroupId
+                        FilterId   = $filterId
+                        FilterType = $filterType
+                    })
+            }
+        }
+        return , $normalized
+    }
+
+    function Test-CategoryEntityPreFilter {
+        param($Entity, $Category)
+        if ($null -eq $EntityPreFilter) { return $true }
+        return [bool](& $EntityPreFilter $Entity $Category)
+    }
+
+    function Invoke-ProcessEntityCallback {
+        param($Category, $Entity, $Assignments, $RawAssignments)
+        $context = [PSCustomObject]@{
+            Category       = $Category
+            Entity         = $Entity
+            Assignments    = $Assignments
+            RawAssignments = $RawAssignments
+            Buckets        = $buckets
+        }
+        & $ProcessEntity $context
+    }
+
+    $fetchableCategories = @($Categories | Where-Object { -not $_.BucketOnly })
+    $totalCategories = $fetchableCategories.Count
+    $currentCategory = 0
+
+    foreach ($category in $fetchableCategories) {
+        $currentCategory++
+        if ($ShowProgress) {
+            Write-Host "[$currentCategory/$totalCategories] $ProgressVerb $($category.DisplayName)..." -ForegroundColor Yellow
+        }
+
+        try {
+            switch ($category.Kind) {
+                'Entity' {
+                    $entities = Get-CachedEntitySet -EntityType $category.EntityType
+                    if ($category.EntityFilter) {
+                        $entities = @($entities | Where-Object $category.EntityFilter)
+                    }
+                    foreach ($entity in $entities) {
+                        if (-not (Test-CategoryEntityPreFilter -Entity $entity -Category $category)) { continue }
+                        $assignments = @(Get-IntuneAssignments -EntityType $category.AssignmentEntityType -EntityId $entity.id -GroupIds $AssignmentGroupIds)
+                        Invoke-ProcessEntityCallback -Category $category -Entity $entity -Assignments $assignments -RawAssignments $null
+                    }
+                }
+                'EndpointSecurity' {
+                    # Two-phase lookup is retained intentionally: some assigned intents (e.g. a macOS
+                    # FileVault intent) have no configurationPolicies counterpart because the MC955748
+                    # migration was Windows-only.
+                    $processedIds = [System.Collections.Generic.HashSet[string]]::new()
+
+                    # Phase 1: Settings Catalog style ES policies from configurationPolicies
+                    $configPolicies = Get-CachedEntitySet -EntityType $category.EntityType
+                    $matchingConfigPolicies = @($configPolicies | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $category.TemplateFamily })
+                    foreach ($policy in $matchingConfigPolicies) {
+                        if (-not $processedIds.Add([string]$policy.id)) { continue }
+                        if (-not (Test-CategoryEntityPreFilter -Entity $policy -Category $category)) { continue }
+                        $assignments = @(Get-IntuneAssignments -EntityType $category.AssignmentEntityType -EntityId $policy.id -GroupIds $AssignmentGroupIds)
+                        Invoke-ProcessEntityCallback -Category $category -Entity $policy -Assignments $assignments -RawAssignments $null
+                    }
+
+                    # Phase 2: legacy template style ES policies from deviceManagement/intents
+                    $intents = Get-CachedEntitySet -EntityType 'deviceManagement/intents'
+                    Add-IntentTemplateFamilyInfo -IntentPolicies $intents
+                    $matchingIntents = @($intents | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $category.TemplateFamily })
+                    foreach ($policy in $matchingIntents) {
+                        if (-not $processedIds.Add([string]$policy.id)) { continue }
+                        if (-not (Test-CategoryEntityPreFilter -Entity $policy -Category $category)) { continue }
+                        $rawAssignments = Get-PagedGraphValue -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments"
+                        $assignments = ConvertTo-NormalizedAssignment -RawAssignments $rawAssignments
+                        Invoke-ProcessEntityCallback -Category $category -Entity $policy -Assignments $assignments -RawAssignments $rawAssignments
+                    }
+                }
+                'AppProtection' {
+                    $policies = Get-CachedEntitySet -EntityType $category.EntityType
+                    if ($category.EntityFilter) {
+                        $policies = @($policies | Where-Object $category.EntityFilter)
+                    }
+                    foreach ($policy in $policies) {
+                        if (-not (Test-CategoryEntityPreFilter -Entity $policy -Category $category)) { continue }
+                        $assignmentsUri = Get-AppProtectionAssignmentUri -Policy $policy
+                        $rawAssignments = if ($assignmentsUri) {
+                            Get-PagedGraphValue -Uri $assignmentsUri
+                        }
+                        else {
+                            [System.Collections.Generic.List[object]]::new()
+                        }
+                        $assignments = ConvertTo-NormalizedAssignment -RawAssignments $rawAssignments
+                        Invoke-ProcessEntityCallback -Category $category -Entity $policy -Assignments $assignments -RawAssignments $rawAssignments
+                    }
+                }
+                'MobileApps' {
+                    if (-not $EntityCache.ContainsKey($category.EntityType)) {
+                        $EntityCache[$category.EntityType] = Get-PagedGraphValue -Uri "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
+                    }
+                    $allApps = @($EntityCache[$category.EntityType])
+                    if ($category.EntityFilter) {
+                        $allApps = @($allApps | Where-Object $category.EntityFilter)
+                    }
+                    foreach ($app in $allApps) {
+                        if (-not (Test-CategoryEntityPreFilter -Entity $app -Category $category)) { continue }
+                        $rawAssignments = Get-PagedGraphValue -Uri "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$($app.id)')/assignments"
+                        $assignments = ConvertTo-NormalizedAssignment -RawAssignments $rawAssignments
+                        Invoke-ProcessEntityCallback -Category $category -Entity $app -Assignments $assignments -RawAssignments $rawAssignments
+                    }
+                }
+                default {
+                    throw "Unknown category kind '$($category.Kind)' for category '$($category.Id)'."
+                }
+            }
+        }
+        catch {
+            if ($category.OptionalFeature) {
+                # Optional features (e.g. Windows 365) fail quietly when the tenant is not licensed
+                Write-Verbose "Skipping optional category '$($category.DisplayName)': $($_.Exception.Message)"
+                continue
+            }
+            $scanErrors.Add([PSCustomObject]@{
+                    CategoryId  = $category.Id
+                    DisplayName = $category.DisplayName
+                    Message     = $_.Exception.Message
+                    ErrorRecord = $_
+                })
+            Write-Host "Error processing category '$($category.DisplayName)': $($_.Exception.Message)" -ForegroundColor Red
+            Write-Error -Message "Category '$($category.Id)' failed: $($_.Exception.Message)"
+            continue
+        }
+    }
+
+    return [PSCustomObject]@{
+        Buckets       = $buckets
+        Errors        = $scanErrors
+        CategoryCount = $totalCategories
+    }
+}

--- a/Module/IntuneAssignmentChecker/Private/Invoke-MultipleAssignments.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Invoke-MultipleAssignments.ps1
@@ -1,4 +1,5 @@
 function Invoke-MultipleAssignments {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [Array]$Assignments,

--- a/Module/IntuneAssignmentChecker/Private/Resolve-AssignmentReason.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Resolve-AssignmentReason.ps1
@@ -1,4 +1,5 @@
 function Resolve-AssignmentReason {
+    [CmdletBinding()]
     param (
         [object[]]$Assignments,
         [object[]]$GroupMembershipIds,

--- a/Module/IntuneAssignmentChecker/Private/Resolve-SimulatedAssignmentDelta.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Resolve-SimulatedAssignmentDelta.ps1
@@ -1,4 +1,5 @@
 function Resolve-SimulatedAssignmentDelta {
+    [CmdletBinding()]
     param (
         [object[]]$Assignments,
         [object[]]$CurrentGroupIds,

--- a/Module/IntuneAssignmentChecker/Private/Set-Environment.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Set-Environment.ps1
@@ -69,7 +69,7 @@ function Set-Environment {
                 Write-Host "- Starring the repository: https://github.com/ugurkocde/IntuneAssignmentChecker" -ForegroundColor White
                 Write-Host "- Supporting the project: https://github.com/sponsors/ugurkocde" -ForegroundColor White
                 Write-Host ""
-                exit
+                return $null
             }
             default {
                 Write-Host "Invalid choice, please select 1,2,3, or 0" -ForegroundColor Red

--- a/Module/IntuneAssignmentChecker/Private/Set-Environment.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Set-Environment.ps1
@@ -1,4 +1,5 @@
 function Set-Environment {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
         [string]$EnvironmentName

--- a/Module/IntuneAssignmentChecker/Private/Show-CategoryResultTable.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Show-CategoryResultTable.ps1
@@ -1,0 +1,103 @@
+function Show-CategoryResultTable {
+    <#
+    .SYNOPSIS
+        Renders one category result section as a fixed-width table.
+    .DESCRIPTION
+        Generalizes the table renderer that lived inside Get-IntuneGroupAssignment
+        (Format-PolicyTable). Prints a Cyan section header, a Yellow column header,
+        one row per item with truncation, and reason-based row coloring:
+        Inherited Exclusion = Magenta, Direct Exclusion = Red, Inherited = DarkYellow,
+        everything else = White.
+    .PARAMETER Title
+        Section title shown in the header block.
+    .PARAMETER Items
+        Items to render. Each item is expected to expose id, roleScopeTagIds and
+        (optionally) AssignmentReason.
+    .PARAMETER GetName
+        Resolves the display name for one item. Defaults to displayName, then name,
+        then "Unnamed Profile".
+    .PARAMETER EmptyMessage
+        Message shown when the section has no items. Defaults to "No <Title> found."
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [object[]]$Items,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$GetName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$EmptyMessage
+    )
+
+    if (-not $GetName) {
+        $GetName = {
+            param($item)
+            if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName }
+            elseif (-not [string]::IsNullOrWhiteSpace($item.name)) { $item.name }
+            else { "Unnamed Profile" }
+        }
+    }
+    if (-not $EmptyMessage) { $EmptyMessage = "No $Title found." }
+
+    $tableSeparator = Get-Separator
+
+    # Create prominent section header
+    $headerSeparator = "-" * ($Title.Length + 16)
+    Write-Host "`n$headerSeparator" -ForegroundColor Cyan
+    Write-Host "------- $Title -------" -ForegroundColor Cyan
+    Write-Host "$headerSeparator" -ForegroundColor Cyan
+
+    if ($null -eq $Items -or $Items.Count -eq 0) {
+        Write-Host $EmptyMessage -ForegroundColor Gray
+        Write-Host $tableSeparator -ForegroundColor Gray
+        Write-Host ""
+        return
+    }
+
+    # Create table header
+    $headerFormat = "{0,-40} {1,-15} {2,-20} {3,-30} {4,-35}" -f "Policy Name", "Platform", "Scope Tags", "ID", "Assignment"
+
+    Write-Host $headerFormat -ForegroundColor Yellow
+    Write-Host $tableSeparator -ForegroundColor Gray
+
+    # Display each item
+    foreach ($item in $Items) {
+        $name = & $GetName $item
+
+        if ($name.Length -gt 37) { $name = $name.Substring(0, 34) + "..." }
+
+        $platform = Get-PolicyPlatform -Policy $item
+        if ($platform.Length -gt 12) { $platform = $platform.Substring(0, 9) + "..." }
+
+        $scopeTags = Get-ScopeTagNames -ScopeTagIds $item.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
+        if ($scopeTags.Length -gt 17) { $scopeTags = $scopeTags.Substring(0, 14) + "..." }
+
+        $id = $item.id
+        if ($id.Length -gt 27) { $id = $id.Substring(0, 24) + "..." }
+
+        $assignment = if ($item.AssignmentReason) { $item.AssignmentReason } else { "N/A" }
+        if ($assignment.Length -gt 32) { $assignment = $assignment.Substring(0, 29) + "..." }
+
+        $rowFormat = "{0,-40} {1,-15} {2,-20} {3,-30} {4,-35}" -f $name, $platform, $scopeTags, $id, $assignment
+        if ($assignment -match "Inherited Exclusion") {
+            Write-Host $rowFormat -ForegroundColor Magenta
+        }
+        elseif ($assignment -match "Direct Exclusion") {
+            Write-Host $rowFormat -ForegroundColor Red
+        }
+        elseif ($assignment -match "Inherited") {
+            Write-Host $rowFormat -ForegroundColor DarkYellow
+        }
+        else {
+            Write-Host $rowFormat -ForegroundColor White
+        }
+    }
+    Write-Host $tableSeparator -ForegroundColor Gray
+}

--- a/Module/IntuneAssignmentChecker/Private/Show-Menu.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Show-Menu.ps1
@@ -1,4 +1,6 @@
 function Show-Menu {
+    [CmdletBinding()]
+    param()
     # Display current connection status
     if ($script:CurrentTenantName -and $script:CurrentUserUPN) {
         Write-Host "Connected to: " -ForegroundColor Green -NoNewline

--- a/Module/IntuneAssignmentChecker/Private/Show-SaveFileDialog.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Show-SaveFileDialog.ps1
@@ -1,4 +1,5 @@
 function Show-SaveFileDialog {
+    [CmdletBinding()]
     param (
         [string]$DefaultFileName
     )

--- a/Module/IntuneAssignmentChecker/Private/Switch-Tenant.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Switch-Tenant.ps1
@@ -1,4 +1,6 @@
 function Switch-Tenant {
+    [CmdletBinding()]
+    param()
     Write-Host "`nDisconnecting from current tenant..." -ForegroundColor Yellow
 
     try {

--- a/Module/IntuneAssignmentChecker/Private/Switch-Tenant.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Switch-Tenant.ps1
@@ -17,10 +17,14 @@ function Switch-Tenant {
         Write-Host "Please log in to connect to a different tenant..." -ForegroundColor Cyan
 
         # Get required permissions
-        $permissionsList = ($requiredPermissions | ForEach-Object { $_.Permission }) -join ', '
+        $permissionsList = ($script:RequiredPermissions | ForEach-Object { $_.Permission }) -join ', '
 
         # Prompt for environment selection
-        Set-Environment
+        $environment = Set-Environment
+        if ($null -eq $environment) {
+            Write-Host "Tenant switch cancelled." -ForegroundColor Yellow
+            return
+        }
 
         # Attempt new connection
         $null = Connect-MgGraph -Scopes $permissionsList -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
@@ -49,6 +53,12 @@ function Switch-Tenant {
 
             # Refresh scope tag lookup for the new tenant
             $script:ScopeTagLookup = Get-ScopeTagLookup
+
+            # Refresh assignment filter lookup for the new tenant
+            $script:AssignmentFilterLookup = Get-AssignmentFilterLookup
+
+            # Clear cached group info from the previous tenant
+            $script:GroupInfoCache = $null
         }
     }
     catch {

--- a/Module/IntuneAssignmentChecker/Private/Test-AppPlatformCompatibility.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Test-AppPlatformCompatibility.ps1
@@ -1,4 +1,5 @@
 function Test-AppPlatformCompatibility {
+    [CmdletBinding()]
     param (
         [string]$DeviceOS,
         [PSObject]$App

--- a/Module/IntuneAssignmentChecker/Private/Test-PlatformCompatibility.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Test-PlatformCompatibility.ps1
@@ -1,4 +1,5 @@
 function Test-PlatformCompatibility {
+    [CmdletBinding()]
     param (
         [string]$DeviceOS,
         [PSObject]$Policy

--- a/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
@@ -313,9 +313,10 @@ function Compare-IntuneGroupAssignment {
 
             foreach ($assignment in $assignmentResponse.value) {
                 if ($allGroupIds -contains $assignment.target.groupId) {
+                    $exclusionSuffix = if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget') { " [EXCLUDED]" } else { "" }
                     $inheritedSuffix = if ($assignment.target.groupId -ne $groupId) { " [INHERITED]" } else { "" }
                     $filterSuffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
-                    $combinedSuffix = "$inheritedSuffix$filterSuffix"
+                    $combinedSuffix = "$exclusionSuffix$inheritedSuffix$filterSuffix"
                     switch ($assignment.intent) {
                         "required" { [void]$groupAssignments[$groupName].RequiredApps.Add("$($app.displayName)$combinedSuffix") }
                         "available" { [void]$groupAssignments[$groupName].AvailableApps.Add("$($app.displayName)$combinedSuffix") }

--- a/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
@@ -49,6 +49,81 @@ function Compare-IntuneGroupAssignment {
     # Before caching starts, initialize the group assignments hashtable
     $groupAssignments = [ordered]@{}
 
+    # Shell Scripts stay outside the shared engine: their assignments live under
+    # /groupAssignments (flat targetGroupId shape) instead of /assignments, which
+    # the engine's assignment fetch does not model.
+    $scanCategories = @(Get-IntuneCategoryDefinition -Audience 'Compare' | Where-Object { $_.Id -ne 'ShellScripts' })
+    # Shared across groups so each entity set is fetched from Graph once per run
+    $entityCache = @{}
+
+    # Compare historically checks Endpoint Security via deviceManagement/intents only.
+    # Skip the engine's configurationPolicies phase (those entities carry no top-level
+    # templateId) so results and fetch counts match the legacy intents-only scope.
+    $entityPreFilter = {
+        param($entity, $category)
+        if ($category.Kind -eq 'EndpointSecurity' -and -not $entity.templateId) { return $false }
+        return $true
+    }
+
+    $processEntity = {
+        param($ctx)
+
+        $entity = $ctx.Entity
+        $category = $ctx.Category
+
+        if ($category.Kind -eq 'MobileApps') {
+            # Legacy per-assignment loop: every assignment targeting one of the checked
+            # group ids yields its own entry, tagged [EXCLUDED]/[INHERITED]/filter and
+            # bucketed by that assignment's intent (exclusion-only apps stay visible).
+            foreach ($assignment in $ctx.RawAssignments) {
+                if ($allGroupIds -notcontains $assignment.target.groupId) { continue }
+                $exclusionSuffix = if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget') { " [EXCLUDED]" } else { "" }
+                $inheritedSuffix = if ($assignment.target.groupId -ne $groupId) { " [INHERITED]" } else { "" }
+                $filterSuffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
+                $combinedSuffix = "$exclusionSuffix$inheritedSuffix$filterSuffix"
+                switch ($assignment.intent) {
+                    "required" { $ctx.Buckets['RequiredApps'].Add("$($entity.displayName)$combinedSuffix") }
+                    "available" { $ctx.Buckets['AvailableApps'].Add("$($entity.displayName)$combinedSuffix") }
+                    "uninstall" { $ctx.Buckets['UninstallApps'].Add("$($entity.displayName)$combinedSuffix") }
+                }
+            }
+            return
+        }
+
+        if ($category.Kind -eq 'EndpointSecurity' -or $category.Id -eq 'HealthScripts') {
+            # Backstop for the prefilter: never take ES results from the configurationPolicies phase
+            if ($category.Kind -eq 'EndpointSecurity' -and $null -eq $ctx.RawAssignments) { return }
+            # Legacy matching: inclusion targets only, [INHERITED] as the only tag
+            $inclusions = @($ctx.Assignments | Where-Object { $_.Reason -eq 'Direct Assignment' })
+            if ($inclusions.Count -eq 0) { return }
+            $suffix = if (@($inclusions | Where-Object { $_.GroupId -ne $groupId }).Count -gt 0) { " [INHERITED]" } else { "" }
+            $ctx.Buckets[$category.BucketKeys[0]].Add("$($entity.displayName)$suffix")
+            return
+        }
+
+        if ($category.Id -eq 'PlatformScripts') {
+            # Legacy matching: any group target (inclusion or exclusion) counts,
+            # [INHERITED] as the only tag, "(PowerShell)" marker in the name
+            if (@($ctx.Assignments).Count -eq 0) { return }
+            $suffix = if (@($ctx.Assignments | Where-Object { $_.GroupId -ne $groupId }).Count -gt 0) { " [INHERITED]" } else { "" }
+            $ctx.Buckets['PlatformScripts'].Add("$($entity.displayName) (PowerShell)$suffix")
+            return
+        }
+
+        # Device Configurations / Settings Catalog / Compliance Policies: one entry per
+        # policy with [EXCLUDED], [INHERITED] and filter suffixes, in that order
+        if (@($ctx.Assignments).Count -eq 0) { return }
+        $suffix = ""
+        if (@($ctx.Assignments | Where-Object { $_.Reason -eq 'Direct Exclusion' }).Count -gt 0) { $suffix += " [EXCLUDED]" }
+        if (@($ctx.Assignments | Where-Object { $_.GroupId -ne $groupId }).Count -gt 0) { $suffix += " [INHERITED]" }
+        $filterMatch = $ctx.Assignments | Where-Object { $_.FilterId } | Select-Object -First 1
+        if ($filterMatch) {
+            $suffix += (Format-AssignmentFilter -FilterId $filterMatch.FilterId -FilterType $filterMatch.FilterType)
+        }
+        $entryName = if ($category.Id -eq 'SettingsCatalog') { $entity.name } else { $entity.displayName }
+        $ctx.Buckets[$category.BucketKeys[0]].Add("$entryName$suffix")
+    }
+
     # Process each group input
     $resolvedGroups = @{}
     foreach ($groupInput in $groupInputs) {
@@ -57,52 +132,17 @@ function Compare-IntuneGroupAssignment {
         # Initialize variables
         $groupId = $null
         $groupName = $null
-        $allGroupIds = @()
-        $parentGroupMap = @{}
 
         # Check if input is a GUID
         if ($groupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
             try {
                 # Get group info from Graph API
-                $groupUri = "$GraphEndpoint/v1.0/groups/$groupInput"
+                $groupUri = "$script:GraphEndpoint/v1.0/groups/$groupInput"
                 $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
                 $groupId = $groupResponse.id
                 $groupName = $groupResponse.displayName
                 $resolvedGroups[$groupId] = $groupName
-
-                # Initialize collections for this group
-                $groupAssignments[$groupName] = @{
-                    DeviceConfigs              = [System.Collections.ArrayList]::new()
-                    SettingsCatalog            = [System.Collections.ArrayList]::new()
-                    CompliancePolicies         = [System.Collections.ArrayList]::new()
-                    RequiredApps               = [System.Collections.ArrayList]::new()
-                    AvailableApps              = [System.Collections.ArrayList]::new()
-                    UninstallApps              = [System.Collections.ArrayList]::new()
-                    PlatformScripts            = [System.Collections.ArrayList]::new()
-                    HealthScripts              = [System.Collections.ArrayList]::new()
-                    AntivirusProfiles          = [System.Collections.ArrayList]::new()
-                    DiskEncryptionProfiles     = [System.Collections.ArrayList]::new()
-                    FirewallProfiles           = [System.Collections.ArrayList]::new()
-                    EndpointDetectionProfiles  = [System.Collections.ArrayList]::new()
-                    AttackSurfaceProfiles      = [System.Collections.ArrayList]::new()
-                    AccountProtectionProfiles  = [System.Collections.ArrayList]::new()
-                }
-
                 Write-Host "Found group by ID: $groupName" -ForegroundColor Green
-
-                # Build effective group IDs for nested group support
-                $allGroupIds = @($groupId)
-                $parentGroupMap = @{}
-                if ($checkNestedGroupsCompare) {
-                    $parentGroups = Get-TransitiveGroupMembership -GroupId $groupId
-                    if ($parentGroups.Count -gt 0) {
-                        foreach ($pg in $parentGroups) {
-                            $allGroupIds += $pg.id
-                            $parentGroupMap[$pg.id] = $pg.displayName
-                        }
-                        Write-Host "  Found $($parentGroups.Count) parent group(s)" -ForegroundColor Green
-                    }
-                }
             }
             catch {
                 Write-Host "No group found with ID: $groupInput" -ForegroundColor Red
@@ -110,9 +150,9 @@ function Compare-IntuneGroupAssignment {
             }
         }
         else {
-            # Try to find group by display name
+            # Try to find group by display name (single quotes escaped for the OData filter)
             $escapedGroupName = $groupInput -replace "'", "''"
-            $groupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
+            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
 
             if ($groupResponse.value.Count -eq 0) {
@@ -130,347 +170,43 @@ function Compare-IntuneGroupAssignment {
             $groupId = $groupResponse.value[0].id
             $groupName = $groupResponse.value[0].displayName
             $resolvedGroups[$groupId] = $groupName
-
-            # Initialize collections for this group
-            $groupAssignments[$groupName] = @{
-                DeviceConfigs              = [System.Collections.ArrayList]::new()
-                SettingsCatalog            = [System.Collections.ArrayList]::new()
-                CompliancePolicies         = [System.Collections.ArrayList]::new()
-                RequiredApps               = [System.Collections.ArrayList]::new()
-                AvailableApps              = [System.Collections.ArrayList]::new()
-                UninstallApps              = [System.Collections.ArrayList]::new()
-                PlatformScripts            = [System.Collections.ArrayList]::new()
-                HealthScripts              = [System.Collections.ArrayList]::new()
-                AntivirusProfiles          = [System.Collections.ArrayList]::new()
-                DiskEncryptionProfiles     = [System.Collections.ArrayList]::new()
-                FirewallProfiles           = [System.Collections.ArrayList]::new()
-                EndpointDetectionProfiles  = [System.Collections.ArrayList]::new()
-                AttackSurfaceProfiles      = [System.Collections.ArrayList]::new()
-                AccountProtectionProfiles  = [System.Collections.ArrayList]::new()
-            }
-
             Write-Host "Found group by name: $groupName (ID: $groupId)" -ForegroundColor Green
+        }
 
-            # Build effective group IDs for nested group support
-            $allGroupIds = @($groupId)
-            $parentGroupMap = @{}
-            if ($checkNestedGroupsCompare) {
-                $parentGroups = Get-TransitiveGroupMembership -GroupId $groupId
-                if ($parentGroups.Count -gt 0) {
-                    foreach ($pg in $parentGroups) {
-                        $allGroupIds += $pg.id
-                        $parentGroupMap[$pg.id] = $pg.displayName
-                    }
-                    Write-Host "  Found $($parentGroups.Count) parent group(s)" -ForegroundColor Green
+        # Build effective group IDs for nested group support (direct + transitive parents)
+        $allGroupIds = @($groupId)
+        if ($checkNestedGroupsCompare) {
+            $parentGroups = Get-TransitiveGroupMembership -GroupId $groupId
+            if ($parentGroups.Count -gt 0) {
+                foreach ($pg in $parentGroups) {
+                    $allGroupIds += $pg.id
                 }
+                Write-Host "  Found $($parentGroups.Count) parent group(s)" -ForegroundColor Green
             }
         }
 
-        # Process Device Configurations
-        $deviceConfigsUri = "$GraphEndpoint/beta/deviceManagement/deviceConfigurations"
-        $deviceConfigsResponse = Invoke-MgGraphRequest -Uri $deviceConfigsUri -Method Get
-        $allDeviceConfigs = $deviceConfigsResponse.value
-        while ($deviceConfigsResponse.'@odata.nextLink') {
-            $deviceConfigsResponse = Invoke-MgGraphRequest -Uri $deviceConfigsResponse.'@odata.nextLink' -Method Get
-            $allDeviceConfigs += $deviceConfigsResponse.value
+        $scanResult = Invoke-IntuneCategoryScan -Categories $scanCategories -ProcessEntity $processEntity -AssignmentGroupIds $allGroupIds -EntityPreFilter $entityPreFilter -ShowProgress -EntityCache $entityCache
+        $groupAssignments[$groupName] = $scanResult.Buckets
+
+        # Process Shell Scripts (macOS) via the legacy /groupAssignments endpoint
+        Write-Host "Fetching Shell Scripts..." -ForegroundColor Yellow
+        if (-not $entityCache.ContainsKey('deviceShellScripts')) {
+            $entityCache['deviceShellScripts'] = @(Get-IntuneEntities -EntityType 'deviceShellScripts')
         }
-        $totalDeviceConfigs = $allDeviceConfigs.Count
-        $currentDeviceConfig = 0
-        foreach ($config in $allDeviceConfigs) {
-            $currentDeviceConfig++
-            Write-Host "`rFetching Device Configuration $currentDeviceConfig of $totalDeviceConfigs" -NoNewline
-            $configId = $config.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceConfigurations('$configId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
+        foreach ($shellScript in $entityCache['deviceShellScripts']) {
+            $assignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/deviceShellScripts('$($shellScript.id)')/groupAssignments"
+            $shellAssignments = [System.Collections.Generic.List[object]]::new()
+            do {
+                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
+                if ($assignmentResponse -and $null -ne $assignmentResponse.value) { $shellAssignments.AddRange(@($assignmentResponse.value)) }
+                $assignmentsUri = $assignmentResponse.'@odata.nextLink'
+            } while (![string]::IsNullOrEmpty($assignmentsUri))
 
-            # Check for both inclusion and exclusion assignments
-            $hasAssignment = $assignmentResponse.value | Where-Object {
-                $allGroupIds -contains $_.target.groupId -and
-                ($_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -or
-                $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget')
-            }
-            if ($hasAssignment) {
-                $isExclusion = $hasAssignment | Where-Object {
-                    $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget'
-                }
-                $isInherited = $hasAssignment | Where-Object {
-                    $_.target.groupId -ne $groupId
-                }
-                $suffix = ""
-                if ($isExclusion) { $suffix += " [EXCLUDED]" }
-                if ($isInherited) { $suffix += " [INHERITED]" }
-                $filterMatch = $hasAssignment | Where-Object { $_.target.deviceAndAppManagementAssignmentFilterType -and $_.target.deviceAndAppManagementAssignmentFilterType -ne 'none' } | Select-Object -First 1
-                if ($filterMatch) {
-                    $suffix += (Format-AssignmentFilter -FilterId $filterMatch.target.deviceAndAppManagementAssignmentFilterId -FilterType $filterMatch.target.deviceAndAppManagementAssignmentFilterType)
-                }
-                $displayName = "$($config.displayName)$suffix"
-                [void]$groupAssignments[$groupName].DeviceConfigs.Add($displayName)
-            }
-        }
-        Write-Host "`rFetching Device Configuration $totalDeviceConfigs of $totalDeviceConfigs" -NoNewline
-        Start-Sleep -Milliseconds 100
-        Write-Host ""  # Move to the next line after the loop
-
-        # Process Settings Catalog
-        $settingsCatalogUri = "$GraphEndpoint/beta/deviceManagement/configurationPolicies"
-        $settingsCatalogResponse = Invoke-MgGraphRequest -Uri $settingsCatalogUri -Method Get
-        $allSettingsCatalog = [System.Collections.Generic.List[object]]::new()
-        if ($settingsCatalogResponse.value) { $allSettingsCatalog.AddRange($settingsCatalogResponse.value) }
-        while ($settingsCatalogResponse.'@odata.nextLink') {
-            $settingsCatalogResponse = Invoke-MgGraphRequest -Uri $settingsCatalogResponse.'@odata.nextLink' -Method Get
-            if ($settingsCatalogResponse.value) { $allSettingsCatalog.AddRange($settingsCatalogResponse.value) }
-        }
-
-        foreach ($policy in $allSettingsCatalog) {
-            $policyId = $policy.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/configurationPolicies('$policyId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            # Check for both inclusion and exclusion assignments
-            $hasAssignment = $assignmentResponse.value | Where-Object {
-                $allGroupIds -contains $_.target.groupId -and
-                ($_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -or
-                $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget')
-            }
-            if ($hasAssignment) {
-                $isExclusion = $hasAssignment | Where-Object {
-                    $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget'
-                }
-                $isInherited = $hasAssignment | Where-Object {
-                    $_.target.groupId -ne $groupId
-                }
-                $suffix = ""
-                if ($isExclusion) { $suffix += " [EXCLUDED]" }
-                if ($isInherited) { $suffix += " [INHERITED]" }
-                $filterMatch = $hasAssignment | Where-Object { $_.target.deviceAndAppManagementAssignmentFilterType -and $_.target.deviceAndAppManagementAssignmentFilterType -ne 'none' } | Select-Object -First 1
-                if ($filterMatch) {
-                    $suffix += (Format-AssignmentFilter -FilterId $filterMatch.target.deviceAndAppManagementAssignmentFilterId -FilterType $filterMatch.target.deviceAndAppManagementAssignmentFilterType)
-                }
-                $displayName = "$($policy.name)$suffix"
-                [void]$groupAssignments[$groupName].SettingsCatalog.Add($displayName)
-            }
-        }
-
-        # Process Compliance Policies
-        $complianceUri = "$GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies"
-        $complianceResponse = Invoke-MgGraphRequest -Uri $complianceUri -Method Get
-        $allCompliancePolicies = [System.Collections.Generic.List[object]]::new()
-        if ($complianceResponse.value) { $allCompliancePolicies.AddRange($complianceResponse.value) }
-        while ($complianceResponse.'@odata.nextLink') {
-            $complianceResponse = Invoke-MgGraphRequest -Uri $complianceResponse.'@odata.nextLink' -Method Get
-            if ($complianceResponse.value) { $allCompliancePolicies.AddRange($complianceResponse.value) }
-        }
-
-        foreach ($policy in $allCompliancePolicies) {
-            $policyId = $policy.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies('$policyId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            # Check for both inclusion and exclusion assignments
-            $hasAssignment = $assignmentResponse.value | Where-Object {
-                $allGroupIds -contains $_.target.groupId -and
-                ($_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -or
-                $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget')
-            }
-            if ($hasAssignment) {
-                $isExclusion = $hasAssignment | Where-Object {
-                    $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget'
-                }
-                $isInherited = $hasAssignment | Where-Object {
-                    $_.target.groupId -ne $groupId
-                }
-                $suffix = ""
-                if ($isExclusion) { $suffix += " [EXCLUDED]" }
-                if ($isInherited) { $suffix += " [INHERITED]" }
-                $filterMatch = $hasAssignment | Where-Object { $_.target.deviceAndAppManagementAssignmentFilterType -and $_.target.deviceAndAppManagementAssignmentFilterType -ne 'none' } | Select-Object -First 1
-                if ($filterMatch) {
-                    $suffix += (Format-AssignmentFilter -FilterId $filterMatch.target.deviceAndAppManagementAssignmentFilterId -FilterType $filterMatch.target.deviceAndAppManagementAssignmentFilterType)
-                }
-                $displayName = "$($policy.displayName)$suffix"
-                [void]$groupAssignments[$groupName].CompliancePolicies.Add($displayName)
-            }
-        }
-
-        # Process Apps
-        $appUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-        $allApps = [System.Collections.Generic.List[object]]::new()
-        if ($appResponse.value) { $allApps.AddRange($appResponse.value) }
-        while ($appResponse.'@odata.nextLink') {
-            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-            if ($appResponse.value) { $allApps.AddRange($appResponse.value) }
-        }
-
-        foreach ($app in $allApps) {
-            # Skip built-in and Microsoft apps
-            if ($app.isFeatured -or $app.isBuiltIn) {
-                continue
-            }
-
-            $appId = $app.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            foreach ($assignment in $assignmentResponse.value) {
-                if ($allGroupIds -contains $assignment.target.groupId) {
-                    $exclusionSuffix = if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget') { " [EXCLUDED]" } else { "" }
-                    $inheritedSuffix = if ($assignment.target.groupId -ne $groupId) { " [INHERITED]" } else { "" }
-                    $filterSuffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
-                    $combinedSuffix = "$exclusionSuffix$inheritedSuffix$filterSuffix"
-                    switch ($assignment.intent) {
-                        "required" { [void]$groupAssignments[$groupName].RequiredApps.Add("$($app.displayName)$combinedSuffix") }
-                        "available" { [void]$groupAssignments[$groupName].AvailableApps.Add("$($app.displayName)$combinedSuffix") }
-                        "uninstall" { [void]$groupAssignments[$groupName].UninstallApps.Add("$($app.displayName)$combinedSuffix") }
-                    }
-                }
-            }
-        }
-
-        # Process Platform Scripts (PowerShell)
-        $scriptsUri = "$GraphEndpoint/beta/deviceManagement/deviceManagementScripts"
-        $scriptsResponse = Invoke-MgGraphRequest -Uri $scriptsUri -Method Get
-        # For PowerShell scripts, we need to check the script type
-        foreach ($script in $scriptsResponse.value) {
-            $scriptId = $script.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceManagementScripts('$scriptId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            $hasAssignment = $assignmentResponse.value | Where-Object { $allGroupIds -contains $_.target.groupId }
-            if ($hasAssignment) {
-                $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                $scriptInfo = "$($script.displayName) (PowerShell)$suffix"
-                [void]$groupAssignments[$groupName].PlatformScripts.Add($scriptInfo)
-            }
-        }
-
-        # Process Shell Scripts (macOS)
-        $shellScriptsUri = "$GraphEndpoint/beta/deviceManagement/deviceShellScripts"
-        $shellScriptsResponse = Invoke-MgGraphRequest -Uri $shellScriptsUri -Method Get
-        # For Shell scripts, we need to check the script type
-        foreach ($script in $shellScriptsResponse.value) {
-            $scriptId = $script.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceShellScripts('$scriptId')/groupAssignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            $hasAssignment = $assignmentResponse.value | Where-Object { $allGroupIds -contains $_.targetGroupId }
-            if ($hasAssignment) {
-                $isInherited = $hasAssignment | Where-Object { $_.targetGroupId -ne $groupId }
-                $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                $scriptInfo = "$($script.displayName) (Shell)$suffix"
-                [void]$groupAssignments[$groupName].PlatformScripts.Add($scriptInfo)
-            }
-        }
-
-        # Fetch and process Proactive Remediation Scripts (deviceHealthScripts)
-        $healthScriptsUri = "$GraphEndpoint/beta/deviceManagement/deviceHealthScripts"
-        $healthScriptsResponse = Invoke-MgGraphRequest -Uri $healthScriptsUri -Method Get
-        foreach ($script in $healthScriptsResponse.value) {
-            $scriptId = $script.id
-            $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceHealthScripts('$scriptId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            $hasAssignment = $assignmentResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-            if ($hasAssignment) {
-                $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                [void]$groupAssignments[$groupName].HealthScripts.Add("$($script.displayName)$suffix")
-            }
-        }
-
-        # Get Endpoint Security - Antivirus Policies
-        $allIntentsForAntivirusCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirusCompare
-        $antivirusPolicies = $allIntentsForAntivirusCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-        if ($antivirusPolicies) {
-            foreach ($policy in $antivirusPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].AntivirusProfiles.Add("$($policy.displayName)$suffix")
-                }
-            }
-        }
-
-        # Get Endpoint Security - Disk Encryption Policies
-        $allIntentsForDiskEncCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEncCompare
-        $diskEncryptionPolicies = $allIntentsForDiskEncCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-        if ($diskEncryptionPolicies) {
-            foreach ($policy in $diskEncryptionPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].DiskEncryptionProfiles.Add("$($policy.displayName)$suffix")
-                }
-            }
-        }
-
-        # Get Endpoint Security - Firewall Policies
-        $allIntentsForFirewallCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewallCompare
-        $firewallPolicies = $allIntentsForFirewallCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-        if ($firewallPolicies) {
-            foreach ($policy in $firewallPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].FirewallProfiles.Add("$($policy.displayName)$suffix")
-                }
-            }
-        }
-
-        # Get Endpoint Security - Endpoint Detection and Response Policies
-        $allIntentsForEDRCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDRCompare
-        $edrPolicies = $allIntentsForEDRCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-        if ($edrPolicies) {
-            foreach ($policy in $edrPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].EndpointDetectionProfiles.Add("$($policy.displayName)$suffix")
-                }
-            }
-        }
-
-        # Get Endpoint Security - Attack Surface Reduction Policies
-        $allIntentsForASRCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASRCompare
-        $asrPolicies = $allIntentsForASRCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-        if ($asrPolicies) {
-            foreach ($policy in $asrPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].AttackSurfaceProfiles.Add("$($policy.displayName)$suffix")
-                }
-            }
-        }
-
-        # Get Endpoint Security - Account Protection Policies
-        $allIntentsForAccountProtectionCompare = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtectionCompare
-        $accountProtectionPolicies = $allIntentsForAccountProtectionCompare | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-        if ($accountProtectionPolicies) {
-            foreach ($policy in $accountProtectionPolicies) {
-                $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $hasAssignment = $assignments.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $_.target.groupId }
-                if ($hasAssignment) {
-                    $isInherited = $hasAssignment | Where-Object { $_.target.groupId -ne $groupId }
-                    $suffix = if ($isInherited) { " [INHERITED]" } else { "" }
-                    [void]$groupAssignments[$groupName].AccountProtectionProfiles.Add("$($policy.displayName)$suffix")
-                }
+            $hasAssignment = @($shellAssignments | Where-Object { $allGroupIds -contains $_.targetGroupId })
+            if ($hasAssignment.Count -gt 0) {
+                $isInherited = @($hasAssignment | Where-Object { $_.targetGroupId -ne $groupId })
+                $suffix = if ($isInherited.Count -gt 0) { " [INHERITED]" } else { "" }
+                $groupAssignments[$groupName]['PlatformScripts'].Add("$($shellScript.displayName) (Shell)$suffix")
             }
         }
     }

--- a/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
@@ -111,7 +111,8 @@ function Compare-IntuneGroupAssignment {
         }
         else {
             # Try to find group by display name
-            $groupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$groupInput'"
+            $escapedGroupName = $groupInput -replace "'", "''"
+            $groupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
 
             if ($groupResponse.value.Count -eq 0) {
@@ -213,8 +214,14 @@ function Compare-IntuneGroupAssignment {
         # Process Settings Catalog
         $settingsCatalogUri = "$GraphEndpoint/beta/deviceManagement/configurationPolicies"
         $settingsCatalogResponse = Invoke-MgGraphRequest -Uri $settingsCatalogUri -Method Get
+        $allSettingsCatalog = [System.Collections.Generic.List[object]]::new()
+        if ($settingsCatalogResponse.value) { $allSettingsCatalog.AddRange($settingsCatalogResponse.value) }
+        while ($settingsCatalogResponse.'@odata.nextLink') {
+            $settingsCatalogResponse = Invoke-MgGraphRequest -Uri $settingsCatalogResponse.'@odata.nextLink' -Method Get
+            if ($settingsCatalogResponse.value) { $allSettingsCatalog.AddRange($settingsCatalogResponse.value) }
+        }
 
-        foreach ($policy in $settingsCatalogResponse.value) {
+        foreach ($policy in $allSettingsCatalog) {
             $policyId = $policy.id
             $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/configurationPolicies('$policyId')/assignments"
             $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
@@ -247,8 +254,14 @@ function Compare-IntuneGroupAssignment {
         # Process Compliance Policies
         $complianceUri = "$GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies"
         $complianceResponse = Invoke-MgGraphRequest -Uri $complianceUri -Method Get
+        $allCompliancePolicies = [System.Collections.Generic.List[object]]::new()
+        if ($complianceResponse.value) { $allCompliancePolicies.AddRange($complianceResponse.value) }
+        while ($complianceResponse.'@odata.nextLink') {
+            $complianceResponse = Invoke-MgGraphRequest -Uri $complianceResponse.'@odata.nextLink' -Method Get
+            if ($complianceResponse.value) { $allCompliancePolicies.AddRange($complianceResponse.value) }
+        }
 
-        foreach ($policy in $complianceResponse.value) {
+        foreach ($policy in $allCompliancePolicies) {
             $policyId = $policy.id
             $assignmentsUri = "$GraphEndpoint/beta/deviceManagement/deviceCompliancePolicies('$policyId')/assignments"
             $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
@@ -281,8 +294,14 @@ function Compare-IntuneGroupAssignment {
         # Process Apps
         $appUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
         $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
+        $allApps = [System.Collections.Generic.List[object]]::new()
+        if ($appResponse.value) { $allApps.AddRange($appResponse.value) }
+        while ($appResponse.'@odata.nextLink') {
+            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
+            if ($appResponse.value) { $allApps.AddRange($appResponse.value) }
+        }
 
-        foreach ($app in $appResponse.value) {
+        foreach ($app in $allApps) {
             # Skip built-in and Microsoft apps
             if ($app.isFeatured -or $app.isBuiltIn) {
                 continue

--- a/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
@@ -69,17 +69,7 @@ function Connect-IntuneAssignmentChecker {
     $parameterMode     = $hasAppId -or $hasTenantId -or $hasClientSecret -or $hasCertThumbprint -or $hasAccessToken
 
     # ── Required permissions ──────────────────────────────────────────────
-    $requiredPermissions = @(
-        @{ Permission = "User.Read.All";                         Reason = "Required to read user profile information and check group memberships" }
-        @{ Permission = "Group.Read.All";                        Reason = "Needed to read group information and memberships" }
-        @{ Permission = "DeviceManagementConfiguration.Read.All"; Reason = "Allows reading Intune device configuration policies and their assignments" }
-        @{ Permission = "DeviceManagementApps.Read.All";         Reason = "Necessary to read mobile app management policies and app configurations" }
-        @{ Permission = "DeviceManagementManagedDevices.Read.All"; Reason = "Required to read managed device information and compliance policies" }
-        @{ Permission = "Device.Read.All";                       Reason = "Needed to read device information from Entra ID" }
-        @{ Permission = "DeviceManagementScripts.Read.All";      Reason = "Needed to read device management and health scripts" }
-        @{ Permission = "CloudPC.Read.All";                      Reason = "Required to read Windows 365 Cloud PC provisioning policies and settings (optional if W365 not licensed)" }
-        @{ Permission = "DeviceManagementRBAC.Read.All";         Reason = "Required to read role scope tags for scope tag display and filtering" }
-    )
+    $requiredPermissions = $script:RequiredPermissions
 
     # ── Connect to Microsoft Graph ────────────────────────────────────────
     try {
@@ -101,13 +91,21 @@ function Connect-IntuneAssignmentChecker {
             if ($hasAccessToken) {
                 # Pre-fetched access token authentication (managed identity, federated creds, parent-script tokens, etc.)
                 Write-Host "Connecting using pre-fetched access token..." -ForegroundColor Yellow
-                Set-Environment -EnvironmentName $Environment
+                $environmentResult = Set-Environment -EnvironmentName $Environment
+                if ($null -eq $environmentResult) {
+                    Write-Host "Connection cancelled by user." -ForegroundColor Red
+                    return
+                }
                 $null = Connect-MgGraph -AccessToken $AccessToken -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
             }
             elseif ($hasAppId -and $hasTenantId -and $hasClientSecret) {
                 # Client Secret authentication
                 Write-Host "Connecting using Client Secret authentication..." -ForegroundColor Yellow
-                Set-Environment -EnvironmentName $Environment
+                $environmentResult = Set-Environment -EnvironmentName $Environment
+                if ($null -eq $environmentResult) {
+                    Write-Host "Connection cancelled by user." -ForegroundColor Red
+                    return
+                }
                 $secureSecret = ConvertTo-SecureString $ClientSecret -AsPlainText -Force
                 $credential = New-Object System.Management.Automation.PSCredential($AppId, $secureSecret)
                 $null = Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $credential -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
@@ -115,7 +113,11 @@ function Connect-IntuneAssignmentChecker {
             elseif ($hasAppId -and $hasTenantId -and $hasCertThumbprint) {
                 # Certificate-based authentication
                 Write-Host "Connecting using Certificate authentication..." -ForegroundColor Yellow
-                Set-Environment -EnvironmentName $Environment
+                $environmentResult = Set-Environment -EnvironmentName $Environment
+                if ($null -eq $environmentResult) {
+                    Write-Host "Connection cancelled by user." -ForegroundColor Red
+                    return
+                }
                 $null = Connect-MgGraph -ClientId $AppId -TenantId $TenantId -Environment $script:GraphEnvironment -CertificateThumbprint $CertificateThumbprint -NoWelcome -ErrorAction Stop
             }
             else {
@@ -126,10 +128,14 @@ function Connect-IntuneAssignmentChecker {
                     Write-Host "Attempting manual interactive connection (you need privileges to consent permissions)..." -ForegroundColor Yellow
                     $permissionsList = ($requiredPermissions | ForEach-Object { $_.Permission }) -join ', '
                     if ($parameterMode) {
-                        Set-Environment -EnvironmentName $Environment
+                        $environmentResult = Set-Environment -EnvironmentName $Environment
                     }
                     else {
-                        Set-Environment
+                        $environmentResult = Set-Environment
+                    }
+                    if ($null -eq $environmentResult) {
+                        Write-Host "Connection cancelled by user." -ForegroundColor Red
+                        return
                     }
                     $null = Connect-MgGraph -Scopes $permissionsList -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
                 }

--- a/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
@@ -10,8 +10,11 @@ function Connect-IntuneAssignmentChecker {
         [Parameter(Mandatory = $false, HelpMessage = "Certificate Thumbprint for authentication")]
         [string]$CertificateThumbprint,
 
-        [Parameter(Mandatory = $false, HelpMessage = "Client Secret for authentication")]
+        [Parameter(Mandatory = $false, HelpMessage = "Client Secret for authentication (plain text; retained for compatibility, prefer -ClientSecretCredential)")]
         [string]$ClientSecret,
+
+        [Parameter(Mandatory = $false, HelpMessage = "Client Secret as PSCredential (UserName = App ID, Password = client secret); preferred over -ClientSecret")]
+        [PSCredential]$ClientSecretCredential,
 
         [Parameter(Mandatory = $false, HelpMessage = "Pre-fetched Microsoft Graph access token (SecureString)")]
         [SecureString]$AccessToken,
@@ -22,7 +25,12 @@ function Connect-IntuneAssignmentChecker {
     )
 
     # ── Banner ────────────────────────────────────────────────────────────
-    $localVersion = "4.2.0"
+    $localVersion = if ($MyInvocation.MyCommand.Module) {
+        $MyInvocation.MyCommand.Module.Version.ToString()
+    }
+    else {
+        (Get-Module IntuneAssignmentChecker).Version.ToString()
+    }
 
     Write-Host "INTUNE ASSIGNMENT CHECKER" -ForegroundColor Cyan
     Write-Host "Made by Ugur Koc" -NoNewline
@@ -64,9 +72,10 @@ function Connect-IntuneAssignmentChecker {
     $hasAppId          = -not [string]::IsNullOrWhiteSpace($AppId)
     $hasTenantId       = -not [string]::IsNullOrWhiteSpace($TenantId)
     $hasClientSecret   = -not [string]::IsNullOrWhiteSpace($ClientSecret)
+    $hasClientSecretCredential = $null -ne $ClientSecretCredential
     $hasCertThumbprint = -not [string]::IsNullOrWhiteSpace($CertificateThumbprint)
     $hasAccessToken    = $null -ne $AccessToken -and $AccessToken.Length -gt 0
-    $parameterMode     = $hasAppId -or $hasTenantId -or $hasClientSecret -or $hasCertThumbprint -or $hasAccessToken
+    $parameterMode     = $hasAppId -or $hasTenantId -or $hasClientSecret -or $hasClientSecretCredential -or $hasCertThumbprint -or $hasAccessToken
 
     # ── Required permissions ──────────────────────────────────────────────
     $requiredPermissions = $script:RequiredPermissions
@@ -98,8 +107,18 @@ function Connect-IntuneAssignmentChecker {
                 }
                 $null = Connect-MgGraph -AccessToken $AccessToken -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
             }
+            elseif ($hasTenantId -and $hasClientSecretCredential) {
+                # Client Secret authentication (PSCredential, preferred over plain-text -ClientSecret)
+                Write-Host "Connecting using Client Secret authentication..." -ForegroundColor Yellow
+                $environmentResult = Set-Environment -EnvironmentName $Environment
+                if ($null -eq $environmentResult) {
+                    Write-Host "Connection cancelled by user." -ForegroundColor Red
+                    return
+                }
+                $null = Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $ClientSecretCredential -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
+            }
             elseif ($hasAppId -and $hasTenantId -and $hasClientSecret) {
-                # Client Secret authentication
+                # Client Secret authentication (plain-text string, retained for compatibility)
                 Write-Host "Connecting using Client Secret authentication..." -ForegroundColor Yellow
                 $environmentResult = Set-Environment -EnvironmentName $Environment
                 if ($null -eq $environmentResult) {

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
@@ -14,420 +14,81 @@ function Get-IntuneAllDevicesAssignment {
     Write-Host "Fetching all 'All Devices' assignments..." -ForegroundColor Green
     $exportData = [System.Collections.ArrayList]::new()
 
-    # Initialize collections for policies with "All Devices" assignments
-    $allDevicesAssignments = @{
-        DeviceConfigs             = @()
-        SettingsCatalog           = @()
-        CompliancePolicies        = @()
-        AppProtectionPolicies     = @()
-        AppConfigurationPolicies  = @()
-        PlatformScripts           = @()
-        HealthScripts             = @()
-        RequiredApps              = @()
-        AvailableApps             = @()
-        UninstallApps             = @()
-        DeploymentProfiles        = @()
-        ESPProfiles               = @()
-        AntivirusProfiles         = @()
-        DiskEncryptionProfiles    = @()
-        FirewallProfiles          = @()
-        EndpointDetectionProfiles    = @()
-        AttackSurfaceProfiles        = @()
-        AccountProtectionProfiles    = @()
+    # Local display-name helpers preserving the historical per-category fallback quirks.
+    function Get-NamePreferringName { param($Item) if ([string]::IsNullOrWhiteSpace($Item.name)) { $Item.displayName } else { $Item.name } }
+    function Get-NamePreferringDisplayName { param($Item) if ([string]::IsNullOrWhiteSpace($Item.displayName)) { $Item.name } else { $Item.displayName } }
+    function Get-NameWithUnnamedFallback {
+        param($Item, [string]$Fallback)
+        if (-not [string]::IsNullOrWhiteSpace($Item.displayName)) { $Item.displayName }
+        elseif (-not [string]::IsNullOrWhiteSpace($Item.name)) { $Item.name }
+        else { $Fallback }
     }
 
-    # Get Device Configurations
-    Write-Host "Fetching Device Configurations..." -ForegroundColor Yellow
-    $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    foreach ($config in $deviceConfigs) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.DeviceConfigs += $config
-        }
+    # UserContext is the registry audience whose category set covers this cmdlet
+    # (Applications included, no ES exclusion on Settings Catalog). Local adjustments
+    # reproduce the pre-migration behavior of this cmdlet: Autopilot/ESP profiles ARE
+    # fetched here (UserContext registers them bucket-only for export parity) and the
+    # Windows 365 Cloud PC categories are not part of this cmdlet.
+    $categoryById = @{}
+    foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoryById[$category.Id] = $category }
+    foreach ($id in @('DeploymentProfiles', 'ESPProfiles')) { $categoryById[$id].BucketOnly = $false }
+
+    # Fetch order matches the pre-migration cmdlet (16 categories).
+    $scanCategories = foreach ($id in @(
+            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'AppConfigurationPolicies', 'Applications', 'PlatformScripts', 'HealthScripts',
+            'DeploymentProfiles', 'ESPProfiles',
+            'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection')) {
+        $categoryById[$id]
     }
 
-    # Get Settings Catalog Policies
-    Write-Host "Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-    $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    foreach ($policy in $settingsCatalog) {
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.SettingsCatalog += $policy
-        }
-    }
+    $processEntity = {
+        param($ctx)
 
-    # Get Compliance Policies
-    Write-Host "Fetching Compliance Policies..." -ForegroundColor Yellow
-    $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    foreach ($policy in $compliancePolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.CompliancePolicies += $policy
-        }
-    }
+        $entity = $ctx.Entity
 
-    # Get App Protection Policies
-    Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
-    $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    foreach ($policy in $appProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $allDevicesTarget = $null
-                foreach ($assignment in $assignmentResponse.value) {
-                    if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-                        $allDevicesTarget = $assignment.target
-                        break
+        if ($ctx.Category.Kind -eq 'MobileApps') {
+            # Historical app handling: only the first 'All Devices' assignment counts,
+            # and the app lands in the bucket matching that assignment's intent.
+            foreach ($assignment in $ctx.RawAssignments) {
+                if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget') {
+                    $suffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
+                    $appWithReason = $entity.PSObject.Copy()
+                    $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$suffix" -Force
+                    switch ($assignment.intent) {
+                        'required' { $ctx.Buckets['AppsRequired'].Add($appWithReason); break }
+                        'available' { $ctx.Buckets['AppsAvailable'].Add($appWithReason); break }
+                        'uninstall' { $ctx.Buckets['AppsUninstall'].Add($appWithReason); break }
                     }
-                }
-                if ($allDevicesTarget) {
-                    $suffix = Format-AssignmentFilter -FilterId $allDevicesTarget.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$suffix" -Force
-                    $allDevicesAssignments.AppProtectionPolicies += $policy
+                    break
                 }
             }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+            return
+        }
+
+        $reason = if ($null -ne $ctx.RawAssignments) {
+            # App Protection policies and legacy intent-based ES policies: historical
+            # wording built the filter suffix from the first raw 'All Devices' target.
+            $allDevicesAssignment = $ctx.RawAssignments |
+                Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } |
+                Select-Object -First 1
+            if ($allDevicesAssignment) {
+                $suffix = Format-AssignmentFilter -FilterId $allDevicesAssignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesAssignment.target.deviceAndAppManagementAssignmentFilterType
+                "All Devices$suffix"
             }
         }
-    }
+        else {
+            Get-AllTargetReason -Assignments $ctx.Assignments -TargetReason 'All Devices'
+        }
 
-    # Get App Configuration Policies
-    Write-Host "Fetching App Configuration Policies..." -ForegroundColor Yellow
-    $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    foreach ($policy in $appConfigPolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.AppConfigurationPolicies += $policy
+        if ($reason) {
+            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
+            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
         }
     }
 
-    # Get Applications
-    Write-Host "Fetching Applications..." -ForegroundColor Yellow
-    $appUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-    $allApps = $appResponse.value
-    while ($appResponse.'@odata.nextLink') {
-        $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-        $allApps += $appResponse.value
-    }
-    $totalApps = $allApps.Count
-
-    foreach ($app in $allApps) {
-        # Filter out irrelevant apps
-        if ($app.isFeatured -or $app.isBuiltIn) {
-            continue
-        }
-
-        $appId = $app.id
-        $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-        $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-        foreach ($assignment in $assignmentResponse.value) {
-            if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-                $suffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$suffix" -Force
-                switch ($assignment.intent) {
-                    "required" { $allDevicesAssignments.RequiredApps += $appWithReason; break }
-                    "available" { $allDevicesAssignments.AvailableApps += $appWithReason; break }
-                    "uninstall" { $allDevicesAssignments.UninstallApps += $appWithReason; break }
-                }
-                break
-            }
-        }
-    }
-
-    # Get Platform Scripts
-    Write-Host "Fetching Platform Scripts..." -ForegroundColor Yellow
-    $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    foreach ($script in $platformScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.PlatformScripts += $script
-        }
-    }
-
-    # Get Proactive Remediation Scripts
-    Write-Host "Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    foreach ($script in $healthScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.HealthScripts += $script
-        }
-    }
-
-    # Get Autopilot Deployment Profiles
-    Write-Host "Fetching Autopilot Deployment Profiles assigned to All Devices..." -ForegroundColor Yellow
-    $autoProfilesAD = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($policyProfile in $autoProfilesAD) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policyProfile.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $policyProfile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.DeploymentProfiles += $policyProfile
-        }
-    }
-
-    # Get Enrollment Status Page Profiles
-    Write-Host "Fetching Enrollment Status Page Profiles assigned to All Devices..." -ForegroundColor Yellow
-    $enrollmentConfigsAD = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $espProfilesAD = $enrollmentConfigsAD | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    foreach ($esp in $espProfilesAD) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-            $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allDevicesAssignments.ESPProfiles += $esp
-        }
-    }
-
-    # Get Endpoint Security - Antivirus Policies (Dual Check)
-    Write-Host "Fetching Antivirus Policies assigned to All Devices..." -ForegroundColor Yellow
-    $antivirusPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedAntivirusIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for Antivirus
-    $configPoliciesForAntivirus_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAntivirus_AllDevices = $configPoliciesForAntivirus_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($matchingConfigPoliciesAntivirus_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesAntivirus_AllDevices) {
-            if ($processedAntivirusIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$antivirusPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for Antivirus
-    $allIntentsForAntivirus_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirus_AllDevices
-    $matchingIntentsAntivirus_AllDevices = $allIntentsForAntivirus_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($matchingIntentsAntivirus_AllDevices) {
-        foreach ($policy in $matchingIntentsAntivirus_AllDevices) {
-            if ($processedAntivirusIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$antivirusPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.AntivirusProfiles = $antivirusPoliciesFound_AllDevices
-
-    # Get Endpoint Security - Disk Encryption Policies (Dual Check)
-    Write-Host "Fetching Disk Encryption Policies assigned to All Devices..." -ForegroundColor Yellow
-    $diskEncryptionPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedDiskEncryptionIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for Disk Encryption
-    $configPoliciesForDiskEnc_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesDiskEnc_AllDevices = $configPoliciesForDiskEnc_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($matchingConfigPoliciesDiskEnc_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesDiskEnc_AllDevices) {
-            if ($processedDiskEncryptionIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$diskEncryptionPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for Disk Encryption
-    $allIntentsForDiskEnc_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEnc_AllDevices
-    $matchingIntentsDiskEnc_AllDevices = $allIntentsForDiskEnc_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($matchingIntentsDiskEnc_AllDevices) {
-        foreach ($policy in $matchingIntentsDiskEnc_AllDevices) {
-            if ($processedDiskEncryptionIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$diskEncryptionPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.DiskEncryptionProfiles = $diskEncryptionPoliciesFound_AllDevices
-
-    # Get Endpoint Security - Firewall Policies (Dual Check)
-    Write-Host "Fetching Firewall Policies assigned to All Devices..." -ForegroundColor Yellow
-    $firewallPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedFirewallIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for Firewall
-    $configPoliciesForFirewall_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesFirewall_AllDevices = $configPoliciesForFirewall_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($matchingConfigPoliciesFirewall_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesFirewall_AllDevices) {
-            if ($processedFirewallIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$firewallPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for Firewall
-    $allIntentsForFirewall_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewall_AllDevices
-    $matchingIntentsFirewall_AllDevices = $allIntentsForFirewall_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($matchingIntentsFirewall_AllDevices) {
-        foreach ($policy in $matchingIntentsFirewall_AllDevices) {
-            if ($processedFirewallIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$firewallPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.FirewallProfiles = $firewallPoliciesFound_AllDevices
-
-    # Get Endpoint Security - Endpoint Detection and Response Policies (Dual Check)
-    Write-Host "Fetching EDR Policies assigned to All Devices..." -ForegroundColor Yellow
-    $edrPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedEDRIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for EDR
-    $configPoliciesForEDR_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesEDR_AllDevices = $configPoliciesForEDR_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($matchingConfigPoliciesEDR_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesEDR_AllDevices) {
-            if ($processedEDRIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$edrPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for EDR
-    $allIntentsForEDR_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDR_AllDevices
-    $matchingIntentsEDR_AllDevices = $allIntentsForEDR_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($matchingIntentsEDR_AllDevices) {
-        foreach ($policy in $matchingIntentsEDR_AllDevices) {
-            if ($processedEDRIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$edrPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.EndpointDetectionProfiles = $edrPoliciesFound_AllDevices
-
-    # Get Endpoint Security - Attack Surface Reduction Policies (Dual Check)
-    Write-Host "Fetching ASR Policies assigned to All Devices..." -ForegroundColor Yellow
-    $asrPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedASRIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for ASR
-    $configPoliciesForASR_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesASR_AllDevices = $configPoliciesForASR_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($matchingConfigPoliciesASR_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesASR_AllDevices) {
-            if ($processedASRIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$asrPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for ASR
-    $allIntentsForASR_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASR_AllDevices
-    $matchingIntentsASR_AllDevices = $allIntentsForASR_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($matchingIntentsASR_AllDevices) {
-        foreach ($policy in $matchingIntentsASR_AllDevices) {
-            if ($processedASRIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$asrPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.AttackSurfaceProfiles = $asrPoliciesFound_AllDevices
-
-    # Get Endpoint Security - Account Protection Policies (Dual Check)
-    Write-Host "Fetching Account Protection Policies assigned to All Devices..." -ForegroundColor Yellow
-    $accountProtectionPoliciesFound_AllDevices = [System.Collections.ArrayList]::new()
-    $processedAccountProtectionIds_AllDevices = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies for Account Protection
-    $configPoliciesForAccountProtection_AllDevices = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAccountProtection_AllDevices = $configPoliciesForAccountProtection_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($matchingConfigPoliciesAccountProtection_AllDevices) {
-        foreach ($policy in $matchingConfigPoliciesAccountProtection_AllDevices) {
-            if ($processedAccountProtectionIds_AllDevices.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Devices")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$accountProtectionPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents for Account Protection
-    $allIntentsForAccountProtection_AllDevices = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtection_AllDevices
-    $matchingIntentsAccountProtection_AllDevices = $allIntentsForAccountProtection_AllDevices | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($matchingIntentsAccountProtection_AllDevices) {
-        foreach ($policy in $matchingIntentsAccountProtection_AllDevices) {
-            if ($processedAccountProtectionIds_AllDevices.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allDevicesTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' } | Select-Object -First 1
-                if ($allDevicesTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allDevicesTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Devices$intentSuffix" -Force
-                    [void]$accountProtectionPoliciesFound_AllDevices.Add($policy)
-                }
-            }
-        }
-    }
-    $allDevicesAssignments.AccountProtectionProfiles = $accountProtectionPoliciesFound_AllDevices
+    $scanResult = Invoke-IntuneCategoryScan -Categories $scanCategories -ProcessEntity $processEntity -ShowProgress
+    $allDevicesAssignments = $scanResult.Buckets
 
     # Apply scope tag filter if specified
     if ($ScopeTagFilter) {
@@ -439,243 +100,58 @@ function Get-IntuneAllDevicesAssignment {
     # Display results
     Write-Host "`nPolicies Assigned to All Devices:" -ForegroundColor Green
 
-    # Display Device Configurations
-    Write-Host "`n------- Device Configurations -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.DeviceConfigs.Count -eq 0) {
-        Write-Host "No Device Configurations assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($config in $allDevicesAssignments.DeviceConfigs) {
-            $configName = if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
-            $platform = Get-PolicyPlatform -Policy $config
-            Write-Host "Device Configuration Name: $configName, Platform: $platform, Configuration ID: $($config.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items @($config) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Settings Catalog Policies
-    Write-Host "`n------- Settings Catalog Policies -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.SettingsCatalog.Count -eq 0) {
-        Write-Host "No Settings Catalog Policies assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allDevicesAssignments.SettingsCatalog) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            Write-Host "Settings Catalog Policy Name: $policyName, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items @($policy) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Compliance Policies
-    Write-Host "`n------- Compliance Policies -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.CompliancePolicies.Count -eq 0) {
-        Write-Host "No Compliance Policies assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allDevicesAssignments.CompliancePolicies) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            $platform = Get-PolicyPlatform -Policy $policy
-            Write-Host "Compliance Policy Name: $policyName, Platform: $platform, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items @($policy) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display App Protection Policies
-    Write-Host "`n------- App Protection Policies -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AppProtectionPolicies.Count -eq 0) {
-        Write-Host "No App Protection Policies assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allDevicesAssignments.AppProtectionPolicies) {
-            $policyName = $policy.displayName
-            $policyType = switch ($policy.'@odata.type') {
-                "#microsoft.graph.androidManagedAppProtection" { "Android" }
-                "#microsoft.graph.iosManagedAppProtection" { "iOS" }
-                "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
-                default { "Unknown" }
+    $displaySpecs = @(
+        @{ Bucket = 'DeviceConfigs'; Header = 'Device Configurations'; Empty = 'Device Configurations'; Line = { param($item) "Device Configuration Name: $(Get-NamePreferringName $item), Platform: $(Get-PolicyPlatform -Policy $item), Configuration ID: $($item.id)" } }
+        @{ Bucket = 'SettingsCatalog'; Header = 'Settings Catalog Policies'; Empty = 'Settings Catalog Policies'; Line = { param($item) "Settings Catalog Policy Name: $(Get-NamePreferringName $item), Policy ID: $($item.id)" } }
+        @{ Bucket = 'CompliancePolicies'; Header = 'Compliance Policies'; Empty = 'Compliance Policies'; Line = { param($item) "Compliance Policy Name: $(Get-NamePreferringName $item), Platform: $(Get-PolicyPlatform -Policy $item), Policy ID: $($item.id)" } }
+        @{ Bucket = 'AppProtectionPolicies'; Header = 'App Protection Policies'; Empty = 'App Protection Policies'; Line = {
+                param($item)
+                $policyType = switch ($item.'@odata.type') {
+                    "#microsoft.graph.androidManagedAppProtection" { "Android" }
+                    "#microsoft.graph.iosManagedAppProtection" { "iOS" }
+                    "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
+                    default { "Unknown" }
+                }
+                "App Protection Policy Name: $($item.displayName), Policy ID: $($item.id), Type: $policyType"
             }
-            Write-Host "App Protection Policy Name: $policyName, Policy ID: $($policy.id), Type: $policyType" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items @($policy) -AssignmentReason "All Devices"
+        }
+        @{ Bucket = 'AppConfigurationPolicies'; Header = 'App Configuration Policies'; Empty = 'App Configuration Policies'; Line = { param($item) "App Configuration Policy Name: $(Get-NamePreferringName $item), Policy ID: $($item.id)" } }
+        @{ Bucket = 'PlatformScripts'; Header = 'Platform Scripts'; Empty = 'Platform Scripts'; Line = { param($item) "Script Name: $(Get-NamePreferringName $item), Script ID: $($item.id)" } }
+        @{ Bucket = 'HealthScripts'; Header = 'Proactive Remediation Scripts'; Empty = 'Proactive Remediation Scripts'; Line = { param($item) "Script Name: $(Get-NamePreferringName $item), Script ID: $($item.id)" } }
+        @{ Bucket = 'AppsRequired'; Header = 'Required Apps'; Empty = 'Required Apps'; Line = { param($item) "App Name: $($item.displayName), App ID: $($item.id)" } }
+        @{ Bucket = 'AppsAvailable'; Header = 'Available Apps'; Empty = 'Available Apps'; Line = { param($item) "App Name: $($item.displayName), App ID: $($item.id)" } }
+        @{ Bucket = 'AppsUninstall'; Header = 'Uninstall Apps'; Empty = 'Uninstall Apps'; Line = { param($item) "App Name: $($item.displayName), App ID: $($item.id)" } }
+        @{ Bucket = 'AntivirusProfiles'; Header = 'Endpoint Security - Antivirus Profiles'; Empty = 'Antivirus Profiles'; Line = { param($item) "Antivirus Profile Name: $($item.displayName), Profile ID: $($item.id)" } }
+        @{ Bucket = 'DiskEncryptionProfiles'; Header = 'Endpoint Security - Disk Encryption Profiles'; Empty = 'Disk Encryption Profiles'; Line = { param($item) "Disk Encryption Profile Name: $($item.displayName), Profile ID: $($item.id)" } }
+        @{ Bucket = 'FirewallProfiles'; Header = 'Endpoint Security - Firewall Profiles'; Empty = 'Firewall Profiles'; Line = { param($item) "Firewall Profile Name: $($item.displayName), Profile ID: $($item.id)" } }
+        @{ Bucket = 'EndpointDetectionProfiles'; Header = 'Endpoint Security - EDR Profiles'; Empty = 'EDR Profiles'; Line = { param($item) "EDR Profile Name: $(Get-NameWithUnnamedFallback $item 'Unnamed EDR Profile'), Profile ID: $($item.id)" } }
+        @{ Bucket = 'AttackSurfaceProfiles'; Header = 'Endpoint Security - ASR Profiles'; Empty = 'ASR Profiles'; Line = { param($item) "ASR Profile Name: $($item.displayName), Profile ID: $($item.id)" } }
+        @{ Bucket = 'AccountProtectionProfiles'; Header = 'Endpoint Security - Account Protection Profiles'; Empty = 'Account Protection Profiles'; Line = { param($item) "Account Protection Profile Name: $(Get-NameWithUnnamedFallback $item 'Unnamed Account Protection Profile'), Profile ID: $($item.id)" } }
+        @{ Bucket = 'DeploymentProfiles'; Header = 'Autopilot Deployment Profiles'; Empty = 'Autopilot Deployment Profiles'; Line = { param($item) "Deployment Profile Name: $(Get-NamePreferringDisplayName $item), Profile ID: $($item.id)" } }
+        @{ Bucket = 'ESPProfiles'; Header = 'Enrollment Status Page Profiles'; Empty = 'Enrollment Status Page Profiles'; Line = { param($item) "Enrollment Status Page Name: $(Get-NamePreferringDisplayName $item), Profile ID: $($item.id)" } }
+    )
+
+    foreach ($spec in $displaySpecs) {
+        Write-Host "`n------- $($spec.Header) -------" -ForegroundColor Cyan
+        $items = @($allDevicesAssignments[$spec.Bucket])
+        if ($items.Count -eq 0) {
+            Write-Host "No $($spec.Empty) assigned to All Devices" -ForegroundColor Gray
+            continue
+        }
+        foreach ($item in $items) {
+            Write-Host (& $spec.Line $item) -ForegroundColor White
         }
     }
 
-    # Display App Configuration Policies
-    Write-Host "`n------- App Configuration Policies -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AppConfigurationPolicies.Count -eq 0) {
-        Write-Host "No App Configuration Policies assigned to All Devices" -ForegroundColor Gray
+    # Export rows in the pre-migration CSV order (apps after scripts, Autopilot/ESP last).
+    $exportCategories = foreach ($id in @(
+            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'Applications',
+            'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection',
+            'DeploymentProfiles', 'ESPProfiles')) {
+        $categoryById[$id]
     }
-    else {
-        foreach ($policy in $allDevicesAssignments.AppConfigurationPolicies) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            Write-Host "App Configuration Policy Name: $policyName, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items @($policy) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Platform Scripts
-    Write-Host "`n------- Platform Scripts -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.PlatformScripts.Count -eq 0) {
-        Write-Host "No Platform Scripts assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($script in $allDevicesAssignments.PlatformScripts) {
-            $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-            Write-Host "Script Name: $scriptName, Script ID: $($script.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items @($script) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Proactive Remediation Scripts
-    Write-Host "`n------- Proactive Remediation Scripts -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.HealthScripts.Count -eq 0) {
-        Write-Host "No Proactive Remediation Scripts assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($script in $allDevicesAssignments.HealthScripts) {
-            $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-            Write-Host "Script Name: $scriptName, Script ID: $($script.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items @($script) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Required Apps
-    Write-Host "`n------- Required Apps -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.RequiredApps.Count -eq 0) {
-        Write-Host "No Required Apps assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allDevicesAssignments.RequiredApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Required Apps" -Items @($app) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Available Apps
-    Write-Host "`n------- Available Apps -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AvailableApps.Count -eq 0) {
-        Write-Host "No Available Apps assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allDevicesAssignments.AvailableApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Available Apps" -Items @($app) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Uninstall Apps
-    Write-Host "`n------- Uninstall Apps -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.UninstallApps.Count -eq 0) {
-        Write-Host "No Uninstall Apps assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allDevicesAssignments.UninstallApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items @($app) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Antivirus Profiles
-    Write-Host "`n------- Endpoint Security - Antivirus Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AntivirusProfiles.Count -eq 0) {
-        Write-Host "No Antivirus Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.AntivirusProfiles) {
-            Write-Host "Antivirus Profile Name: $($policyProfile.displayName), Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Disk Encryption Profiles
-    Write-Host "`n------- Endpoint Security - Disk Encryption Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.DiskEncryptionProfiles.Count -eq 0) {
-        Write-Host "No Disk Encryption Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.DiskEncryptionProfiles) {
-            Write-Host "Disk Encryption Profile Name: $($policyProfile.displayName), Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Firewall Profiles
-    Write-Host "`n------- Endpoint Security - Firewall Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.FirewallProfiles.Count -eq 0) {
-        Write-Host "No Firewall Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.FirewallProfiles) {
-            Write-Host "Firewall Profile Name: $($policyProfile.displayName), Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Endpoint Detection and Response Profiles
-    Write-Host "`n------- Endpoint Security - EDR Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.EndpointDetectionProfiles.Count -eq 0) {
-        Write-Host "No EDR Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.EndpointDetectionProfiles) {
-            $profileNameForDisplay = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed EDR Profile" }
-            Write-Host "EDR Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Attack Surface Reduction Profiles
-    Write-Host "`n------- Endpoint Security - ASR Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AttackSurfaceProfiles.Count -eq 0) {
-        Write-Host "No ASR Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.AttackSurfaceProfiles) {
-            Write-Host "ASR Profile Name: $($policyProfile.displayName), Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Endpoint Security - Account Protection Profiles
-    Write-Host "`n------- Endpoint Security - Account Protection Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.AccountProtectionProfiles.Count -eq 0) {
-        Write-Host "No Account Protection Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.AccountProtectionProfiles) {
-            $profileNameForDisplay = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Account Protection Profile" }
-            Write-Host "Account Protection Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Autopilot Deployment Profiles
-    Write-Host "`n------- Autopilot Deployment Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.DeploymentProfiles.Count -eq 0) {
-        Write-Host "No Autopilot Deployment Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.DeploymentProfiles) {
-            $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.name } else { $policyProfile.displayName }
-            Write-Host "Deployment Profile Name: $profileName, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
-
-    # Display Enrollment Status Page Profiles
-    Write-Host "`n------- Enrollment Status Page Profiles -------" -ForegroundColor Cyan
-    if ($allDevicesAssignments.ESPProfiles.Count -eq 0) {
-        Write-Host "No Enrollment Status Page Profiles assigned to All Devices" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allDevicesAssignments.ESPProfiles) {
-            $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.name } else { $policyProfile.displayName }
-            Write-Host "Enrollment Status Page Name: $profileName, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items @($policyProfile) -AssignmentReason "All Devices"
-        }
-    }
+    Add-CategoryExportData -ExportData $exportData -Categories $exportCategories -Buckets $allDevicesAssignments -AssignmentReason "All Devices"
 
     # Export results if requested
     Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllDevicesAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
@@ -678,5 +678,5 @@ function Get-IntuneAllDevicesAssignment {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllDevicesAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllDevicesAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
@@ -609,5 +609,5 @@ function Get-IntuneAllPolicies {
     Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $allPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllPolicies.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllPolicies.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
@@ -14,27 +14,6 @@ function Get-IntuneAllPolicies {
     Write-Host "Fetching all policies and their assignments..." -ForegroundColor Green
     $exportData = [System.Collections.ArrayList]::new()
 
-    # Initialize collections for all policies
-    $allPolicies = @{
-        DeviceConfigs               = @()
-        SettingsCatalog             = @()
-        CompliancePolicies          = @()
-        AppProtectionPolicies       = @()
-        AppConfigurationPolicies    = @()
-        PlatformScripts             = @()
-        HealthScripts               = @()
-        AntivirusProfiles           = @()
-        DiskEncryptionProfiles      = @()
-        FirewallProfiles            = @()
-        EndpointDetectionProfiles   = @()
-        AttackSurfaceProfiles       = @()
-        AccountProtectionProfiles   = @()
-        DeploymentProfiles          = @()
-        ESPProfiles                 = @()
-        CloudPCProvisioningPolicies = @()
-        CloudPCUserSettings         = @()
-    }
-
     # Function to process and display policy assignments
     function Invoke-PolicyAssignments {
         param (
@@ -67,501 +46,69 @@ function Get-IntuneAllPolicies {
         }
     }
 
-    # Get Device Configurations
-    Write-Host "Fetching Device Configurations..." -ForegroundColor Yellow
-    $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    foreach ($config in $deviceConfigs) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $config | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.DeviceConfigs += $config
-    }
+    $categories = Get-IntuneCategoryDefinition -Audience 'AllPolicies'
 
-    # Get Settings Catalog Policies
-    Write-Host "Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-    $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    foreach ($policy in $settingsCatalog) {
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.SettingsCatalog += $policy
-    }
+    $processEntity = {
+        param($ctx)
 
-    # Get Compliance Policies
-    Write-Host "Fetching Compliance Policies..." -ForegroundColor Yellow
-    $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    foreach ($policy in $compliancePolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.CompliancePolicies += $policy
-    }
+        $entity = $ctx.Entity
+        $bucketKey = $ctx.Category.BucketKeys[0]
 
-    # Get App Protection Policies
-    Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
-    $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    foreach ($policy in $appProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $assignments = @()
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentReason = $null
-                    $groupId = $null
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' {
-                            $assignmentReason = "All Users"
-                        }
-                        '#microsoft.graph.groupAssignmentTarget' {
-                            $groupId = $assignment.target.groupId
-                            if (!$GroupId -or $groupId -eq $GroupId) {
-                                $groupInfo = Get-GroupInfo -GroupId $groupId
-                                $assignmentReason = "Group Assignment - $($groupInfo.DisplayName)"
-                            }
-                        }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                            $groupId = $assignment.target.groupId
-                            if (!$GroupId -or $groupId -eq $GroupId) {
-                                $groupInfo = Get-GroupInfo -GroupId $groupId
-                                $assignmentReason = "Group Exclusion - $($groupInfo.DisplayName)"
-                            }
-                        }
-                    }
-
-                    if ($assignmentReason) {
-                        $assignments += $assignmentReason
-                    }
-                }
-
-                if ($assignments.Count -gt 0) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignments -join "; ") -Force
-                    $allPolicies.AppProtectionPolicies += $policy
+        if ($ctx.Category.Id -eq 'AppProtectionPolicies') {
+            # Historical App Protection summary: group names for assignments and
+            # exclusions, no filter suffix, All Devices targets not listed, and
+            # policies without any listed assignment are dropped from the output.
+            $summaryLines = foreach ($assignment in $ctx.Assignments) {
+                switch ($assignment.Reason) {
+                    'All Users' { 'All Users' }
+                    'Group Assignment' { "Group Assignment - $((Get-GroupInfo -GroupId $assignment.GroupId).DisplayName)" }
+                    'Group Exclusion' { "Group Exclusion - $((Get-GroupInfo -GroupId $assignment.GroupId).DisplayName)" }
                 }
             }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-            }
+            if (-not $summaryLines) { return }
+            $entity | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($summaryLines -join '; ') -Force
+            $ctx.Buckets[$bucketKey].Add($entity)
+            return
         }
-    }
 
-    # Get App Configuration Policies
-    Write-Host "Fetching App Configuration Policies..." -ForegroundColor Yellow
-    $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    foreach ($policy in $appConfigPolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.AppConfigurationPolicies += $policy
-    }
-
-    # Get Platform Scripts
-    Write-Host "Fetching Platform Scripts..." -ForegroundColor Yellow
-    $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    foreach ($script in $platformScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $script | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.PlatformScripts += $script
-    }
-
-    # Get Proactive Remediation Scripts
-    Write-Host "Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    foreach ($script in $healthScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            Format-AssignmentSummaryLine -Assignment $_
-        }
-        $script | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.HealthScripts += $script
-    }
-
-    # Get Autopilot Deployment Profiles
-    Write-Host "Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-    $autoProfilesAll = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($policyProfile in $autoProfilesAll) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policyProfile.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            if ($_.Reason -eq "Group Assignment") {
-                $groupInfo = Get-GroupInfo -GroupId $_.GroupId
-                "$($_.Reason) - $($groupInfo.DisplayName)"
-            }
-            else { $_.Reason }
-        }
-        $policyProfile | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.DeploymentProfiles += $policyProfile
-    }
-
-    # Get Enrollment Status Page Profiles
-    Write-Host "Fetching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-    $enrollmentConfigsAll = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $espProfilesAll = $enrollmentConfigsAll | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    foreach ($esp in $espProfilesAll) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        $assignmentSummary = $assignments | ForEach-Object {
-            if ($_.Reason -eq "Group Assignment") {
-                $groupInfo = Get-GroupInfo -GroupId $_.GroupId
-                "$($_.Reason) - $($groupInfo.DisplayName)"
-            }
-            else { $_.Reason }
-        }
-        $esp | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-        $allPolicies.ESPProfiles += $esp
-    }
-
-    # Get Windows 365 Cloud PC Provisioning Policies
-    Write-Host "Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-    try {
-        $cloudPCProvisioningPoliciesAll = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-        foreach ($policy in $cloudPCProvisioningPoliciesAll) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-            $assignmentSummary = $assignments | ForEach-Object {
-                if ($_.Reason -eq "Group Assignment") {
-                    $groupInfo = Get-GroupInfo -GroupId $_.GroupId
-                    "$($_.Reason) - $($groupInfo.DisplayName)"
+        $summaryLines = if ($ctx.Category.Id -in @('DeploymentProfiles', 'ESPProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')) {
+            # Historical summary for these categories: group name appended only for
+            # inclusions, exclusions stay reason-only, no filter suffix.
+            foreach ($assignment in $ctx.Assignments) {
+                if ($assignment.Reason -eq 'Group Assignment') {
+                    $groupInfo = Get-GroupInfo -GroupId $assignment.GroupId
+                    "$($assignment.Reason) - $($groupInfo.DisplayName)"
                 }
-                else { $_.Reason }
+                else { $assignment.Reason }
             }
-            $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-            $allPolicies.CloudPCProvisioningPolicies += $policy
         }
-    }
-    catch {
-        Write-Warning "Unable to fetch Windows 365 Cloud PC Provisioning Policies: $($_.Exception.Message)"
-    }
-
-    # Get Windows 365 Cloud PC User Settings
-    Write-Host "Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-    try {
-        $cloudPCUserSettingsAll = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-        foreach ($setting in $cloudPCUserSettingsAll) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-            $assignmentSummary = $assignments | ForEach-Object {
-                if ($_.Reason -eq "Group Assignment") {
-                    $groupInfo = Get-GroupInfo -GroupId $_.GroupId
-                    "$($_.Reason) - $($groupInfo.DisplayName)"
+        elseif ($ctx.Category.Kind -eq 'EndpointSecurity' -and $null -ne $ctx.RawAssignments) {
+            # Legacy intent-based ES policies keep their historical wording
+            # ("Group: X" / "Exclude Group: X" / "Unknown") with filter suffix.
+            foreach ($assignment in $ctx.RawAssignments) {
+                $reasonText = switch ($assignment.target.'@odata.type') {
+                    '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
+                    '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
+                    '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $assignment.target.groupId).DisplayName }
+                    '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $assignment.target.groupId).DisplayName }
+                    default { "Unknown" }
                 }
-                else { $_.Reason }
-            }
-            $setting | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-            $allPolicies.CloudPCUserSettings += $setting
-        }
-    }
-    catch {
-        Write-Warning "Unable to fetch Windows 365 Cloud PC User Settings: $($_.Exception.Message)"
-    }
-
-    # Get Endpoint Security - Antivirus Policies
-    Write-Host "Fetching Antivirus Policies..." -ForegroundColor Yellow
-    $antivirusPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedAntivirusIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForAntivirusAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAntivirusAll = $configPoliciesForAntivirusAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-    if ($matchingConfigPoliciesAntivirusAll) {
-        foreach ($policy in $matchingConfigPoliciesAntivirusAll) {
-            if ($processedAntivirusIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$antivirusPoliciesFoundAll.Add($policy)
+                $suffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
+                "$reasonText$suffix"
             }
         }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForAntivirusAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirusAll
-    $matchingIntentsAntivirusAll = $allIntentsForAntivirusAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-    if ($matchingIntentsAntivirusAll) {
-        foreach ($policy in $matchingIntentsAntivirusAll) {
-            if ($processedAntivirusIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$antivirusPoliciesFoundAll.Add($policy)
+        else {
+            foreach ($assignment in $ctx.Assignments) {
+                Format-AssignmentSummaryLine -Assignment $assignment
             }
         }
-    }
-    $allPolicies.AntivirusProfiles = $antivirusPoliciesFoundAll
 
-    # Get Endpoint Security - Disk Encryption Policies
-    Write-Host "Fetching Disk Encryption Policies..." -ForegroundColor Yellow
-    $diskEncryptionPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedDiskEncryptionIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForDiskEncAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesDiskEncAll = $configPoliciesForDiskEncAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-    if ($matchingConfigPoliciesDiskEncAll) {
-        foreach ($policy in $matchingConfigPoliciesDiskEncAll) {
-            if ($processedDiskEncryptionIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$diskEncryptionPoliciesFoundAll.Add($policy)
-            }
-        }
+        $entity | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($summaryLines -join '; ') -Force
+        $ctx.Buckets[$bucketKey].Add($entity)
     }
 
-    # 2. Check deviceManagement/intents
-    $allIntentsForDiskEncAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEncAll
-    $matchingIntentsDiskEncAll = $allIntentsForDiskEncAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-    if ($matchingIntentsDiskEncAll) {
-        foreach ($policy in $matchingIntentsDiskEncAll) {
-            if ($processedDiskEncryptionIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$diskEncryptionPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-    $allPolicies.DiskEncryptionProfiles = $diskEncryptionPoliciesFoundAll
-
-    # Get Endpoint Security - Firewall Policies
-    Write-Host "Fetching Firewall Policies..." -ForegroundColor Yellow
-    $firewallPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedFirewallIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForFirewallAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesFirewallAll = $configPoliciesForFirewallAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-    if ($matchingConfigPoliciesFirewallAll) {
-        foreach ($policy in $matchingConfigPoliciesFirewallAll) {
-            if ($processedFirewallIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$firewallPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForFirewallAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewallAll
-    $matchingIntentsFirewallAll = $allIntentsForFirewallAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-    if ($matchingIntentsFirewallAll) {
-        foreach ($policy in $matchingIntentsFirewallAll) {
-            if ($processedFirewallIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$firewallPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-    $allPolicies.FirewallProfiles = $firewallPoliciesFoundAll
-
-    # Get Endpoint Security - Endpoint Detection and Response Policies
-    Write-Host "Fetching EDR Policies..." -ForegroundColor Yellow
-    $edrPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedEDRIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForEDRAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesEDRAll = $configPoliciesForEDRAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-    if ($matchingConfigPoliciesEDRAll) {
-        foreach ($policy in $matchingConfigPoliciesEDRAll) {
-            if ($processedEDRIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$edrPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForEDRAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDRAll
-    $matchingIntentsEDRAll = $allIntentsForEDRAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-    if ($matchingIntentsEDRAll) {
-        foreach ($policy in $matchingIntentsEDRAll) {
-            if ($processedEDRIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$edrPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-    $allPolicies.EndpointDetectionProfiles = $edrPoliciesFoundAll
-
-    # Get Endpoint Security - Attack Surface Reduction Policies
-    Write-Host "Fetching ASR Policies..." -ForegroundColor Yellow
-    $asrPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedASRIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForASRAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesASRAll = $configPoliciesForASRAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-    if ($matchingConfigPoliciesASRAll) {
-        foreach ($policy in $matchingConfigPoliciesASRAll) {
-            if ($processedASRIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$asrPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForASRAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASRAll
-    $matchingIntentsASRAll = $allIntentsForASRAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-    if ($matchingIntentsASRAll) {
-        foreach ($policy in $matchingIntentsASRAll) {
-            if ($processedASRIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$asrPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-    $allPolicies.AttackSurfaceProfiles = $asrPoliciesFoundAll
-
-    # Get Endpoint Security - Account Protection Policies
-    Write-Host "Fetching Account Protection Policies..." -ForegroundColor Yellow
-    $accountProtectionPoliciesFoundAll = [System.Collections.ArrayList]::new()
-    $processedAccountProtectionIdsAll = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForAccountProtectionAll = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAccountProtectionAll = $configPoliciesForAccountProtectionAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-    if ($matchingConfigPoliciesAccountProtectionAll) {
-        foreach ($policy in $matchingConfigPoliciesAccountProtectionAll) {
-            if ($processedAccountProtectionIdsAll.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $assignmentSummary = $assignments | ForEach-Object {
-                    Format-AssignmentSummaryLine -Assignment $_
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$accountProtectionPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForAccountProtectionAll = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtectionAll
-    $matchingIntentsAccountProtectionAll = $allIntentsForAccountProtectionAll | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-    if ($matchingIntentsAccountProtectionAll) {
-        foreach ($policy in $matchingIntentsAccountProtectionAll) {
-            if ($processedAccountProtectionIdsAll.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentSummary = $assignmentsResponse.value | ForEach-Object {
-                    $reasonText = switch ($_.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget'       { "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget'            { "Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget'   { "Exclude Group: " + (Get-GroupInfo -GroupId $_.target.groupId).DisplayName }
-                        default { "Unknown" }
-                    }
-                    $suffix = Format-AssignmentFilter -FilterId $_.target.deviceAndAppManagementAssignmentFilterId -FilterType $_.target.deviceAndAppManagementAssignmentFilterType
-                    "$reasonText$suffix"
-                }
-                $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                [void]$accountProtectionPoliciesFoundAll.Add($policy)
-            }
-        }
-    }
-    $allPolicies.AccountProtectionProfiles = $accountProtectionPoliciesFoundAll
+    $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -ShowProgress
+    $allPolicies = $scanResult.Buckets
 
     # Apply scope tag filter if specified
     if ($ScopeTagFilter) {
@@ -590,23 +137,7 @@ function Get-IntuneAllPolicies {
     Invoke-PolicyAssignments -Policies $allPolicies.AccountProtectionProfiles -DisplayName "Endpoint Security - Account Protection Profiles"
 
     # Add to export data
-    Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $allPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $allPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $allPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $allPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $allPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $allPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $allPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $allPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $allPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $allPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $allPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $allPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $allPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $allPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $allPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $allPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
-    Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $allPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentSummary }
+    Add-CategoryExportData -ExportData $exportData -Categories $categories -Buckets $allPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
 
     # Export results if requested
     Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllPolicies.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
@@ -695,5 +695,5 @@ function Get-IntuneAllUsersAssignment {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllUsersAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllUsersAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
@@ -14,433 +14,70 @@ function Get-IntuneAllUsersAssignment {
     Write-Host "Fetching all 'All Users' assignments..." -ForegroundColor Green
     $exportData = [System.Collections.ArrayList]::new()
 
-    # Initialize collections for policies with "All Users" assignments
-    $allUsersAssignments = @{
-        DeviceConfigs            = @()
-        SettingsCatalog          = @()
-        CompliancePolicies       = @()
-        AppProtectionPolicies    = @()
-        AppConfigurationPolicies = @()
-        PlatformScripts          = @()
-        HealthScripts            = @()
-        RequiredApps             = @()
-        AvailableApps            = @()
-        UninstallApps                = @()
-        AntivirusProfiles            = @()
-        DiskEncryptionProfiles       = @()
-        FirewallProfiles             = @()
-        EndpointDetectionProfiles    = @()
-        AttackSurfaceProfiles        = @()
-        AccountProtectionProfiles    = @()
-        DeploymentProfiles           = @()
-        ESPProfiles                  = @()
-    }
+    # Renders one result section: Cyan header, Gray empty message, one White line per item.
+    function Show-AllUsersSection {
+        param (
+            [string]$Header,
+            [string]$EmptyLabel,
+            [object[]]$Items,
+            [scriptblock]$Line
+        )
 
-    # Get Device Configurations
-    Write-Host "Fetching Device Configurations..." -ForegroundColor Yellow
-    $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    foreach ($config in $deviceConfigs) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.DeviceConfigs += $config
+        Write-Host "`n------- $Header -------" -ForegroundColor Cyan
+        if ($null -eq $Items -or $Items.Count -eq 0) {
+            Write-Host "No $EmptyLabel assigned to All Users" -ForegroundColor Gray
+            return
+        }
+        foreach ($item in $Items) {
+            Write-Host (& $Line $item) -ForegroundColor White
         }
     }
 
-    # Get Settings Catalog Policies
-    Write-Host "Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-    $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    foreach ($policy in $settingsCatalog) {
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.SettingsCatalog += $policy
-        }
+    # UserContext carries this cmdlet's exact category order and buckets, with three
+    # caller-side adjustments to match the legacy walk:
+    # - Cloud PC categories were never fetched here, so drop them entirely
+    # - Autopilot/ESP are BucketOnly for a single user but ARE fetched by this cmdlet
+    # - the legacy ESP export label here was "Enrollment Status Page Profile"
+    $categories = @(Get-IntuneCategoryDefinition -Audience 'UserContext' | Where-Object { $_.Id -notin @('CloudPCProvisioningPolicies', 'CloudPCUserSettings') })
+    foreach ($category in $categories) {
+        if ($category.Id -in @('DeploymentProfiles', 'ESPProfiles')) { $category.BucketOnly = $false }
+        if ($category.Id -eq 'ESPProfiles') { $category.ExportCategory = 'Enrollment Status Page Profile' }
     }
 
-    # Get Compliance Policies
-    Write-Host "Fetching Compliance Policies..." -ForegroundColor Yellow
-    $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    foreach ($policy in $compliancePolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.CompliancePolicies += $policy
-        }
-    }
+    $processEntity = {
+        param($ctx)
 
-    # Get App Protection Policies
-    Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
-    $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    foreach ($policy in $appProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
+        $entity = $ctx.Entity
 
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $allUsersTarget = $null
-                foreach ($assignment in $assignmentResponse.value) {
-                    if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
-                        $allUsersTarget = $assignment.target
-                        break
+        if ($ctx.Category.Kind -eq 'MobileApps') {
+            # Legacy quirk: only the first "All Users" assignment counts, so each app
+            # lands in exactly one intent bucket, on a copy of the app object.
+            foreach ($assignment in $ctx.RawAssignments) {
+                if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
+                    $suffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
+                    $appWithReason = $entity.PSObject.Copy()
+                    $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$suffix" -Force
+                    switch ($assignment.intent) {
+                        "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason); break }
+                        "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason); break }
+                        "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason); break }
                     }
-                }
-                if ($allUsersTarget) {
-                    $suffix = Format-AssignmentFilter -FilterId $allUsersTarget.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$suffix" -Force
-                    $allUsersAssignments.AppProtectionPolicies += $policy
+                    break
                 }
             }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-            }
+            return
+        }
+
+        # All other categories: keep the entity only when an "All Users" target exists;
+        # exclusions and group targets never qualify. Reason keeps the filter suffix.
+        if (($reason = Get-AllTargetReason -Assignments $ctx.Assignments -TargetReason "All Users")) {
+            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
+            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
         }
     }
 
-    # Get App Configuration Policies
-    Write-Host "Fetching App Configuration Policies..." -ForegroundColor Yellow
-    $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    foreach ($policy in $appConfigPolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.AppConfigurationPolicies += $policy
-        }
-    }
-
-    # Get Applications
-    Write-Host "Fetching Applications..." -ForegroundColor Yellow
-    # Fetch Applications
-    $appUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-    $allApps = $appResponse.value
-    while ($appResponse.'@odata.nextLink') {
-        $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-        $allApps += $appResponse.value
-    }
-    $totalApps = $allApps.Count
-
-    foreach ($app in $allApps) {
-        # Filter out irrelevant apps
-        if ($app.isFeatured -or $app.isBuiltIn) {
-            continue
-        }
-
-        $appId = $app.id
-        $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-        $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-        foreach ($assignment in $assignmentResponse.value) {
-            if ($assignment.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
-                $suffix = Format-AssignmentFilter -FilterId $assignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignment.target.deviceAndAppManagementAssignmentFilterType
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$suffix" -Force
-                switch ($assignment.intent) {
-                    "required" { $allUsersAssignments.RequiredApps += $appWithReason; break }
-                    "available" { $allUsersAssignments.AvailableApps += $appWithReason; break }
-                    "uninstall" { $allUsersAssignments.UninstallApps += $appWithReason; break }
-                }
-                break
-            }
-        }
-    }
-
-    # Get Platform Scripts
-    Write-Host "Fetching Platform Scripts..." -ForegroundColor Yellow
-    $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    foreach ($script in $platformScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.PlatformScripts += $script
-        }
-    }
-
-    # Get Proactive Remediation Scripts
-    Write-Host "Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    foreach ($script in $healthScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.HealthScripts += $script
-        }
-    }
-
-    # Get Endpoint Security - Antivirus Policies
-    Write-Host "Fetching Antivirus Policies assigned to All Users..." -ForegroundColor Yellow
-    $antivirusPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedAntivirusIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForAntivirus_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAntivirus_AllUsers = $configPoliciesForAntivirus_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-    if ($matchingConfigPoliciesAntivirus_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesAntivirus_AllUsers) {
-            if ($processedAntivirusIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$antivirusPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForAntivirus_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirus_AllUsers
-    $matchingIntentsAntivirus_AllUsers = $allIntentsForAntivirus_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-    if ($matchingIntentsAntivirus_AllUsers) {
-        foreach ($policy in $matchingIntentsAntivirus_AllUsers) {
-            if ($processedAntivirusIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$antivirusPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.AntivirusProfiles = $antivirusPoliciesFound_AllUsers
-
-    # Get Endpoint Security - Disk Encryption Policies
-    Write-Host "Fetching Disk Encryption Policies assigned to All Users..." -ForegroundColor Yellow
-    $diskEncryptionPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedDiskEncryptionIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForDiskEnc_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesDiskEnc_AllUsers = $configPoliciesForDiskEnc_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-    if ($matchingConfigPoliciesDiskEnc_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesDiskEnc_AllUsers) {
-            if ($processedDiskEncryptionIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$diskEncryptionPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForDiskEnc_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEnc_AllUsers
-    $matchingIntentsDiskEnc_AllUsers = $allIntentsForDiskEnc_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-    if ($matchingIntentsDiskEnc_AllUsers) {
-        foreach ($policy in $matchingIntentsDiskEnc_AllUsers) {
-            if ($processedDiskEncryptionIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$diskEncryptionPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.DiskEncryptionProfiles = $diskEncryptionPoliciesFound_AllUsers
-
-    # Get Endpoint Security - Firewall Policies
-    Write-Host "Fetching Firewall Policies assigned to All Users..." -ForegroundColor Yellow
-    $firewallPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedFirewallIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForFirewall_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesFirewall_AllUsers = $configPoliciesForFirewall_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-    if ($matchingConfigPoliciesFirewall_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesFirewall_AllUsers) {
-            if ($processedFirewallIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$firewallPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForFirewall_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewall_AllUsers
-    $matchingIntentsFirewall_AllUsers = $allIntentsForFirewall_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-    if ($matchingIntentsFirewall_AllUsers) {
-        foreach ($policy in $matchingIntentsFirewall_AllUsers) {
-            if ($processedFirewallIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$firewallPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.FirewallProfiles = $firewallPoliciesFound_AllUsers
-
-    # Get Endpoint Security - Endpoint Detection and Response Policies
-    Write-Host "Fetching EDR Policies assigned to All Users..." -ForegroundColor Yellow
-    $edrPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedEDRIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForEDR_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesEDR_AllUsers = $configPoliciesForEDR_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-    if ($matchingConfigPoliciesEDR_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesEDR_AllUsers) {
-            if ($processedEDRIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$edrPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForEDR_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDR_AllUsers
-    $matchingIntentsEDR_AllUsers = $allIntentsForEDR_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-    if ($matchingIntentsEDR_AllUsers) {
-        foreach ($policy in $matchingIntentsEDR_AllUsers) {
-            if ($processedEDRIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$edrPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.EndpointDetectionProfiles = $edrPoliciesFound_AllUsers
-
-    # Get Endpoint Security - Attack Surface Reduction Policies
-    Write-Host "Fetching ASR Policies assigned to All Users..." -ForegroundColor Yellow
-    $asrPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedASRIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForASR_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesASR_AllUsers = $configPoliciesForASR_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-    if ($matchingConfigPoliciesASR_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesASR_AllUsers) {
-            if ($processedASRIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$asrPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForASR_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASR_AllUsers
-    $matchingIntentsASR_AllUsers = $allIntentsForASR_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-    if ($matchingIntentsASR_AllUsers) {
-        foreach ($policy in $matchingIntentsASR_AllUsers) {
-            if ($processedASRIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$asrPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.AttackSurfaceProfiles = $asrPoliciesFound_AllUsers
-
-    # Get Endpoint Security - Account Protection Policies
-    Write-Host "Fetching Account Protection Policies assigned to All Users..." -ForegroundColor Yellow
-    $accountProtectionPoliciesFound_AllUsers = [System.Collections.ArrayList]::new()
-    $processedAccountProtectionIds_AllUsers = [System.Collections.Generic.HashSet[string]]::new()
-
-    # 1. Check configurationPolicies
-    $configPoliciesForAccountProtection_AllUsers = Get-IntuneEntities -EntityType "configurationPolicies"
-    $matchingConfigPoliciesAccountProtection_AllUsers = $configPoliciesForAccountProtection_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-    if ($matchingConfigPoliciesAccountProtection_AllUsers) {
-        foreach ($policy in $matchingConfigPoliciesAccountProtection_AllUsers) {
-            if ($processedAccountProtectionIds_AllUsers.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                    [void]$accountProtectionPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-
-    # 2. Check deviceManagement/intents
-    $allIntentsForAccountProtection_AllUsers = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtection_AllUsers
-    $matchingIntentsAccountProtection_AllUsers = $allIntentsForAccountProtection_AllUsers | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-    if ($matchingIntentsAccountProtection_AllUsers) {
-        foreach ($policy in $matchingIntentsAccountProtection_AllUsers) {
-            if ($processedAccountProtectionIds_AllUsers.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $allUsersTarget = $assignmentsResponse.value | Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' } | Select-Object -First 1
-                if ($allUsersTarget) {
-                    $intentSuffix = Format-AssignmentFilter -FilterId $allUsersTarget.target.deviceAndAppManagementAssignmentFilterId -FilterType $allUsersTarget.target.deviceAndAppManagementAssignmentFilterType
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "All Users$intentSuffix" -Force
-                    [void]$accountProtectionPoliciesFound_AllUsers.Add($policy)
-                }
-            }
-        }
-    }
-    $allUsersAssignments.AccountProtectionProfiles = $accountProtectionPoliciesFound_AllUsers
-
-    # Get Autopilot Deployment Profiles
-    Write-Host "Fetching Autopilot Deployment Profiles assigned to All Users..." -ForegroundColor Yellow
-    $autoProfilesAU = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($policyProfile in $autoProfilesAU) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policyProfile.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $policyProfile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.DeploymentProfiles += $policyProfile
-        }
-    }
-
-    # Get Enrollment Status Page Profiles
-    Write-Host "Fetching Enrollment Status Page Profiles assigned to All Users..." -ForegroundColor Yellow
-    $enrollmentConfigsAU = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $espProfilesAU = $enrollmentConfigsAU | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    foreach ($esp in $espProfilesAU) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        if (($reason = Get-AllTargetReason -Assignments $assignments -TargetReason "All Users")) {
-            $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-            $allUsersAssignments.ESPProfiles += $esp
-        }
-    }
+    $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -ShowProgress
+    $allUsersAssignments = $scanResult.Buckets
 
     # Apply scope tag filter if specified
     if ($ScopeTagFilter) {
@@ -452,247 +89,99 @@ function Get-IntuneAllUsersAssignment {
     # Display results
     Write-Host "`nPolicies Assigned to All Users:" -ForegroundColor Green
 
-    # Display Device Configurations
-    Write-Host "`n------- Device Configurations -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.DeviceConfigs.Count -eq 0) {
-        Write-Host "No Device Configurations assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($config in $allUsersAssignments.DeviceConfigs) {
-            $configName = if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
-            $platform = Get-PolicyPlatform -Policy $config
-            Write-Host "Device Configuration Name: $configName, Platform: $platform, Configuration ID: $($config.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items @($config) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "Device Configurations" -EmptyLabel "Device Configurations" -Items $allUsersAssignments.DeviceConfigs -Line {
+        param($config)
+        $configName = if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
+        $platform = Get-PolicyPlatform -Policy $config
+        "Device Configuration Name: $configName, Platform: $platform, Configuration ID: $($config.id)"
     }
 
-    # Display Settings Catalog Policies
-    Write-Host "`n------- Settings Catalog Policies -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.SettingsCatalog.Count -eq 0) {
-        Write-Host "No Settings Catalog Policies assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allUsersAssignments.SettingsCatalog) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            Write-Host "Settings Catalog Policy Name: $policyName, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items @($policy) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "Settings Catalog Policies" -EmptyLabel "Settings Catalog Policies" -Items $allUsersAssignments.SettingsCatalog -Line {
+        param($policy)
+        $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
+        "Settings Catalog Policy Name: $policyName, Policy ID: $($policy.id)"
     }
 
-    # Display Compliance Policies
-    Write-Host "`n------- Compliance Policies -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.CompliancePolicies.Count -eq 0) {
-        Write-Host "No Compliance Policies assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allUsersAssignments.CompliancePolicies) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            $platform = Get-PolicyPlatform -Policy $policy
-            Write-Host "Compliance Policy Name: $policyName, Platform: $platform, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items @($policy) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "Compliance Policies" -EmptyLabel "Compliance Policies" -Items $allUsersAssignments.CompliancePolicies -Line {
+        param($policy)
+        $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
+        $platform = Get-PolicyPlatform -Policy $policy
+        "Compliance Policy Name: $policyName, Platform: $platform, Policy ID: $($policy.id)"
     }
 
-    # Display App Protection Policies
-    Write-Host "`n------- App Protection Policies -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AppProtectionPolicies.Count -eq 0) {
-        Write-Host "No App Protection Policies assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allUsersAssignments.AppProtectionPolicies) {
-            $policyName = $policy.displayName
-            $policyType = switch ($policy.'@odata.type') {
-                "#microsoft.graph.androidManagedAppProtection" { "Android" }
-                "#microsoft.graph.iosManagedAppProtection" { "iOS" }
-                "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
-                default { "Unknown" }
-            }
-            Write-Host "App Protection Policy Name: $policyName, Policy ID: $($policy.id), Type: $policyType" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items @($policy) -AssignmentReason "All Users"
+    Show-AllUsersSection -Header "App Protection Policies" -EmptyLabel "App Protection Policies" -Items $allUsersAssignments.AppProtectionPolicies -Line {
+        param($policy)
+        $policyType = switch ($policy.'@odata.type') {
+            "#microsoft.graph.androidManagedAppProtection" { "Android" }
+            "#microsoft.graph.iosManagedAppProtection" { "iOS" }
+            "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
+            default { "Unknown" }
         }
+        "App Protection Policy Name: $($policy.displayName), Policy ID: $($policy.id), Type: $policyType"
     }
 
-    # Display App Configuration Policies
-    Write-Host "`n------- App Configuration Policies -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AppConfigurationPolicies.Count -eq 0) {
-        Write-Host "No App Configuration Policies assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policy in $allUsersAssignments.AppConfigurationPolicies) {
-            $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-            Write-Host "App Configuration Policy Name: $policyName, Policy ID: $($policy.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items @($policy) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "App Configuration Policies" -EmptyLabel "App Configuration Policies" -Items $allUsersAssignments.AppConfigurationPolicies -Line {
+        param($policy)
+        $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
+        "App Configuration Policy Name: $policyName, Policy ID: $($policy.id)"
     }
 
-    # Display Platform Scripts
-    Write-Host "`n------- Platform Scripts -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.PlatformScripts.Count -eq 0) {
-        Write-Host "No Platform Scripts assigned to All Users" -ForegroundColor Gray
+    $scriptLine = {
+        param($script)
+        $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
+        "Script Name: $scriptName, Script ID: $($script.id)"
     }
-    else {
-        foreach ($script in $allUsersAssignments.PlatformScripts) {
-            $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-            Write-Host "Script Name: $scriptName, Script ID: $($script.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items @($script) -AssignmentReason "All Users"
-        }
-    }
+    Show-AllUsersSection -Header "Platform Scripts" -EmptyLabel "Platform Scripts" -Items $allUsersAssignments.PlatformScripts -Line $scriptLine
+    Show-AllUsersSection -Header "Proactive Remediation Scripts" -EmptyLabel "Proactive Remediation Scripts" -Items $allUsersAssignments.HealthScripts -Line $scriptLine
 
-    # Display Proactive Remediation Scripts
-    Write-Host "`n------- Proactive Remediation Scripts -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.HealthScripts.Count -eq 0) {
-        Write-Host "No Proactive Remediation Scripts assigned to All Users" -ForegroundColor Gray
+    $appLine = {
+        param($app)
+        "App Name: $($app.displayName), App ID: $($app.id)"
     }
-    else {
-        foreach ($script in $allUsersAssignments.HealthScripts) {
-            $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-            Write-Host "Script Name: $scriptName, Script ID: $($script.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items @($script) -AssignmentReason "All Users"
-        }
-    }
+    Show-AllUsersSection -Header "Required Apps" -EmptyLabel "Required Apps" -Items $allUsersAssignments.AppsRequired -Line $appLine
+    Show-AllUsersSection -Header "Available Apps" -EmptyLabel "Available Apps" -Items $allUsersAssignments.AppsAvailable -Line $appLine
+    Show-AllUsersSection -Header "Uninstall Apps" -EmptyLabel "Uninstall Apps" -Items $allUsersAssignments.AppsUninstall -Line $appLine
 
-    # Display Required Apps
-    Write-Host "`n------- Required Apps -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.RequiredApps.Count -eq 0) {
-        Write-Host "No Required Apps assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allUsersAssignments.RequiredApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Required Apps" -Items @($app) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Available Apps
-    Write-Host "`n------- Available Apps -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AvailableApps.Count -eq 0) {
-        Write-Host "No Available Apps assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allUsersAssignments.AvailableApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Available Apps" -Items @($app) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Uninstall Apps
-    Write-Host "`n------- Uninstall Apps -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.UninstallApps.Count -eq 0) {
-        Write-Host "No Uninstall Apps assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($app in $allUsersAssignments.UninstallApps) {
-            $appName = $app.displayName
-            Write-Host "App Name: $appName, App ID: $($app.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items @($app) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Endpoint Security - Antivirus Profiles
-    Write-Host "`n------- Endpoint Security - Antivirus Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AntivirusProfiles.Count -eq 0) {
-        Write-Host "No Antivirus Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.AntivirusProfiles) {
+    $esSections = @(
+        @{ Bucket = 'AntivirusProfiles'; Label = 'Antivirus' }
+        @{ Bucket = 'DiskEncryptionProfiles'; Label = 'Disk Encryption' }
+        @{ Bucket = 'FirewallProfiles'; Label = 'Firewall' }
+        @{ Bucket = 'EndpointDetectionProfiles'; Label = 'EDR' }
+        @{ Bucket = 'AttackSurfaceProfiles'; Label = 'ASR' }
+        @{ Bucket = 'AccountProtectionProfiles'; Label = 'Account Protection' }
+    )
+    foreach ($section in $esSections) {
+        $esLabel = $section.Label
+        Show-AllUsersSection -Header "Endpoint Security - $esLabel Profiles" -EmptyLabel "$esLabel Profiles" -Items $allUsersAssignments[$section.Bucket] -Line {
+            param($policyProfile)
             $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Antivirus Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
+            "$esLabel Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)"
+        }.GetNewClosure()
     }
 
-    # Display Endpoint Security - Disk Encryption Profiles
-    Write-Host "`n------- Endpoint Security - Disk Encryption Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.DiskEncryptionProfiles.Count -eq 0) {
-        Write-Host "No Disk Encryption Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.DiskEncryptionProfiles) {
-            $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Disk Encryption Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "Autopilot Deployment Profiles" -EmptyLabel "Autopilot Deployment Profiles" -Items $allUsersAssignments.DeploymentProfiles -Line {
+        param($policyProfile)
+        $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.displayName } else { $policyProfile.name }
+        "Autopilot Deployment Profile Name: $profileName, Profile ID: $($policyProfile.id)"
     }
 
-    # Display Endpoint Security - Firewall Profiles
-    Write-Host "`n------- Endpoint Security - Firewall Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.FirewallProfiles.Count -eq 0) {
-        Write-Host "No Firewall Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.FirewallProfiles) {
-            $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Firewall Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
+    Show-AllUsersSection -Header "Enrollment Status Page Profiles" -EmptyLabel "Enrollment Status Page Profiles" -Items $allUsersAssignments.ESPProfiles -Line {
+        param($policyProfile)
+        $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.displayName } else { $policyProfile.name }
+        "Enrollment Status Page Profile Name: $profileName, Profile ID: $($policyProfile.id)"
     }
 
-    # Display Endpoint Security - Endpoint Detection and Response Profiles
-    Write-Host "`n------- Endpoint Security - EDR Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.EndpointDetectionProfiles.Count -eq 0) {
-        Write-Host "No EDR Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.EndpointDetectionProfiles) {
-            $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "EDR Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Endpoint Security - Attack Surface Reduction Profiles
-    Write-Host "`n------- Endpoint Security - ASR Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AttackSurfaceProfiles.Count -eq 0) {
-        Write-Host "No ASR Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.AttackSurfaceProfiles) {
-            $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "ASR Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Endpoint Security - Account Protection Profiles
-    Write-Host "`n------- Endpoint Security - Account Protection Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.AccountProtectionProfiles.Count -eq 0) {
-        Write-Host "No Account Protection Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.AccountProtectionProfiles) {
-            $profileNameForDisplay = if ($policyProfile.displayName) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Account Protection Profile Name: $profileNameForDisplay, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Autopilot Deployment Profiles
-    Write-Host "`n------- Autopilot Deployment Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.DeploymentProfiles.Count -eq 0) {
-        Write-Host "No Autopilot Deployment Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.DeploymentProfiles) {
-            $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Autopilot Deployment Profile Name: $profileName, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
-    }
-
-    # Display Enrollment Status Page Profiles
-    Write-Host "`n------- Enrollment Status Page Profiles -------" -ForegroundColor Cyan
-    if ($allUsersAssignments.ESPProfiles.Count -eq 0) {
-        Write-Host "No Enrollment Status Page Profiles assigned to All Users" -ForegroundColor Gray
-    }
-    else {
-        foreach ($policyProfile in $allUsersAssignments.ESPProfiles) {
-            $profileName = if ([string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.displayName } else { $policyProfile.name }
-            Write-Host "Enrollment Status Page Profile Name: $profileName, Profile ID: $($policyProfile.id)" -ForegroundColor White
-            Add-ExportData -ExportData $exportData -Category "Enrollment Status Page Profile" -Items @($policyProfile) -AssignmentReason "All Users"
-        }
-    }
+    # Add to export data. The legacy CSV row order follows the display order above,
+    # where the app buckets came after the script categories, so export in that order
+    # rather than fetch order.
+    $exportOrderIds = @(
+        'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+        'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'Applications',
+        'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface',
+        'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles'
+    )
+    $exportCategories = foreach ($id in $exportOrderIds) { $categories | Where-Object { $_.Id -eq $id } }
+    Add-CategoryExportData -ExportData $exportData -Categories $exportCategories -Buckets $allUsersAssignments -AssignmentReason "All Users"
 
     # Export results if requested
     Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneAllUsersAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
@@ -31,10 +31,81 @@ function Get-IntuneDeviceAssignment {
         return
     }
 
-    $deviceNames = $deviceInput -split ',' | ForEach-Object { $_.Trim() }
+    # Distinct name from the [string]$DeviceNames parameter: assigning this array to the
+    # case-insensitively identical, type-constrained parameter variable would coerce it
+    # back into one space-joined string and break multi-device input.
+    $deviceNameList = $deviceInput -split ',' | ForEach-Object { $_.Trim() }
     $exportData = [System.Collections.ArrayList]::new()
 
-    foreach ($deviceName in $deviceNames) {
+    $categories = Get-IntuneCategoryDefinition -Audience 'DeviceContext'
+    # Categories the legacy code fetched only for Windows (or unknown-OS) devices
+    $windowsOnlyCategoryIds = @('DeploymentProfiles', 'ESPProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
+    # Shared across devices so each entity set is fetched from Graph once per run
+    $entityCache = @{}
+
+    # Legacy device table: four columns (no Platform), "No Assignment" fallback,
+    # red rows for exclusions. Kept local because it differs from Show-CategoryResultTable.
+    function Format-PolicyTable {
+        param (
+            [string]$Title,
+            [object[]]$Policies,
+            [scriptblock]$GetName
+        )
+        $tableSeparator = Get-Separator
+
+        # Create prominent section header
+        $headerSeparator = "-" * ($Title.Length + 16)
+        Write-Host "`n$headerSeparator" -ForegroundColor Cyan
+        Write-Host "------- $Title -------" -ForegroundColor Cyan
+        Write-Host "$headerSeparator" -ForegroundColor Cyan
+
+        if ($Policies.Count -eq 0) {
+            Write-Host "No $Title found for this device." -ForegroundColor Gray
+            Write-Host $tableSeparator -ForegroundColor Gray
+            Write-Host ""
+            return
+        }
+
+        # Create table header
+        $headerFormat = "{0,-45} {1,-20} {2,-35} {3,-30}" -f "Policy Name", "Scope Tags", "ID", "Assignment"
+
+        Write-Host $headerFormat -ForegroundColor Yellow
+        Write-Host $tableSeparator -ForegroundColor Gray
+
+        # Display each policy in table format
+        foreach ($policy in $Policies) {
+            $name = & $GetName $policy
+
+            if ($name.Length -gt 42) {
+                $name = $name.Substring(0, 39) + "..."
+            }
+
+            $scopeTags = Get-ScopeTagNames -ScopeTagIds $policy.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
+            if ($scopeTags.Length -gt 17) { $scopeTags = $scopeTags.Substring(0, 14) + "..." }
+
+            $id = $policy.id
+            if ($id.Length -gt 32) {
+                $id = $id.Substring(0, 29) + "..."
+            }
+
+            $assignment = if ($policy.AssignmentReason) { $policy.AssignmentReason } else { "No Assignment" }
+            if ($assignment.Length -gt 27) {
+                $assignment = $assignment.Substring(0, 24) + "..."
+            }
+
+            $rowFormat = "{0,-45} {1,-20} {2,-35} {3,-30}" -f $name, $scopeTags, $id, $assignment
+            if ($assignment -like "Excluded*" -or $assignment -like "*Exclusion*") {
+                Write-Host $rowFormat -ForegroundColor Red
+            }
+            else {
+                Write-Host $rowFormat -ForegroundColor White
+            }
+        }
+
+        Write-Host $tableSeparator -ForegroundColor Gray
+    }
+
+    foreach ($deviceName in $deviceNameList) {
         Write-Host "`nProcessing device: $deviceName" -ForegroundColor Yellow
 
         # Check if input is a GUID (Object ID)
@@ -131,683 +202,129 @@ function Get-IntuneDeviceAssignment {
 
         Write-Host "Fetching Intune Profiles and Applications for the device..." -ForegroundColor Yellow
 
-        # Initialize collections for relevant policies
-        $relevantPolicies = @{
-            DeviceConfigs               = @()
-            SettingsCatalog             = @()
-            CompliancePolicies          = @()
-            AppProtectionPolicies       = @()
-            AppConfigurationPolicies    = @()
-            AppsRequired                = @()
-            AppsAvailable               = @()
-            AppsUninstall               = @()
-            PlatformScripts             = @()
-            HealthScripts               = @()
-            AntivirusProfiles           = @()
-            DiskEncryptionProfiles      = @()
-            FirewallProfiles            = @()
-            EndpointDetectionProfiles   = @()
-            AttackSurfaceProfiles       = @()
-            AccountProtectionProfiles   = @()
-            DeploymentProfiles          = @()
-            ESPProfiles                 = @()
-            CloudPCProvisioningPolicies = @()
-            CloudPCUserSettings         = @()
+        # Autopilot/ESP/Windows 365 stay bucket-only (export parity, never fetched) unless
+        # the device is Windows or its OS is unknown, matching the legacy conditional fetch.
+        $isWindowsDevice = (-not $deviceOS) -or ($deviceOS -eq "Windows")
+        foreach ($category in $categories) {
+            if ($category.Id -in $windowsOnlyCategoryIds) { $category.BucketOnly = -not $isWindowsDevice }
         }
 
-        # Get Device Configurations
-        Write-Host "Fetching Device Configurations..." -ForegroundColor Yellow
-        $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-        foreach ($config in $deviceConfigs) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $config)) {
-                $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.DeviceConfigs += $config
+        # The legacy code platform-filtered apps and App Protection policies before fetching
+        # their assignments; every other category is platform-checked after reason resolution.
+        $entityPreFilter = {
+            param($entity, $category)
+            switch ($category.Kind) {
+                'MobileApps' { Test-AppPlatformCompatibility -DeviceOS $deviceOS -App $entity }
+                'AppProtection' { Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $entity }
+                default { $true }
             }
         }
 
-        # Get Settings Catalog Policies
-        Write-Host "Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-        $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-        foreach ($policy in $settingsCatalog) {
-            $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.SettingsCatalog += $policy
-            }
-        }
+        $processEntity = {
+            param($ctx)
 
-        # Get Compliance Policies
-        Write-Host "Fetching Compliance Policies..." -ForegroundColor Yellow
-        $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-        foreach ($policy in $compliancePolicies) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.CompliancePolicies += $policy
-            }
-        }
+            $entity = $ctx.Entity
+            $bucketKey = $ctx.Category.BucketKeys[0]
 
-        # Get App Protection Policies
-        Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
-        $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-        foreach ($policy in $appProtectionPolicies) {
-            if (-not (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                continue
-            }
-            $policyType = $policy.'@odata.type'
-            $assignmentsUri = switch ($policyType) {
-                "#microsoft.graph.androidManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-                "#microsoft.graph.iosManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-                "#microsoft.graph.windowsManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-                default { $null }
-            }
+            if ($ctx.Category.Kind -eq 'MobileApps') {
+                # Winning-assignment walk: an exclusion for a member group wins immediately;
+                # otherwise the intent comes from the FIRST matching inclusion assignment
+                # while the reason text reflects the last one (historical behavior, F14).
+                $isExcluded = $false
+                $isIncluded = $false
+                $inclusionReason = ""
+                $exclusionReason = ""
+                $inclusionAssignment = $null
+                $exclusionAssignment = $null
 
-            if ($assignmentsUri) {
-                try {
-                    $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                    $assignments = @()
-                    foreach ($assignment in $assignmentResponse.value) {
-                        $assignmentReason = $null
-                        switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' {
-                                $assignmentReason = "All Users"
-                            }
-                            '#microsoft.graph.allDevicesAssignmentTarget' {
-                                $assignmentReason = "All Devices"
-                            }
-                            '#microsoft.graph.groupAssignmentTarget' {
-                                if ($groupMemberships.id -contains $assignment.target.groupId) {
-                                    $assignmentReason = "Group Assignment"
-                                }
-                            }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                                if ($groupMemberships.id -contains $assignment.target.groupId) {
-                                    $assignmentReason = "Group Exclusion"
-                                }
-                            }
-                        }
-
-                        if ($assignmentReason -and $assignmentReason -ne "All Users") {
-                            $rawFilterId   = $assignment.target.deviceAndAppManagementAssignmentFilterId
-                            $rawFilterType = $assignment.target.deviceAndAppManagementAssignmentFilterType
-                            $effFilterId   = $null
-                            $effFilterType = $null
-                            if ($rawFilterType -and $rawFilterType -ne 'none' -and $rawFilterId -and $rawFilterId -ne '00000000-0000-0000-0000-000000000000') {
-                                $effFilterId   = $rawFilterId
-                                $effFilterType = $rawFilterType
-                            }
-                            $assignments += @{
-                                Reason     = $assignmentReason
-                                GroupId    = $assignment.target.groupId
-                                FilterId   = $effFilterId
-                                FilterType = $effFilterType
-                            }
-                        }
-                    }
-
-                    if ($assignments.Count -gt 0) {
-                        $assignmentSummary = $assignments | Where-Object { $_.Reason -ne "All Users" } | ForEach-Object {
-                            Format-AssignmentSummaryLine -Assignment ([PSCustomObject]$_)
-                        }
-                        $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                        $relevantPolicies.AppProtectionPolicies += $policy
-                    }
-                }
-                catch {
-                    Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-                }
-            }
-        }
-
-        # Get App Configuration Policies
-        Write-Host "Fetching App Configuration Policies..." -ForegroundColor Yellow
-        $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-        foreach ($policy in $appConfigPolicies) {
-            $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.AppConfigurationPolicies += $policy
-            }
-        }
-
-        # Get Platform Scripts
-        Write-Host "Fetching Platform Scripts..." -ForegroundColor Yellow
-        $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-        foreach ($script in $platformScripts) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $script)) {
-                $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.PlatformScripts += $script
-            }
-        }
-
-        # Get Proactive Remediation Scripts
-        Write-Host "Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-        $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-        foreach ($script in $healthScripts) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $script)) {
-                $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.HealthScripts += $script
-            }
-        }
-
-        # Get Autopilot Deployment Profiles (Windows-only)
-        if (-not $deviceOS -or $deviceOS -eq "Windows") {
-            Write-Host "Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-            $autoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-            foreach ($policyProfile in $autoProfiles) {
-                $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policyProfile.id
-                foreach ($assignment in $assignments) {
-                    if (($assignment.Reason -eq "All Devices") -or
-                        ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $policyProfile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                        $relevantPolicies.DeploymentProfiles += $policyProfile
+                foreach ($assignment in $ctx.RawAssignments) {
+                    if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and
+                        $groupMemberships.id -contains $assignment.target.groupId) {
+                        $isExcluded = $true
+                        $groupInfo = Get-GroupInfo -GroupId $assignment.target.groupId
+                        $exclusionReason = "Excluded via group: $($groupInfo.DisplayName)"
+                        $exclusionAssignment = $assignment
                         break
                     }
-                    elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $policyProfile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                        $relevantPolicies.DeploymentProfiles += $policyProfile
-                        break
+                    elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget') {
+                        if (-not $isIncluded) { $inclusionAssignment = $assignment }
+                        $isIncluded = $true
+                        $inclusionReason = "All Devices"
+                    }
+                    elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
+                        $groupMemberships.id -contains $assignment.target.groupId) {
+                        if (-not $isIncluded) { $inclusionAssignment = $assignment }
+                        $isIncluded = $true
+                        $groupInfo = Get-GroupInfo -GroupId $assignment.target.groupId
+                        $inclusionReason = "Group Assignment - $($groupInfo.DisplayName)"
                     }
                 }
-            }
-        }
 
-        # Get Enrollment Status Page Profiles (Windows-only)
-        if (-not $deviceOS -or $deviceOS -eq "Windows") {
-            Write-Host "Fetching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-            $enrollmentConfigs = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-            $espProfiles = $enrollmentConfigs | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-            foreach ($esp in $espProfiles) {
-                $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-                foreach ($assignment in $assignments) {
-                    if (($assignment.Reason -eq "All Devices") -or
-                        ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                        $relevantPolicies.ESPProfiles += $esp
-                        break
-                    }
-                    elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                        $relevantPolicies.ESPProfiles += $esp
-                        break
-                    }
-                }
-            }
-        }
-
-        # Get Windows 365 Cloud PC Provisioning Policies (Windows-only)
-        if (-not $deviceOS -or $deviceOS -eq "Windows") {
-            Write-Host "Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-            try {
-                $cloudPCProvisioningPolicies = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-                foreach ($policy in $cloudPCProvisioningPolicies) {
-                    $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-                    foreach ($assignment in $assignments) {
-                        if (($assignment.Reason -eq "All Devices") -or
-                            ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                            $relevantPolicies.CloudPCProvisioningPolicies += $policy
-                            break
-                        }
-                        elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                            $relevantPolicies.CloudPCProvisioningPolicies += $policy
-                            break
-                        }
-                    }
-                }
-            }
-            catch {
-                Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-            }
-        }
-
-        # Get Windows 365 Cloud PC User Settings (Windows-only)
-        if (-not $deviceOS -or $deviceOS -eq "Windows") {
-            Write-Host "Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-            try {
-                $cloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-                foreach ($setting in $cloudPCUserSettings) {
-                    $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-                    foreach ($assignment in $assignments) {
-                        if (($assignment.Reason -eq "All Devices") -or
-                            ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                            $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                            $relevantPolicies.CloudPCUserSettings += $setting
-                            break
-                        }
-                        elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                            $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                            $relevantPolicies.CloudPCUserSettings += $setting
-                            break
-                        }
-                    }
-                }
-            }
-            catch {
-                Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-            }
-        }
-
-        # Get Endpoint Security - Antivirus Policies
-        Write-Host "Fetching Antivirus Policies" -ForegroundColor Yellow
-        $antivirusPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedAntivirusIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForAntivirusDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesAntivirusDevice = $configPoliciesForAntivirusDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-        if ($matchingConfigPoliciesAntivirusDevice) {
-            foreach ($policy in $matchingConfigPoliciesAntivirusDevice) {
-                if ($processedAntivirusIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$antivirusPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForAntivirusDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirusDevice
-        $matchingIntentsAntivirusDevice = $allIntentsForAntivirusDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-        if ($matchingIntentsAntivirusDevice) {
-            foreach ($policy in $matchingIntentsAntivirusDevice) {
-                if ($processedAntivirusIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$antivirusPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AntivirusProfiles = $antivirusPoliciesFoundDevice
-
-        # Get Endpoint Security - Disk Encryption Policies
-        Write-Host "Fetching Disk Encryption Policies." -ForegroundColor Yellow
-        $diskEncryptionPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedDiskEncryptionIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForDiskEncDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesDiskEncDevice = $configPoliciesForDiskEncDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-        if ($matchingConfigPoliciesDiskEncDevice) {
-            foreach ($policy in $matchingConfigPoliciesDiskEncDevice) {
-                if ($processedDiskEncryptionIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$diskEncryptionPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForDiskEncDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEncDevice
-        $matchingIntentsDiskEncDevice = $allIntentsForDiskEncDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-        if ($matchingIntentsDiskEncDevice) {
-            foreach ($policy in $matchingIntentsDiskEncDevice) {
-                if ($processedDiskEncryptionIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$diskEncryptionPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.DiskEncryptionProfiles = $diskEncryptionPoliciesFoundDevice
-
-        # Get Endpoint Security - Firewall Policies
-        Write-Host "Fetching Firewall Policies" -ForegroundColor Yellow
-        $firewallPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedFirewallIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForFirewallDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesFirewallDevice = $configPoliciesForFirewallDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-        if ($matchingConfigPoliciesFirewallDevice) {
-            foreach ($policy in $matchingConfigPoliciesFirewallDevice) {
-                if ($processedFirewallIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$firewallPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForFirewallDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewallDevice
-        $matchingIntentsFirewallDevice = $allIntentsForFirewallDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-        if ($matchingIntentsFirewallDevice) {
-            foreach ($policy in $matchingIntentsFirewallDevice) {
-                if ($processedFirewallIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$firewallPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.FirewallProfiles = $firewallPoliciesFoundDevice
-
-        # Get Endpoint Security - Endpoint Detection and Response Policies
-        Write-Host "Fetching EDR Policies" -ForegroundColor Yellow
-        $edrPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedEDRIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForEDRDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesEDRDevice = $configPoliciesForEDRDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-        if ($matchingConfigPoliciesEDRDevice) {
-            foreach ($policy in $matchingConfigPoliciesEDRDevice) {
-                if ($processedEDRIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$edrPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForEDRDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDRDevice
-        $matchingIntentsEDRDevice = $allIntentsForEDRDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-        if ($matchingIntentsEDRDevice) {
-            foreach ($policy in $matchingIntentsEDRDevice) {
-                if ($processedEDRIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$edrPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.EndpointDetectionProfiles = $edrPoliciesFoundDevice
-
-        # Get Endpoint Security - Attack Surface Reduction Policies
-        Write-Host "Fetching ASR Policies" -ForegroundColor Yellow
-        $asrPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedASRIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForASRDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesASRDevice = $configPoliciesForASRDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-        if ($matchingConfigPoliciesASRDevice) {
-            foreach ($policy in $matchingConfigPoliciesASRDevice) {
-                if ($processedASRIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$asrPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForASRDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASRDevice
-        $matchingIntentsASRDevice = $allIntentsForASRDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-        if ($matchingIntentsASRDevice) {
-            foreach ($policy in $matchingIntentsASRDevice) {
-                if ($processedASRIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$asrPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AttackSurfaceProfiles = $asrPoliciesFoundDevice
-
-        # Get Endpoint Security - Account Protection Policies
-        Write-Host "Fetching Account Protection Policies" -ForegroundColor Yellow
-        $accountProtectionPoliciesFoundDevice = [System.Collections.ArrayList]::new()
-        $processedAccountProtectionIdsDevice = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForAccountProtectionDevice = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesAccountProtectionDevice = $configPoliciesForAccountProtectionDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-        if ($matchingConfigPoliciesAccountProtectionDevice) {
-            foreach ($policy in $matchingConfigPoliciesAccountProtectionDevice) {
-                if ($processedAccountProtectionIdsDevice.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$accountProtectionPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForAccountProtectionDevice = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtectionDevice
-        $matchingIntentsAccountProtectionDevice = $allIntentsForAccountProtectionDevice | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-        if ($matchingIntentsAccountProtectionDevice) {
-            foreach ($policy in $matchingIntentsAccountProtectionDevice) {
-                if ($processedAccountProtectionIdsDevice.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allDevicesAssignmentTarget'     { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget'          { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
-                    if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$accountProtectionPoliciesFoundDevice.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AccountProtectionProfiles = $accountProtectionPoliciesFoundDevice
-
-        # Get Applications
-        Write-Host "Fetching Applications..." -ForegroundColor Yellow
-        # Fetch Applications
-        $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-        $allApps = $appResponse.value
-        while ($appResponse.'@odata.nextLink') {
-            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-            $allApps += $appResponse.value
-        }
-        $totalApps = $allApps.Count
-
-        foreach ($app in $allApps) {
-            # Filter out irrelevant apps
-            if ($app.isFeatured -or $app.isBuiltIn) {
-                continue
-            }
-
-            if (-not (Test-AppPlatformCompatibility -DeviceOS $deviceOS -App $app)) {
-                continue
-            }
-
-            $appId = $app.id
-            $assignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            $isExcluded = $false
-            $isIncluded = $false
-            $inclusionReason = ""
-            $exclusionReason = ""
-            $inclusionAssignment = $null
-            $exclusionAssignment = $null
-
-            foreach ($assignment in $assignmentResponse.value) {
-                if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and
-                    $groupMemberships.id -contains $assignment.target.groupId) {
-                    $isExcluded = $true
-                    $groupInfo = Get-GroupInfo -GroupId $assignment.target.groupId
-                    $exclusionReason = "Excluded via group: $($groupInfo.DisplayName)"
-                    $exclusionAssignment = $assignment
-                    break
-                }
-                elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-                    if (-not $isIncluded) { $inclusionAssignment = $assignment }
-                    $isIncluded = $true
-                    $inclusionReason = "All Devices"
-                }
-                elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
-                    $groupMemberships.id -contains $assignment.target.groupId) {
-                    if (-not $isIncluded) { $inclusionAssignment = $assignment }
-                    $isIncluded = $true
-                    $groupInfo = Get-GroupInfo -GroupId $assignment.target.groupId
-                    $inclusionReason = "Group Assignment - $($groupInfo.DisplayName)"
-                }
-            }
-
-            if ($isExcluded) {
-                $suffix = Format-AssignmentFilter `
-                    -FilterId   $exclusionAssignment.target.deviceAndAppManagementAssignmentFilterId `
-                    -FilterType $exclusionAssignment.target.deviceAndAppManagementAssignmentFilterType
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$exclusionReason$suffix" -Force
-                switch ($assignment.intent) {
-                    "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
-                    "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
-                    "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
-                }
-            }
-            elseif ($isIncluded) {
-                $suffix = ''
-                if ($inclusionAssignment) {
+                $winningAssignment = if ($isExcluded) { $exclusionAssignment } elseif ($isIncluded) { $inclusionAssignment } else { $null }
+                if ($winningAssignment) {
+                    $reasonText = if ($isExcluded) { $exclusionReason } else { $inclusionReason }
                     $suffix = Format-AssignmentFilter `
-                        -FilterId   $inclusionAssignment.target.deviceAndAppManagementAssignmentFilterId `
-                        -FilterType $inclusionAssignment.target.deviceAndAppManagementAssignmentFilterType
+                        -FilterId   $winningAssignment.target.deviceAndAppManagementAssignmentFilterId `
+                        -FilterType $winningAssignment.target.deviceAndAppManagementAssignmentFilterType
+                    $appWithReason = $entity.PSObject.Copy()
+                    $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$reasonText$suffix" -Force
+                    # F14: the bucket comes from the winning assignment's intent
+                    switch ($winningAssignment.intent) {
+                        "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason) }
+                        "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason) }
+                        "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason) }
+                    }
                 }
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$inclusionReason$suffix" -Force
-                switch ($inclusionAssignment.intent) {
-                    "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
-                    "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
-                    "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
+                return
+            }
+
+            if ($ctx.Category.Kind -eq 'AppProtection') {
+                # Membership check: All Devices always counts, group targets only when the
+                # device is a member, All Users targets are dropped (device context).
+                $relevantAssignments = @($ctx.Assignments | Where-Object {
+                        $_.Reason -eq 'All Devices' -or
+                        ($_.Reason -in @('Group Assignment', 'Group Exclusion') -and $groupMemberships.id -contains $_.GroupId)
+                    })
+                if ($relevantAssignments.Count -gt 0) {
+                    $assignmentSummary = $relevantAssignments | ForEach-Object { Format-AssignmentSummaryLine -Assignment $_ }
+                    $entity | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
+                    $ctx.Buckets[$bucketKey].Add($entity)
                 }
+                return
+            }
+
+            if ($ctx.Category.Id -in $windowsOnlyCategoryIds) {
+                # First-match walk with no platform filtering: All Devices or a member group
+                # assignment includes; a member group exclusion shows as "Excluded".
+                foreach ($assignment in $ctx.Assignments) {
+                    if (($assignment.Reason -eq "All Devices") -or
+                        ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
+                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
+                        $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
+                        $ctx.Buckets[$bucketKey].Add($entity)
+                        return
+                    }
+                    elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
+                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
+                        $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
+                        $ctx.Buckets[$bucketKey].Add($entity)
+                        return
+                    }
+                }
+                return
+            }
+
+            # Standard categories and both Endpoint Security phases: resolve the reason
+            # (All Devices counts as inclusion) first, then drop other-platform policies.
+            $reason = Resolve-AssignmentReason -Assignments $ctx.Assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Devices")
+            if ($reason -and (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $entity)) {
+                $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
+                $ctx.Buckets[$bucketKey].Add($entity)
             }
         }
+
+        $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -EntityPreFilter $entityPreFilter -ShowProgress -EntityCache $entityCache
+        $relevantPolicies = $scanResult.Buckets
 
         # Apply scope tag filter if specified
         if ($ScopeTagFilter) {
@@ -819,195 +336,58 @@ function Get-IntuneDeviceAssignment {
         # Display results
         Write-Host "`nAssignments for Device: $deviceName" -ForegroundColor Green
 
-        # Function to format and display policy table
-        function Format-PolicyTable {
-            param (
-                [string]$Title,
-                [object[]]$Policies,
-                [scriptblock]$GetName
-            )
-            $tableSeparator = Get-Separator
+        # Legacy per-category name resolution. Windows 365 buckets are exported but were
+        # never displayed by the old code, so they get no section here either.
+        $nameFirst = { param($item) if ([string]::IsNullOrWhiteSpace($item.name)) { $item.displayName } else { $item.name } }
+        $displayNameFirst = { param($item) if ([string]::IsNullOrWhiteSpace($item.displayName)) { $item.name } else { $item.displayName } }
+        $displayNameOnly = { param($item) $item.displayName }
+        $esProfileName = { param($item) if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } elseif (-not [string]::IsNullOrWhiteSpace($item.name)) { $item.name } else { "Unnamed Profile" } }
 
-            # Create prominent section header
-            $headerSeparator = "-" * ($Title.Length + 16)
-            Write-Host "`n$headerSeparator" -ForegroundColor Cyan
-            Write-Host "------- $Title -------" -ForegroundColor Cyan
-            Write-Host "$headerSeparator" -ForegroundColor Cyan
-
-            if ($Policies.Count -eq 0) {
-                Write-Host "No $Title found for this device." -ForegroundColor Gray
-                Write-Host $tableSeparator -ForegroundColor Gray
-                Write-Host ""
-                return
-            }
-
-            # Create table header
-            $headerFormat = "{0,-45} {1,-20} {2,-35} {3,-30}" -f "Policy Name", "Scope Tags", "ID", "Assignment"
-
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $tableSeparator -ForegroundColor Gray
-
-            # Display each policy in table format
-            foreach ($policy in $Policies) {
-                $name = & $GetName $policy
-
-                if ($name.Length -gt 42) {
-                    $name = $name.Substring(0, 39) + "..."
-                }
-
-                $scopeTags = Get-ScopeTagNames -ScopeTagIds $policy.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
-                if ($scopeTags.Length -gt 17) { $scopeTags = $scopeTags.Substring(0, 14) + "..." }
-
-                $id = $policy.id
-                if ($id.Length -gt 32) {
-                    $id = $id.Substring(0, 29) + "..."
-                }
-
-                $assignment = if ($policy.AssignmentReason) { $policy.AssignmentReason } else { "No Assignment" }
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-45} {1,-20} {2,-35} {3,-30}" -f $name, $scopeTags, $id, $assignment
-                if ($assignment -like "Excluded*" -or $assignment -like "*Exclusion*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-
-            Write-Host $tableSeparator -ForegroundColor Gray
+        $displaySections = @(
+            @{ Title = 'Device Configurations'; Bucket = 'DeviceConfigs'; GetName = $nameFirst }
+            @{ Title = 'Settings Catalog Policies'; Bucket = 'SettingsCatalog'; GetName = $nameFirst }
+            @{ Title = 'Compliance Policies'; Bucket = 'CompliancePolicies'; GetName = $nameFirst }
+            @{ Title = 'App Protection Policies'; Bucket = 'AppProtectionPolicies'; GetName = $displayNameOnly }
+            @{ Title = 'App Configuration Policies'; Bucket = 'AppConfigurationPolicies'; GetName = $nameFirst }
+            @{ Title = 'Platform Scripts'; Bucket = 'PlatformScripts'; GetName = $nameFirst }
+            @{ Title = 'Proactive Remediation Scripts'; Bucket = 'HealthScripts'; GetName = $nameFirst }
+            @{ Title = 'Autopilot Deployment Profiles'; Bucket = 'DeploymentProfiles'; GetName = $displayNameFirst }
+            @{ Title = 'Enrollment Status Page Profiles'; Bucket = 'ESPProfiles'; GetName = $displayNameFirst }
+            @{ Title = 'Required Apps'; Bucket = 'AppsRequired'; GetName = $displayNameOnly }
+            @{ Title = 'Available Apps'; Bucket = 'AppsAvailable'; GetName = $displayNameOnly }
+            @{ Title = 'Uninstall Apps'; Bucket = 'AppsUninstall'; GetName = $displayNameOnly }
+            @{ Title = 'Endpoint Security - Antivirus Profiles'; Bucket = 'AntivirusProfiles'; GetName = $esProfileName }
+            @{ Title = 'Endpoint Security - Disk Encryption Profiles'; Bucket = 'DiskEncryptionProfiles'; GetName = $esProfileName }
+            @{ Title = 'Endpoint Security - Firewall Profiles'; Bucket = 'FirewallProfiles'; GetName = $esProfileName }
+            @{ Title = 'Endpoint Security - EDR Profiles'; Bucket = 'EndpointDetectionProfiles'; GetName = $esProfileName }
+            @{ Title = 'Endpoint Security - ASR Profiles'; Bucket = 'AttackSurfaceProfiles'; GetName = $esProfileName }
+            @{ Title = 'Endpoint Security - Account Protection Profiles'; Bucket = 'AccountProtectionProfiles'; GetName = $esProfileName }
+        )
+        foreach ($section in $displaySections) {
+            Format-PolicyTable -Title $section.Title -Policies @($relevantPolicies[$section.Bucket]) -GetName $section.GetName
         }
 
-        # Display Device Configurations
-        Format-PolicyTable -Title "Device Configurations" -Policies $relevantPolicies.DeviceConfigs -GetName {
-            param($config)
-            if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
-        }
-
-        # Display Settings Catalog Policies
-        Format-PolicyTable -Title "Settings Catalog Policies" -Policies $relevantPolicies.SettingsCatalog -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display Compliance Policies
-        Format-PolicyTable -Title "Compliance Policies" -Policies $relevantPolicies.CompliancePolicies -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display App Protection Policies
-        Format-PolicyTable -Title "App Protection Policies" -Policies $relevantPolicies.AppProtectionPolicies -GetName {
-            param($policy)
-            $policy.displayName
-        } -GetExtra {
-            param($policy)
-            @{
-                Label = 'Platform'
-                Value = switch ($policy.'@odata.type') {
-                    "#microsoft.graph.androidManagedAppProtection" { "Android" }
-                    "#microsoft.graph.iosManagedAppProtection" { "iOS" }
-                    "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
-                    default { "Unknown" }
-                }
-            }
-        }
-
-        # Display App Configuration Policies
-        Format-PolicyTable -Title "App Configuration Policies" -Policies $relevantPolicies.AppConfigurationPolicies -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display Platform Scripts
-        Format-PolicyTable -Title "Platform Scripts" -Policies $relevantPolicies.PlatformScripts -GetName {
-            param($script)
-            if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-        }
-
-        # Display Proactive Remediation Scripts
-        Format-PolicyTable -Title "Proactive Remediation Scripts" -Policies $relevantPolicies.HealthScripts -GetName {
-            param($script)
-            if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-        }
-
-        # Display Autopilot Deployment Profiles
-        Format-PolicyTable -Title "Autopilot Deployment Profiles" -Policies $relevantPolicies.DeploymentProfiles -GetName {
-            param($policyProfile)
-            if ([string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.name } else { $policyProfile.displayName }
-        }
-
-        # Display Enrollment Status Page Profiles
-        Format-PolicyTable -Title "Enrollment Status Page Profiles" -Policies $relevantPolicies.ESPProfiles -GetName {
-            param($esp)
-            if ([string]::IsNullOrWhiteSpace($esp.displayName)) { $esp.name } else { $esp.displayName }
-        }
-
-        # Display Required Apps
-        Format-PolicyTable -Title "Required Apps" -Policies $relevantPolicies.AppsRequired -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Available Apps
-        Format-PolicyTable -Title "Available Apps" -Policies $relevantPolicies.AppsAvailable -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Uninstall Apps
-        Format-PolicyTable -Title "Uninstall Apps" -Policies $relevantPolicies.AppsUninstall -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Endpoint Security - Antivirus Profiles
-        Format-PolicyTable -Title "Endpoint Security - Antivirus Profiles" -Policies $relevantPolicies.AntivirusProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Disk Encryption Profiles
-        Format-PolicyTable -Title "Endpoint Security - Disk Encryption Profiles" -Policies $relevantPolicies.DiskEncryptionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Firewall Profiles
-        Format-PolicyTable -Title "Endpoint Security - Firewall Profiles" -Policies $relevantPolicies.FirewallProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Endpoint Detection and Response Profiles
-        Format-PolicyTable -Title "Endpoint Security - EDR Profiles" -Policies $relevantPolicies.EndpointDetectionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Attack Surface Reduction Profiles
-        Format-PolicyTable -Title "Endpoint Security - ASR Profiles" -Policies $relevantPolicies.AttackSurfaceProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Account Protection Profiles
-        Format-PolicyTable -Title "Endpoint Security - Account Protection Profiles" -Policies $relevantPolicies.AccountProtectionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Add to export data
+        # Add to export data: the Device row first, then categories in the legacy CSV order
+        # (Autopilot/ESP before Endpoint Security, Windows 365 after it, app buckets last).
         Add-ExportData -ExportData $exportData -Category "Device" -Items @([PSCustomObject]@{
                 displayName      = $deviceName
                 id               = $deviceInfo.Id
                 AssignmentReason = "N/A"
             })
 
-        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
+        $reasonProperty = { param($item) $item.AssignmentReason }
+        $exportBatches = @(
+            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            # App Protection rows export the AssignmentSummary built above
+            @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
+            @{ Ids = @('AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'DeploymentProfiles', 'ESPProfiles',
+                    'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection',
+                    'CloudPCProvisioningPolicies', 'CloudPCUserSettings', 'Applications'); Reason = $reasonProperty }
+        )
+        foreach ($batch in $exportBatches) {
+            $batchCategories = foreach ($id in $batch.Ids) { $categories | Where-Object { $_.Id -eq $id } }
+            Add-CategoryExportData -ExportData $exportData -Categories $batchCategories -Buckets $relevantPolicies -AssignmentReason $batch.Reason
+        }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
@@ -801,7 +801,7 @@ function Get-IntuneDeviceAssignment {
                 }
                 $appWithReason = $app.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$inclusionReason$suffix" -Force
-                switch ($assignment.intent) {
+                switch ($inclusionAssignment.intent) {
                     "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
                     "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
                     "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
@@ -986,29 +986,28 @@ function Get-IntuneDeviceAssignment {
                 displayName      = $deviceName
                 id               = $deviceInfo.Id
                 AssignmentReason = "N/A"
-            }
+            })
 
-            Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-            Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
-        )
+        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
+        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
@@ -1012,5 +1012,5 @@ function Get-IntuneDeviceAssignment {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneDeviceAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneDeviceAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
@@ -406,5 +406,5 @@ function Get-IntuneEmptyGroup {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneEmptyGroupAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneEmptyGroupAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
@@ -19,7 +19,7 @@ function Get-IntuneEmptyGroup {
         )
 
         try {
-            $membersUri = "$GraphEndpoint/v1.0/groups/$GroupId/members?`$select=id"
+            $membersUri = "$script:GraphEndpoint/v1.0/groups/$GroupId/members?`$select=id"
             $response = Invoke-MgGraphRequest -Uri $membersUri -Method Get
             return $response.value.Count -eq 0
         }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
@@ -101,55 +101,15 @@ function Get-IntuneEmptyGroup {
     Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
     $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
     foreach ($policy in $appProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $assignments = @()
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentReason = $null
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' {
-                            $assignmentReason = "All Users"
-                        }
-                        '#microsoft.graph.groupAssignmentTarget' {
-                            if (!$GroupId -or $assignment.target.groupId -eq $GroupId) {
-                                $assignmentReason = "Group Assignment"
-                            }
-                        }
-                    }
-
-                    if ($assignmentReason) {
-                        $assignments += @{
-                            Reason  = $assignmentReason
-                            GroupId = $assignment.target.groupId
-                        }
-                    }
-                }
-
-                if ($assignments.Count -gt 0) {
-                    $assignmentSummary = $assignments | ForEach-Object {
-                        if ($_.Reason -eq "Group Assignment") {
-                            $groupInfo = Get-GroupInfo -GroupId $_.GroupId
-                            "$($_.Reason) - $($groupInfo.DisplayName)"
-                        }
-                        else {
-                            $_.Reason
-                        }
-                    }
-                    $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
+        $assignments = Get-IntuneAssignments -EntityType "deviceAppManagement/managedAppPolicies" -EntityId $policy.id
+        foreach ($assignment in $assignments) {
+            if ($assignment.Reason -eq "Group Assignment" -and $assignment.GroupId) {
+                $groupInfo = Get-GroupInfo -GroupId $assignment.GroupId
+                if ($groupInfo.Success -and (Test-EmptyGroup -GroupId $assignment.GroupId)) {
+                    $policy | Add-Member -NotePropertyName 'EmptyGroupInfo' -NotePropertyValue "Assigned to empty group: $($groupInfo.DisplayName)" -Force
                     $emptyGroupAssignments.AppProtectionPolicies += $policy
+                    break
                 }
-            }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
             }
         }
     }
@@ -200,6 +160,37 @@ function Get-IntuneEmptyGroup {
                     $script | Add-Member -NotePropertyName 'EmptyGroupInfo' -NotePropertyValue "Assigned to empty group: $($groupInfo.DisplayName)" -Force
                     $emptyGroupAssignments.HealthScripts += $script
                     break
+                }
+            }
+        }
+    }
+
+    # Get Endpoint Security Policies
+    Write-Host "Fetching Endpoint Security Policies..." -ForegroundColor Yellow
+    $configPolicies = Get-IntuneEntities -EntityType "configurationPolicies"
+    $endpointSecurityCategories = @(
+        @{ Key = "AntivirusProfiles"; TemplateFamily = "endpointSecurityAntivirus" },
+        @{ Key = "DiskEncryptionProfiles"; TemplateFamily = "endpointSecurityDiskEncryption" },
+        @{ Key = "FirewallProfiles"; TemplateFamily = "endpointSecurityFirewall" },
+        @{ Key = "EndpointDetectionProfiles"; TemplateFamily = "endpointSecurityEndpointDetectionAndResponse" },
+        @{ Key = "AttackSurfaceProfiles"; TemplateFamily = "endpointSecurityAttackSurfaceReduction" },
+        @{ Key = "AccountProtectionProfiles"; TemplateFamily = "endpointSecurityAccountProtection" }
+    )
+    foreach ($esCategory in $endpointSecurityCategories) {
+        $matchingEsPolicies = $configPolicies | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $esCategory.TemplateFamily }
+        foreach ($policy in $matchingEsPolicies) {
+            $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
+            foreach ($assignment in $assignments) {
+                if ($assignment.Reason -eq "Group Assignment" -and $assignment.GroupId) {
+                    $groupInfo = Get-GroupInfo -GroupId $assignment.GroupId
+                    if ($groupInfo.Success -and (Test-EmptyGroup -GroupId $assignment.GroupId)) {
+                        $policy | Add-Member -NotePropertyName 'EmptyGroupInfo' -NotePropertyValue "Assigned to empty group: $($groupInfo.DisplayName)" -Force
+                        if ([string]::IsNullOrWhiteSpace($policy.displayName)) {
+                            $policy | Add-Member -NotePropertyName 'displayName' -NotePropertyValue $policy.name -Force
+                        }
+                        $emptyGroupAssignments[$esCategory.Key] += $policy
+                        break
+                    }
                 }
             }
         }
@@ -402,6 +393,21 @@ function Get-IntuneEmptyGroup {
             Write-Host "$($policyProfile.EmptyGroupInfo)" -ForegroundColor Yellow
             Write-Host ""
             Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items @($policyProfile) -AssignmentReason $policyProfile.EmptyGroupInfo
+        }
+    }
+
+    # Display Endpoint Security - Account Protection Profiles
+    Write-Host "`n------- Endpoint Security - Account Protection Profiles -------" -ForegroundColor Cyan
+    if ($emptyGroupAssignments.AccountProtectionProfiles.Count -eq 0) {
+        Write-Host "No Account Protection Profiles assigned to empty groups" -ForegroundColor Gray
+    }
+    else {
+        foreach ($policyProfile in $emptyGroupAssignments.AccountProtectionProfiles) {
+            Write-Host "Account Protection Profile Name: $($policyProfile.displayName)" -ForegroundColor White
+            Write-Host "Profile ID: $($policyProfile.id)" -ForegroundColor Gray
+            Write-Host "$($policyProfile.EmptyGroupInfo)" -ForegroundColor Yellow
+            Write-Host ""
+            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items @($policyProfile) -AssignmentReason $policyProfile.EmptyGroupInfo
         }
     }
 

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneFailedAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneFailedAssignment.ps1
@@ -47,6 +47,6 @@ function Get-IntuneFailedAssignment {
         }
 
         # Export if requested
-        Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneFailedAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+        Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneFailedAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
     }
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
@@ -50,6 +50,10 @@ function Get-IntuneGroupAssignment {
         }
     }
 
+    $categories = Get-IntuneCategoryDefinition -Audience 'GroupContext'
+    # Shared across groups so each entity set is fetched from Graph once per run
+    $entityCache = @{}
+
     foreach ($groupInput in $groupInputs) {
         Write-Host "`nProcessing input: $groupInput" -ForegroundColor Yellow
 
@@ -68,7 +72,7 @@ function Get-IntuneGroupAssignment {
             $groupName = $groupInfo.DisplayName
         }
         else {
-            # Try to find group by display name
+            # Try to find group by display name (single quotes escaped for the OData filter)
             $escapedGroupName = $groupInput -replace "'", "''"
             $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
@@ -111,376 +115,72 @@ function Get-IntuneGroupAssignment {
 
         Write-Host "Fetching Intune Profiles and Applications for the group..." -ForegroundColor Yellow
 
-        # Initialize collections for relevant policies
-        $relevantPolicies = @{
-            DeviceConfigs               = @()
-            SettingsCatalog             = @()
-            CompliancePolicies          = @()
-            AppProtectionPolicies       = @()
-            AppConfigurationPolicies    = @()
-            AppsRequired                = @()
-            AppsAvailable               = @()
-            AppsUninstall               = @()
-            PlatformScripts             = @()
-            HealthScripts               = @()
-            # Endpoint Security profiles
-            AntivirusProfiles           = @()
-            DiskEncryptionProfiles      = @()
-            FirewallProfiles            = @()
-            EndpointDetectionProfiles   = @()
-            AttackSurfaceProfiles       = @()
-            AccountProtectionProfiles   = @()
-            DeploymentProfiles          = @()
-            ESPProfiles                 = @()
-            CloudPCProvisioningPolicies = @()
-            CloudPCUserSettings         = @()
-        }
+        $processEntity = {
+            param($ctx)
 
-        # Get Device Configurations
-        Write-Host "Fetching Device Configurations..." -ForegroundColor Yellow
-        $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-        foreach ($config in $deviceConfigs) {
-            $directAssignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.DeviceConfigs += $config
-                }
-            }
-        }
+            $entity = $ctx.Entity
 
-        # Get Settings Catalog Policies
-        Write-Host "Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-        $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-        foreach ($policy in $settingsCatalog) {
-            # Exclude Windows-only Endpoint Security policies from this generic Settings Catalog fetch
-            # Allow macOS and cross-platform endpoint security policies through
-            if ($policy.templateReference -and $policy.templateReference.templateFamily -like "endpointSecurity*") {
-                $platforms = $policy.platforms
-                # Only skip if this is a Windows-only policy (not macOS or other platforms)
-                if ($platforms -and
-                    (($platforms -contains "windows10" -or $platforms -contains "windows10AndLater") -and
-                     $platforms -notcontains "macOS")) {
-                    continue
-                }
-            }
-            $directAssignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.SettingsCatalog += $policy
-                }
-            }
-        }
+            if ($ctx.Category.Kind -eq 'MobileApps') {
+                # Apps resolve reason and intent together from the raw assignments.
+                # Exclusion-only assignments are kept (issue #126): the reason strings say
+                # "Group Exclusion"/"Inherited Exclusion (via X)" and, when no inclusion
+                # supplied an intent, the excluding assignment's intent decides the bucket.
+                $relevantAppAssignmentReasons = @()
+                $intentForGroup = $null
+                $exclusionIntentForGroup = $null
 
-        # Get Compliance Policies
-        Write-Host "Fetching Compliance Policies..." -ForegroundColor Yellow
-        $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-        foreach ($policy in $compliancePolicies) {
-            $directAssignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.CompliancePolicies += $policy
-                }
-            }
-        }
-
-        # Get App Protection Policies
-        Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
-        $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-        foreach ($policy in $appProtectionPolicies) {
-            # Get-IntuneAssignments handles App Protection policy type resolution internally
-            try {
-                $directAssignments = Get-IntuneAssignments -EntityType "deviceAppManagement/managedAppPolicies" -EntityId $policy.id -GroupIds $allGroupIds
-                if ($directAssignments.Count -gt 0) {
-                    $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                    if ($assignmentReasons.Count -gt 0) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                        $relevantPolicies.AppProtectionPolicies += $policy
-                    }
-                }
-            }
-            catch {
-                Write-Host "Error fetching assignments for App Protection policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-            }
-        }
-
-        # Get App Configuration Policies
-        Write-Host "Fetching App Configuration Policies..." -ForegroundColor Yellow
-        $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-        foreach ($policy in $appConfigPolicies) {
-            $directAssignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.AppConfigurationPolicies += $policy
-                }
-            }
-        }
-
-        # Endpoint Security Policies for the specific group
-        $endpointSecurityCategories = @(
-            @{ Name = "Antivirus"; Key = "AntivirusProfiles"; TemplateFamily = "endpointSecurityAntivirus"; UserFriendlyType = "Antivirus Profile" },
-            @{ Name = "Disk Encryption"; Key = "DiskEncryptionProfiles"; TemplateFamily = "endpointSecurityDiskEncryption"; UserFriendlyType = "Disk Encryption Profile" },
-            @{ Name = "Firewall"; Key = "FirewallProfiles"; TemplateFamily = "endpointSecurityFirewall"; UserFriendlyType = "Firewall Profile" },
-            @{ Name = "Endpoint Detection and Response"; Key = "EndpointDetectionProfiles"; TemplateFamily = "endpointSecurityEndpointDetectionAndResponse"; UserFriendlyType = "EDR Profile" },
-            @{ Name = "Attack Surface Reduction"; Key = "AttackSurfaceProfiles"; TemplateFamily = "endpointSecurityAttackSurfaceReduction"; UserFriendlyType = "ASR Profile" },
-            @{ Name = "Account Protection"; Key = "AccountProtectionProfiles"; TemplateFamily = "endpointSecurityAccountProtection"; UserFriendlyType = "Account Protection Profile" }
-        )
-
-        foreach ($esCategory in $endpointSecurityCategories) {
-            Write-Host "Fetching $($esCategory.Name) Policies for group..." -ForegroundColor Yellow
-            $processedEsPolicyIds = [System.Collections.Generic.HashSet[string]]::new() # Track IDs per category to avoid duplicates from configPolicies and intents
-
-            # 1. Check configurationPolicies (Settings Catalog style ES policies)
-            $allConfigEsPolicies = Get-IntuneEntities -EntityType "configurationPolicies" # Fetch all, then filter
-            $matchingConfigEsPolicies = $allConfigEsPolicies | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $esCategory.TemplateFamily }
-            if ($matchingConfigEsPolicies) {
-                foreach ($policy in $matchingConfigEsPolicies) {
-                    if ($processedEsPolicyIds.Add($policy.id)) {
-                        $directAssignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id -GroupIds $allGroupIds
-                        if ($directAssignments.Count -gt 0) {
-                            $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                            if ($assignmentReasons.Count -gt 0) {
-                                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                                $relevantPolicies[$esCategory.Key] += $policy
-                            }
+                foreach ($assignmentItem in $ctx.RawAssignments) {
+                    $appTargetGid = $assignmentItem.target.groupId
+                    $reasonText = $null
+                    if ($assignmentItem.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $appTargetGid) {
+                        if ($appTargetGid -eq $groupId) {
+                            $reasonText = "Direct Assignment"
                         }
-                    }
-                }
-            }
-
-            # 2. Check deviceManagement/intents (Template style ES policies)
-            $allIntentEsPolicies = Get-IntuneEntities -EntityType "deviceManagement/intents" # Fetch all, then filter
-            Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentEsPolicies
-            $matchingIntentEsPolicies = $allIntentEsPolicies | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $esCategory.TemplateFamily }
-            if ($matchingIntentEsPolicies) {
-                foreach ($policy in $matchingIntentEsPolicies) {
-                    if ($processedEsPolicyIds.Add($policy.id)) {
-                        # For intents, assignments are fetched differently
-                        try {
-                            $allIntentAssignments = [System.Collections.ArrayList]::new()
-                            $currentIntentAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments"
-                            do {
-                                $intentAssignmentsResponsePage = Invoke-MgGraphRequest -Uri $currentIntentAssignmentsUri -Method Get
-                                if ($intentAssignmentsResponsePage -and $null -ne $intentAssignmentsResponsePage.value) {
-                                    $allIntentAssignments.AddRange($intentAssignmentsResponsePage.value)
-                                }
-                                $currentIntentAssignmentsUri = $intentAssignmentsResponsePage.'@odata.nextLink'
-                            } while (![string]::IsNullOrEmpty($currentIntentAssignmentsUri))
-
-                            $assignmentReasons = @()
-                            foreach ($intentAssignment in $allIntentAssignments) {
-                                $targetGid = $intentAssignment.target.groupId
-                                $reasonText = $null
-                                if ($intentAssignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and $allGroupIds -contains $targetGid) {
-                                    if ($targetGid -eq $groupId) {
-                                        $reasonText = "Direct Exclusion"
-                                    }
-                                    elseif ($parentGroupMap.ContainsKey($targetGid)) {
-                                        $reasonText = "Inherited Exclusion (via $($parentGroupMap[$targetGid]))"
-                                    }
-                                }
-                                elseif ($intentAssignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $targetGid) {
-                                    if ($targetGid -eq $groupId) {
-                                        $reasonText = "Direct Assignment"
-                                    }
-                                    elseif ($parentGroupMap.ContainsKey($targetGid)) {
-                                        $reasonText = "Inherited (via $($parentGroupMap[$targetGid]))"
-                                    }
-                                }
-                                if ($reasonText) {
-                                    $suffix = Format-AssignmentFilter -FilterId $intentAssignment.target.deviceAndAppManagementAssignmentFilterId -FilterType $intentAssignment.target.deviceAndAppManagementAssignmentFilterType
-                                    $assignmentReasons += "$reasonText$suffix"
-                                }
-                            }
-
-                            if ($assignmentReasons.Count -gt 0) {
-                                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                                $relevantPolicies[$esCategory.Key] += $policy
-                            }
+                        elseif ($parentGroupMap.ContainsKey($appTargetGid)) {
+                            $reasonText = "Inherited (via $($parentGroupMap[$appTargetGid]))"
                         }
-                        catch {
-                            Write-Warning "Error fetching assignments for ES Intent $($policy.displayName) (ID: $($policy.id)): $($_.Exception.Message)"
+                        if (-not $intentForGroup) { $intentForGroup = $assignmentItem.intent }
+                    }
+                    elseif ($assignmentItem.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and $allGroupIds -contains $appTargetGid) {
+                        if ($appTargetGid -eq $groupId) {
+                            $reasonText = "Group Exclusion"
                         }
+                        elseif ($parentGroupMap.ContainsKey($appTargetGid)) {
+                            $reasonText = "Inherited Exclusion (via $($parentGroupMap[$appTargetGid]))"
+                        }
+                        if ($reasonText -and -not $exclusionIntentForGroup) { $exclusionIntentForGroup = $assignmentItem.intent }
+                    }
+                    if ($reasonText) {
+                        $suffix = Format-AssignmentFilter -FilterId $assignmentItem.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignmentItem.target.deviceAndAppManagementAssignmentFilterType
+                        $relevantAppAssignmentReasons += "$reasonText$suffix"
                     }
                 }
-            }
-        }
 
-        # Fetch and process Applications
-        Write-Host "Fetching Applications..." -ForegroundColor Yellow
-        $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-        $allApps = $appResponse.value
-        while ($appResponse.'@odata.nextLink') {
-            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-            $allApps += $appResponse.value
-        }
-        $totalApps = $allApps.Count
-
-        foreach ($app in $allApps) {
-            # Filter out irrelevant apps
-            if ($app.isFeatured -or $app.isBuiltIn) {
-                continue
-            }
-
-            $appId = $app.id
-            $allAppAssignments = [System.Collections.ArrayList]::new()
-            $currentAppAssignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            do {
-                $appAssignmentsResponsePage = Invoke-MgGraphRequest -Uri $currentAppAssignmentsUri -Method Get
-                if ($appAssignmentsResponsePage -and $null -ne $appAssignmentsResponsePage.value) {
-                    $allAppAssignments.AddRange($appAssignmentsResponsePage.value)
-                }
-                $currentAppAssignmentsUri = $appAssignmentsResponsePage.'@odata.nextLink'
-            } while (![string]::IsNullOrEmpty($currentAppAssignmentsUri))
-
-            $relevantAppAssignmentReasons = @()
-            $intentForGroup = $null
-            $exclusionIntentForGroup = $null
-
-            foreach ($assignmentItem in $allAppAssignments) {
-                $appTargetGid = $assignmentItem.target.groupId
-                $reasonText = $null
-                if ($assignmentItem.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and $allGroupIds -contains $appTargetGid) {
-                    if ($appTargetGid -eq $groupId) {
-                        $reasonText = "Direct Assignment"
-                    }
-                    elseif ($parentGroupMap.ContainsKey($appTargetGid)) {
-                        $reasonText = "Inherited (via $($parentGroupMap[$appTargetGid]))"
-                    }
-                    if (-not $intentForGroup) { $intentForGroup = $assignmentItem.intent }
-                }
-                elseif ($assignmentItem.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and $allGroupIds -contains $appTargetGid) {
-                    if ($appTargetGid -eq $groupId) {
-                        $reasonText = "Group Exclusion"
-                    }
-                    elseif ($parentGroupMap.ContainsKey($appTargetGid)) {
-                        $reasonText = "Inherited Exclusion (via $($parentGroupMap[$appTargetGid]))"
-                    }
-                    if ($reasonText -and -not $exclusionIntentForGroup) { $exclusionIntentForGroup = $assignmentItem.intent }
-                }
-                if ($reasonText) {
-                    $suffix = Format-AssignmentFilter -FilterId $assignmentItem.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignmentItem.target.deviceAndAppManagementAssignmentFilterType
-                    $relevantAppAssignmentReasons += "$reasonText$suffix"
-                }
-            }
-
-            if ($relevantAppAssignmentReasons.Count -gt 0) {
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($relevantAppAssignmentReasons -join "; ") -Force
-                # Exclusion-only assignments carry the intent of the excluding assignment
-                if (-not $intentForGroup) { $intentForGroup = $exclusionIntentForGroup }
-                if ($intentForGroup) {
+                if ($relevantAppAssignmentReasons.Count -gt 0) {
+                    $appWithReason = $entity.PSObject.Copy()
+                    $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($relevantAppAssignmentReasons -join "; ") -Force
+                    # Exclusion-only assignments carry the intent of the excluding assignment
+                    if (-not $intentForGroup) { $intentForGroup = $exclusionIntentForGroup }
                     switch ($intentForGroup) {
-                        "required" { $relevantPolicies.AppsRequired += $appWithReason }
-                        "available" { $relevantPolicies.AppsAvailable += $appWithReason }
-                        "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason }
+                        "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason) }
+                        "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason) }
+                        "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason) }
                     }
                 }
+                return
+            }
+
+            # Every other category (entities, App Protection, both Endpoint Security phases)
+            # maps the normalized assignments to Direct/Inherited reason strings via the parent map.
+            $assignmentReasons = @(Get-GroupAssignmentReasons -Assignments $ctx.Assignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap)
+            if ($assignmentReasons.Count -gt 0) {
+                $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
+                $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
             }
         }
 
-        # Get Platform Scripts
-        Write-Host "Fetching Platform Scripts..." -ForegroundColor Yellow
-        $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-        foreach ($script in $platformScripts) {
-            $directAssignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.PlatformScripts += $script
-                }
-            }
-        }
-
-        # Get Proactive Remediation Scripts
-        Write-Host "Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-        $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-        foreach ($script in $healthScripts) {
-            $directAssignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.HealthScripts += $script
-                }
-            }
-        }
-
-        # Get Autopilot Deployment Profiles
-        Write-Host "Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-        $autoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-        foreach ($policyProfile in $autoProfiles) {
-            $directAssignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policyProfile.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $policyProfile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.DeploymentProfiles += $policyProfile
-                }
-            }
-        }
-
-        # Get Enrollment Status Page Profiles
-        Write-Host "Fetching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-        $enrollmentConfigs = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-        $espProfiles = $enrollmentConfigs | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-        foreach ($esp in $espProfiles) {
-            $directAssignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id -GroupIds $allGroupIds
-            if ($directAssignments.Count -gt 0) {
-                $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                if ($assignmentReasons.Count -gt 0) {
-                    $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                    $relevantPolicies.ESPProfiles += $esp
-                }
-            }
-        }
-
-        # Get Windows 365 Cloud PC Provisioning Policies
-        Write-Host "Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-        try {
-            $cloudPCProvisioningPolicies = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-            foreach ($policy in $cloudPCProvisioningPolicies) {
-                $directAssignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id -GroupIds $allGroupIds
-                if ($directAssignments.Count -gt 0) {
-                    $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                    if ($assignmentReasons.Count -gt 0) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                        $relevantPolicies.CloudPCProvisioningPolicies += $policy
-                    }
-                }
-            }
-        }
-        catch {
-            Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-        }
-
-        # Get Windows 365 Cloud PC User Settings
-        Write-Host "Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-        try {
-            $cloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-            foreach ($setting in $cloudPCUserSettings) {
-                $directAssignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id -GroupIds $allGroupIds
-                if ($directAssignments.Count -gt 0) {
-                    $assignmentReasons = Get-GroupAssignmentReasons -Assignments $directAssignments -DirectGroupId $groupId -ParentGroupMap $parentGroupMap
-                    if ($assignmentReasons.Count -gt 0) {
-                        $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($assignmentReasons -join "; ") -Force
-                        $relevantPolicies.CloudPCUserSettings += $setting
-                    }
-                }
-            }
-        }
-        catch {
-            Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-        }
+        $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -AssignmentGroupIds $allGroupIds -ShowProgress -EntityCache $entityCache
+        $relevantPolicies = $scanResult.Buckets
 
         # Apply scope tag filter if specified
         if ($ScopeTagFilter) {
@@ -489,198 +189,67 @@ function Get-IntuneGroupAssignment {
             }
         }
 
-        # Function to format and display policy table (specific to Option 2)
-        function Format-PolicyTable {
-            param (
-                [string]$Title,
-                [object[]]$Policies,
-                [scriptblock]$GetName
-            )
-            $localTableSeparator = Get-Separator
+        # Display sections in the legacy order with the legacy per-category name resolution.
+        # Sections without GetName use the Show-CategoryResultTable default
+        # (displayName, then name, then "Unnamed Profile").
+        $nameFirst = { param($item) if ([string]::IsNullOrWhiteSpace($item.name)) { $item.displayName } else { $item.name } }
+        $displayNameFirst = { param($item) if ([string]::IsNullOrWhiteSpace($item.displayName)) { $item.name } else { $item.displayName } }
+        $displayNameOnly = { param($item) $item.displayName }
 
-            # Create prominent section header
-            $headerSeparator = "-" * ($Title.Length + 16)
-            Write-Host "`n$headerSeparator" -ForegroundColor Cyan
-            Write-Host "------- $Title -------" -ForegroundColor Cyan
-            Write-Host "$headerSeparator" -ForegroundColor Cyan
-
-            if ($Policies.Count -eq 0) {
-                Write-Host "No $Title found for this group." -ForegroundColor Gray
-                Write-Host $localTableSeparator -ForegroundColor Gray
-                Write-Host ""
-                return
+        $displaySections = @(
+            @{ Title = 'Device Configurations'; Bucket = 'DeviceConfigs'; GetName = $nameFirst }
+            @{ Title = 'Settings Catalog Policies'; Bucket = 'SettingsCatalog'; GetName = $nameFirst }
+            @{ Title = 'Compliance Policies'; Bucket = 'CompliancePolicies'; GetName = $nameFirst }
+            @{ Title = 'App Protection Policies'; Bucket = 'AppProtectionPolicies'; GetName = $displayNameOnly }
+            @{ Title = 'App Configuration Policies'; Bucket = 'AppConfigurationPolicies'; GetName = $nameFirst }
+            @{ Title = 'Platform Scripts'; Bucket = 'PlatformScripts'; GetName = $nameFirst }
+            @{ Title = 'Proactive Remediation Scripts'; Bucket = 'HealthScripts'; GetName = $nameFirst }
+            @{ Title = 'Autopilot Deployment Profiles'; Bucket = 'DeploymentProfiles'; GetName = $displayNameFirst }
+            @{ Title = 'Enrollment Status Page Profiles'; Bucket = 'ESPProfiles'; GetName = $displayNameFirst }
+            @{ Title = 'Windows 365 Cloud PC Provisioning Policies'; Bucket = 'CloudPCProvisioningPolicies'; GetName = $displayNameFirst }
+            @{ Title = 'Windows 365 Cloud PC User Settings'; Bucket = 'CloudPCUserSettings'; GetName = $displayNameFirst }
+            @{ Title = 'Required Apps'; Bucket = 'AppsRequired'; GetName = $displayNameOnly }
+            @{ Title = 'Available Apps'; Bucket = 'AppsAvailable'; GetName = $displayNameOnly }
+            @{ Title = 'Uninstall Apps'; Bucket = 'AppsUninstall'; GetName = $displayNameOnly }
+            @{ Title = 'Endpoint Security - Antivirus Profiles'; Bucket = 'AntivirusProfiles' }
+            @{ Title = 'Endpoint Security - Disk Encryption Profiles'; Bucket = 'DiskEncryptionProfiles' }
+            @{ Title = 'Endpoint Security - Firewall Profiles'; Bucket = 'FirewallProfiles' }
+            @{ Title = 'Endpoint Security - EDR Profiles'; Bucket = 'EndpointDetectionProfiles' }
+            @{ Title = 'Endpoint Security - ASR Profiles'; Bucket = 'AttackSurfaceProfiles' }
+            @{ Title = 'Endpoint Security - Account Protection Profiles'; Bucket = 'AccountProtectionProfiles' }
+        )
+        foreach ($section in $displaySections) {
+            $sectionParams = @{
+                Title        = $section.Title
+                Items        = @($relevantPolicies[$section.Bucket])
+                EmptyMessage = "No $($section.Title) found for this group."
             }
-
-            # Create table header
-            $headerFormat = "{0,-40} {1,-15} {2,-20} {3,-30} {4,-35}" -f "Policy Name", "Platform", "Scope Tags", "ID", "Assignment"
-
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $localTableSeparator -ForegroundColor Gray
-
-            # Display each policy
-            foreach ($policy in $Policies) {
-                $name = & $GetName $policy
-
-                if ($name.Length -gt 37) { $name = $name.Substring(0, 34) + "..." }
-
-                $platform = Get-PolicyPlatform -Policy $policy
-                if ($platform.Length -gt 12) { $platform = $platform.Substring(0, 9) + "..." }
-
-                $scopeTags = Get-ScopeTagNames -ScopeTagIds $policy.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
-                if ($scopeTags.Length -gt 17) { $scopeTags = $scopeTags.Substring(0, 14) + "..." }
-
-                $id = $policy.id
-                if ($id.Length -gt 27) { $id = $id.Substring(0, 24) + "..." }
-
-                $assignment = if ($policy.AssignmentReason) { $policy.AssignmentReason } else { "N/A" }
-                if ($assignment.Length -gt 32) { $assignment = $assignment.Substring(0, 29) + "..." }
-
-                $rowFormat = "{0,-40} {1,-15} {2,-20} {3,-30} {4,-35}" -f $name, $platform, $scopeTags, $id, $assignment
-                if ($assignment -match "Inherited Exclusion") {
-                    Write-Host $rowFormat -ForegroundColor Magenta
-                }
-                elseif ($assignment -match "Direct Exclusion") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                elseif ($assignment -match "Inherited") {
-                    Write-Host $rowFormat -ForegroundColor DarkYellow
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $localTableSeparator -ForegroundColor Gray
+            if ($section.GetName) { $sectionParams.GetName = $section.GetName }
+            Show-CategoryResultTable @sectionParams
         }
 
-        # Display Device Configurations
-        Format-PolicyTable -Title "Device Configurations" -Policies $relevantPolicies.DeviceConfigs -GetName {
-            param($config)
-            if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
-        }
-
-        # Display Settings Catalog Policies
-        Format-PolicyTable -Title "Settings Catalog Policies" -Policies $relevantPolicies.SettingsCatalog -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display Compliance Policies
-        Format-PolicyTable -Title "Compliance Policies" -Policies $relevantPolicies.CompliancePolicies -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display App Protection Policies
-        Format-PolicyTable -Title "App Protection Policies" -Policies $relevantPolicies.AppProtectionPolicies -GetName {
-            param($policy)
-            $policy.displayName
-        }
-
-        # Display App Configuration Policies
-        Format-PolicyTable -Title "App Configuration Policies" -Policies $relevantPolicies.AppConfigurationPolicies -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-        }
-
-        # Display Platform Scripts
-        Format-PolicyTable -Title "Platform Scripts" -Policies $relevantPolicies.PlatformScripts -GetName {
-            param($script)
-            if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-        }
-
-        # Display Proactive Remediation Scripts
-        Format-PolicyTable -Title "Proactive Remediation Scripts" -Policies $relevantPolicies.HealthScripts -GetName {
-            param($script)
-            if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-        }
-
-        # Display Autopilot Deployment Profiles
-        Format-PolicyTable -Title "Autopilot Deployment Profiles" -Policies $relevantPolicies.DeploymentProfiles -GetName {
-            param($policyProfile)
-            if ([string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.name } else { $policyProfile.displayName }
-        }
-
-        # Display Enrollment Status Page Profiles
-        Format-PolicyTable -Title "Enrollment Status Page Profiles" -Policies $relevantPolicies.ESPProfiles -GetName {
-            param($policyProfile)
-            if ([string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.name } else { $policyProfile.displayName }
-        }
-
-        # Display Windows 365 Cloud PC Provisioning Policies
-        Format-PolicyTable -Title "Windows 365 Cloud PC Provisioning Policies" -Policies $relevantPolicies.CloudPCProvisioningPolicies -GetName {
-            param($policy)
-            if ([string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.name } else { $policy.displayName }
-        }
-
-        # Display Windows 365 Cloud PC User Settings
-        Format-PolicyTable -Title "Windows 365 Cloud PC User Settings" -Policies $relevantPolicies.CloudPCUserSettings -GetName {
-            param($setting)
-            if ([string]::IsNullOrWhiteSpace($setting.displayName)) { $setting.name } else { $setting.displayName }
-        }
-
-        # Display Required Apps
-        Format-PolicyTable -Title "Required Apps" -Policies $relevantPolicies.AppsRequired -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Available Apps
-        Format-PolicyTable -Title "Available Apps" -Policies $relevantPolicies.AppsAvailable -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Uninstall Apps
-        Format-PolicyTable -Title "Uninstall Apps" -Policies $relevantPolicies.AppsUninstall -GetName {
-            param($app)
-            $app.displayName
-        }
-
-        # Display Endpoint Security - Antivirus Profiles
-        Format-PolicyTable -Title "Endpoint Security - Antivirus Profiles" -Policies $relevantPolicies.AntivirusProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Disk Encryption Profiles
-        Format-PolicyTable -Title "Endpoint Security - Disk Encryption Profiles" -Policies $relevantPolicies.DiskEncryptionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Firewall Profiles
-        Format-PolicyTable -Title "Endpoint Security - Firewall Profiles" -Policies $relevantPolicies.FirewallProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Endpoint Detection and Response Profiles
-        Format-PolicyTable -Title "Endpoint Security - EDR Profiles" -Policies $relevantPolicies.EndpointDetectionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Attack Surface Reduction Profiles
-        Format-PolicyTable -Title "Endpoint Security - ASR Profiles" -Policies $relevantPolicies.AttackSurfaceProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Display Endpoint Security - Account Protection Profiles
-        Format-PolicyTable -Title "Endpoint Security - Account Protection Profiles" -Policies $relevantPolicies.AccountProtectionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
-
-        # Add to export data
+        # Add to export data: the Group row first, then categories in the legacy CSV order
+        # (Endpoint Security after the Windows 365 categories, the app buckets last).
         Add-ExportData -ExportData $exportData -Category "Group" -Items @([PSCustomObject]@{
                 displayName      = $groupName
                 id               = $groupId
                 AssignmentReason = "N/A"
             })
 
-        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
+        $reasonProperty = { param($item) $item.AssignmentReason }
+        $exportBatches = @(
+            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            # Historical quirk preserved: App Protection rows export AssignmentSummary,
+            # a property this cmdlet never sets, so their AssignmentReason column stays empty.
+            @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
+            @{ Ids = @('AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'DeploymentProfiles', 'ESPProfiles',
+                    'CloudPCProvisioningPolicies', 'CloudPCUserSettings', 'ESAntivirus', 'ESDiskEncryption', 'ESFirewall',
+                    'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection', 'Applications'); Reason = $reasonProperty }
+        )
+        foreach ($batch in $exportBatches) {
+            $batchCategories = foreach ($id in $batch.Ids) { $categories | Where-Object { $_.Id -eq $id } }
+            Add-CategoryExportData -ExportData $exportData -Categories $batchCategories -Buckets $relevantPolicies -AssignmentReason $batch.Reason
+        }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
@@ -343,6 +343,7 @@ function Get-IntuneGroupAssignment {
 
             $relevantAppAssignmentReasons = @()
             $intentForGroup = $null
+            $exclusionIntentForGroup = $null
 
             foreach ($assignmentItem in $allAppAssignments) {
                 $appTargetGid = $assignmentItem.target.groupId
@@ -363,6 +364,7 @@ function Get-IntuneGroupAssignment {
                     elseif ($parentGroupMap.ContainsKey($appTargetGid)) {
                         $reasonText = "Inherited Exclusion (via $($parentGroupMap[$appTargetGid]))"
                     }
+                    if ($reasonText -and -not $exclusionIntentForGroup) { $exclusionIntentForGroup = $assignmentItem.intent }
                 }
                 if ($reasonText) {
                     $suffix = Format-AssignmentFilter -FilterId $assignmentItem.target.deviceAndAppManagementAssignmentFilterId -FilterType $assignmentItem.target.deviceAndAppManagementAssignmentFilterType
@@ -373,6 +375,8 @@ function Get-IntuneGroupAssignment {
             if ($relevantAppAssignmentReasons.Count -gt 0) {
                 $appWithReason = $app.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue ($relevantAppAssignmentReasons -join "; ") -Force
+                # Exclusion-only assignments carry the intent of the excluding assignment
+                if (-not $intentForGroup) { $intentForGroup = $exclusionIntentForGroup }
                 if ($intentForGroup) {
                     switch ($intentForGroup) {
                         "required" { $relevantPolicies.AppsRequired += $appWithReason }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
@@ -691,5 +691,5 @@ function Get-IntuneGroupAssignment {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
@@ -69,7 +69,8 @@ function Get-IntuneGroupAssignment {
         }
         else {
             # Try to find group by display name
-            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$groupInput'"
+            $escapedGroupName = $groupInput -replace "'", "''"
+            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
 
             if ($groupResponse.value.Count -eq 0) {
@@ -569,17 +570,6 @@ function Get-IntuneGroupAssignment {
         Format-PolicyTable -Title "App Protection Policies" -Policies $relevantPolicies.AppProtectionPolicies -GetName {
             param($policy)
             $policy.displayName
-        } -GetExtra {
-            param($policy)
-            @{
-                Label = 'Platform'
-                Value = switch ($policy.'@odata.type') {
-                    "#microsoft.graph.androidManagedAppProtection" { "Android" }
-                    "#microsoft.graph.iosManagedAppProtection" { "iOS" }
-                    "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
-                    default { "Unknown" }
-                }
-            }
         }
 
         # Display App Configuration Policies
@@ -661,33 +651,32 @@ function Get-IntuneGroupAssignment {
         Format-PolicyTable -Title "Endpoint Security - Account Protection Profiles" -Policies $relevantPolicies.AccountProtectionProfiles -GetName { param($policyProfile) if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" } }
 
         # Add to export data
-        Add-ExportData -ExportData $exportData -Category "Device" -Items @([PSCustomObject]@{
-                displayName      = $deviceName
-                id               = $deviceInfo.Id
+        Add-ExportData -ExportData $exportData -Category "Group" -Items @([PSCustomObject]@{
+                displayName      = $groupName
+                id               = $groupId
                 AssignmentReason = "N/A"
-            }
+            })
 
-            Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-            Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
-        )
+        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
+        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
@@ -402,5 +402,5 @@ function Get-IntuneUnassignedPolicy {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUnassignedPolicies.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUnassignedPolicies.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
@@ -60,13 +60,7 @@ function Get-IntuneUnassignedPolicy {
     Write-Host "Fetching App Protection Policies..." -ForegroundColor Yellow
     $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
     foreach ($policy in $appProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
+        $assignmentsUri = Get-AppProtectionAssignmentUri -Policy $policy
 
         if ($assignmentsUri) {
             try {
@@ -118,9 +112,15 @@ function Get-IntuneUnassignedPolicy {
     $antivirusPolicies = $allIntentsForAntivirusUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
     if ($antivirusPolicies) {
         foreach ($policy in $antivirusPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.AntivirusProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.AntivirusProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -132,9 +132,15 @@ function Get-IntuneUnassignedPolicy {
     $diskEncryptionPolicies = $allIntentsForDiskEncUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
     if ($diskEncryptionPolicies) {
         foreach ($policy in $diskEncryptionPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.DiskEncryptionProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.DiskEncryptionProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -146,9 +152,15 @@ function Get-IntuneUnassignedPolicy {
     $firewallPolicies = $allIntentsForFirewallUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
     if ($firewallPolicies) {
         foreach ($policy in $firewallPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.FirewallProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.FirewallProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -160,9 +172,15 @@ function Get-IntuneUnassignedPolicy {
     $edrPolicies = $allIntentsForEDRUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
     if ($edrPolicies) {
         foreach ($policy in $edrPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.EndpointDetectionProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.EndpointDetectionProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -174,9 +192,15 @@ function Get-IntuneUnassignedPolicy {
     $asrPolicies = $allIntentsForASRUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
     if ($asrPolicies) {
         foreach ($policy in $asrPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.AttackSurfaceProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.AttackSurfaceProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -188,9 +212,15 @@ function Get-IntuneUnassignedPolicy {
     $accountProtectionPolicies = $allIntentsForAccountProtectionUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
     if ($accountProtectionPolicies) {
         foreach ($policy in $accountProtectionPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-            if ($assignments.value.Count -eq 0) {
-                $unassignedPolicies.AccountProtectionProfiles += $policy
+            try {
+                $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                if ($assignments.value.Count -eq 0) {
+                    $unassignedPolicies.AccountProtectionProfiles += $policy
+                }
+            }
+            catch {
+                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
             }
         }
     }
@@ -198,11 +228,18 @@ function Get-IntuneUnassignedPolicy {
     # Get Unassigned Apps
     Write-Host "Fetching Unassigned Apps..." -ForegroundColor Yellow
     $unassignedAppUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq false"
-    $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppUri -Method Get
-    $unassignedApps = $unassignedAppResponse.value
-    while ($unassignedAppResponse.'@odata.nextLink') {
-        $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppResponse.'@odata.nextLink' -Method Get
-        $unassignedApps += $unassignedAppResponse.value
+    $unassignedApps = [System.Collections.Generic.List[object]]::new()
+    try {
+        $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppUri -Method Get
+        if ($unassignedAppResponse.value) { $unassignedApps.AddRange([object[]]$unassignedAppResponse.value) }
+        while ($unassignedAppResponse.'@odata.nextLink') {
+            $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppResponse.'@odata.nextLink' -Method Get
+            if ($unassignedAppResponse.value) { $unassignedApps.AddRange([object[]]$unassignedAppResponse.value) }
+        }
+    }
+    catch {
+        Write-Host "Error fetching unassigned applications: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Error -Message "Unassigned applications fetch failed: $($_.Exception.Message)"
     }
     $unassignedApps = $unassignedApps | Where-Object { -not $_.isFeatured -and -not $_.isBuiltIn }
     $unassignedPolicies.Apps = $unassignedApps

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
@@ -62,9 +62,9 @@ function Get-IntuneUnassignedPolicy {
     foreach ($policy in $appProtectionPolicies) {
         $policyType = $policy.'@odata.type'
         $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
+            "#microsoft.graph.androidManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
+            "#microsoft.graph.iosManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
+            "#microsoft.graph.windowsManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
             default { $null }
         }
 
@@ -118,7 +118,7 @@ function Get-IntuneUnassignedPolicy {
     $antivirusPolicies = $allIntentsForAntivirusUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
     if ($antivirusPolicies) {
         foreach ($policy in $antivirusPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.AntivirusProfiles += $policy
             }
@@ -132,7 +132,7 @@ function Get-IntuneUnassignedPolicy {
     $diskEncryptionPolicies = $allIntentsForDiskEncUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
     if ($diskEncryptionPolicies) {
         foreach ($policy in $diskEncryptionPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.DiskEncryptionProfiles += $policy
             }
@@ -146,7 +146,7 @@ function Get-IntuneUnassignedPolicy {
     $firewallPolicies = $allIntentsForFirewallUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
     if ($firewallPolicies) {
         foreach ($policy in $firewallPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.FirewallProfiles += $policy
             }
@@ -160,7 +160,7 @@ function Get-IntuneUnassignedPolicy {
     $edrPolicies = $allIntentsForEDRUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
     if ($edrPolicies) {
         foreach ($policy in $edrPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.EndpointDetectionProfiles += $policy
             }
@@ -174,7 +174,7 @@ function Get-IntuneUnassignedPolicy {
     $asrPolicies = $allIntentsForASRUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
     if ($asrPolicies) {
         foreach ($policy in $asrPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.AttackSurfaceProfiles += $policy
             }
@@ -188,7 +188,7 @@ function Get-IntuneUnassignedPolicy {
     $accountProtectionPolicies = $allIntentsForAccountProtectionUnassigned | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
     if ($accountProtectionPolicies) {
         foreach ($policy in $accountProtectionPolicies) {
-            $assignments = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            $assignments = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
             if ($assignments.value.Count -eq 0) {
                 $unassignedPolicies.AccountProtectionProfiles += $policy
             }
@@ -197,7 +197,7 @@ function Get-IntuneUnassignedPolicy {
 
     # Get Unassigned Apps
     Write-Host "Fetching Unassigned Apps..." -ForegroundColor Yellow
-    $unassignedAppUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq false"
+    $unassignedAppUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq false"
     $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppUri -Method Get
     $unassignedApps = $unassignedAppResponse.value
     while ($unassignedAppResponse.'@odata.nextLink') {

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
@@ -1436,5 +1436,5 @@ function Get-IntuneUserAssignment {
     }
 
     # Export results if requested
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUserAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUserAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
@@ -169,12 +169,12 @@ function Get-IntuneUserAssignment {
                                 $assignmentReason = "All Users"
                             }
                             '#microsoft.graph.groupAssignmentTarget' {
-                                if (!$GroupId -or $assignment.target.groupId -eq $GroupId) {
+                                if ($groupMemberships.id -contains $assignment.target.groupId) {
                                     $assignmentReason = "Group Assignment"
                                 }
                             }
                             '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                                if (!$GroupId -or $assignment.target.groupId -eq $GroupId) {
+                                if ($groupMemberships.id -contains $assignment.target.groupId) {
                                     $assignmentReason = "Group Exclusion"
                                 }
                             }
@@ -279,7 +279,7 @@ function Get-IntuneUserAssignment {
             if ($isIncluded -and -not $isExcluded) {
                 $appWithReason = $app.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Included$filterSuffix" -Force
-                switch ($assignment.intent) {
+                switch ($winningAssignment.intent) {
                     "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
                     "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
                     "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
@@ -288,7 +288,7 @@ function Get-IntuneUserAssignment {
             elseif ($isExcluded) {
                 $appWithReason = $app.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$filterSuffix" -Force
-                switch ($assignment.intent) {
+                switch ($winningAssignment.intent) {
                     "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
                     "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
                     "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
@@ -1410,29 +1410,28 @@ function Get-IntuneUserAssignment {
                 displayName      = $upn
                 id               = $userInfo.Id
                 AssignmentReason = "N/A"
-            }
+            })
 
-            Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-            Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-            Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
-        )
+        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
+        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
+        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
@@ -55,6 +55,164 @@ function Get-IntuneUserAssignment {
 
     $exportData = [System.Collections.ArrayList]::new()
 
+    # Renders one legacy three-column section (name/ID/assignment). The Device
+    # Configurations and App Protection sections keep their bespoke extra column below.
+    function Show-UserSectionTable {
+        param(
+            [string]$Title,
+            [object[]]$Items,
+            [string]$NameLabel,
+            [string]$IdLabel,
+            [scriptblock]$GetName,
+            [string]$RedPattern = 'Excluded*'
+        )
+        if ($null -eq $Items -or $Items.Count -eq 0) { return }
+        Write-Host "`n------- $Title -------" -ForegroundColor Cyan
+        $headerFormat = "{0,-50} {1,-40} {2,-30}" -f $NameLabel, $IdLabel, "Assignment"
+        $separator = Get-Separator
+        Write-Host $separator
+        Write-Host $headerFormat -ForegroundColor Yellow
+        Write-Host $separator
+        foreach ($item in $Items) {
+            $name = & $GetName $item
+            if ($name.Length -gt 47) { $name = $name.Substring(0, 44) + "..." }
+            $id = $item.id
+            if ($id.Length -gt 37) { $id = $id.Substring(0, 34) + "..." }
+            $assignment = $item.AssignmentReason
+            if ($assignment.Length -gt 27) { $assignment = $assignment.Substring(0, 24) + "..." }
+            $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $name, $id, $assignment
+            if ($assignment -like $RedPattern) {
+                Write-Host $rowFormat -ForegroundColor Red
+            }
+            else {
+                Write-Host $rowFormat -ForegroundColor White
+            }
+        }
+        Write-Host $separator
+    }
+
+    # Legacy per-section name resolution
+    $nameFirst = { param($item) if ([string]::IsNullOrWhiteSpace($item.name)) { $item.displayName } else { $item.name } }
+    $displayNameOnly = { param($item) $item.displayName }
+    $profileNameFirst = { param($item) if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } elseif (-not [string]::IsNullOrWhiteSpace($item.name)) { $item.name } else { "Unnamed Profile" } }
+    $policyNameFirst = { param($item) if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } elseif (-not [string]::IsNullOrWhiteSpace($item.name)) { $item.name } else { "Unnamed Policy" } }
+    $settingNameFirst = { param($item) if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } elseif (-not [string]::IsNullOrWhiteSpace($item.name)) { $item.name } else { "Unnamed Setting" } }
+
+    $categories = Get-IntuneCategoryDefinition -Audience 'UserContext'
+    # Shared across UPNs so each entity set is fetched from Graph once per run
+    $entityCache = @{}
+    $memberGroupIds = @()
+    $appProgress = @{ Current = 0; Total = $null; FilteredTotal = $null }
+
+    $processEntity = {
+        param($ctx)
+
+        $entity = $ctx.Entity
+
+        switch ($ctx.Category.Kind) {
+            'MobileApps' {
+                if ($null -eq $appProgress.Total) {
+                    $allCachedApps = @($entityCache[$ctx.Category.EntityType])
+                    $appProgress.Total = $allCachedApps.Count
+                    $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
+                }
+                $appProgress.Current++
+                Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
+
+                # Winning-assignment walk: an exclusion for one of the user's groups wins
+                # immediately; otherwise the first inclusion (All Users or member group) wins.
+                $isExcluded = $false
+                $isIncluded = $false
+                $winningAssignment = $null
+                foreach ($assignment in $ctx.RawAssignments) {
+                    if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and
+                        $memberGroupIds -contains $assignment.target.groupId) {
+                        $isExcluded = $true
+                        $winningAssignment = $assignment
+                        break
+                    }
+                    elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' -or
+                        ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
+                        $memberGroupIds -contains $assignment.target.groupId)) {
+                        if (-not $isIncluded) { $winningAssignment = $assignment }
+                        $isIncluded = $true
+                    }
+                }
+
+                if ($isIncluded -or $isExcluded) {
+                    $filterSuffix = Format-AssignmentFilter `
+                        -FilterId $winningAssignment.target.deviceAndAppManagementAssignmentFilterId `
+                        -FilterType $winningAssignment.target.deviceAndAppManagementAssignmentFilterType
+                    # Excluded apps stay visible in the intent bucket of the excluding assignment
+                    $reasonText = if ($isExcluded) { "Excluded$filterSuffix" } else { "Included$filterSuffix" }
+                    $appWithReason = $entity.PSObject.Copy()
+                    $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reasonText -Force
+                    switch ($winningAssignment.intent) {
+                        "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason) }
+                        "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason) }
+                        "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason) }
+                    }
+                }
+
+                if ($appProgress.Current -eq $appProgress.FilteredTotal) {
+                    # Legacy final overwrite before the next category header
+                    Write-Host "`rFetching Application $($appProgress.Total) of $($appProgress.Total)"
+                }
+            }
+            'AppProtection' {
+                # Only All Users targets and groups the user is actually a member of count
+                $matchingAssignments = @($ctx.Assignments | Where-Object {
+                        $_.Reason -eq 'All Users' -or
+                        ($_.Reason -in @('Group Assignment', 'Group Exclusion') -and $memberGroupIds -contains $_.GroupId)
+                    })
+                if ($matchingAssignments.Count -gt 0) {
+                    $assignmentSummary = $matchingAssignments | ForEach-Object { Format-AssignmentSummaryLine -Assignment $_ }
+                    $entity | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
+                    $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
+                }
+            }
+            'EndpointSecurity' {
+                $assignments = $ctx.Assignments
+                if ($null -ne $ctx.RawAssignments) {
+                    # Intent-phase detail rows historically carried no filter info, so the
+                    # resolved reason gets no filter suffix (unlike the config-policy phase)
+                    $assignments = @($assignments | ForEach-Object { [PSCustomObject]@{ Reason = $_.Reason; GroupId = $_.GroupId } })
+                }
+                $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $memberGroupIds -IncludeReasons @("All Users")
+                if ($reason) {
+                    $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
+                    $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
+                }
+            }
+            default {
+                if ($ctx.Category.Id -in @('CloudPCProvisioningPolicies', 'CloudPCUserSettings')) {
+                    # Legacy Cloud PC walk: the first matching assignment wins in raw order
+                    foreach ($assignment in $ctx.Assignments) {
+                        if ($assignment.Reason -eq "All Users" -or
+                            ($assignment.Reason -eq "Group Assignment" -and $memberGroupIds -contains $assignment.GroupId)) {
+                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
+                            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
+                            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
+                            break
+                        }
+                        elseif ($assignment.Reason -eq "Group Exclusion" -and $memberGroupIds -contains $assignment.GroupId) {
+                            $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
+                            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
+                            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
+                            break
+                        }
+                    }
+                    return
+                }
+                $reason = Resolve-AssignmentReason -Assignments $ctx.Assignments -GroupMembershipIds $memberGroupIds -IncludeReasons @("All Users")
+                if ($reason) {
+                    $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
+                    $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
+                }
+            }
+        }
+    }
+
     foreach ($upn in $upns) {
         Write-Host "Checking following UPN: $upn" -ForegroundColor Yellow
 
@@ -79,637 +237,11 @@ function Get-IntuneUserAssignment {
 
         Write-Host "Fetching Intune Profiles and Applications for the user..." -ForegroundColor Yellow
 
-        $totalCategories = 16
-        $currentCategory = 0
+        $memberGroupIds = @($groupMemberships.id)
+        $appProgress = @{ Current = 0; Total = $null; FilteredTotal = $null }
 
-        # Initialize collections for relevant policies
-        $relevantPolicies = @{
-            DeviceConfigs               = @()
-            SettingsCatalog             = @()
-            CompliancePolicies          = @()
-            AppProtectionPolicies       = @()
-            AppConfigurationPolicies    = @()
-            AppsRequired                = @()
-            AppsAvailable               = @()
-            AppsUninstall               = @()
-            PlatformScripts             = @()
-            HealthScripts               = @()
-            AntivirusProfiles           = @()
-            DiskEncryptionProfiles      = @()
-            FirewallProfiles            = @()
-            EndpointDetectionProfiles   = @()
-            AttackSurfaceProfiles       = @()
-            AccountProtectionProfiles   = @()
-            DeploymentProfiles          = @()
-            ESPProfiles                 = @()
-            CloudPCProvisioningPolicies = @()
-            CloudPCUserSettings         = @()
-        }
-
-        # Get Device Configurations
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Device Configurations..." -ForegroundColor Yellow
-        $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-        foreach ($config in $deviceConfigs) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.DeviceConfigs += $config
-            }
-        }
-
-        # Get Settings Catalog Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-        $settingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-        foreach ($policy in $settingsCatalog) {
-            $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.SettingsCatalog += $policy
-            }
-        }
-
-        # Get Compliance Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Compliance Policies..." -ForegroundColor Yellow
-        $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-        foreach ($policy in $compliancePolicies) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.CompliancePolicies += $policy
-            }
-        }
-
-        # Get App Protection Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching App Protection Policies..." -ForegroundColor Yellow
-        $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-        foreach ($policy in $appProtectionPolicies) {
-            $policyType = $policy.'@odata.type'
-            $assignmentsUri = switch ($policyType) {
-                "#microsoft.graph.androidManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-                "#microsoft.graph.iosManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-                "#microsoft.graph.windowsManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-                default { $null }
-            }
-
-            if ($assignmentsUri) {
-                try {
-                    $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                    $assignments = @()
-                    foreach ($assignment in $assignmentResponse.value) {
-                        $assignmentReason = $null
-                        switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' {
-                                $assignmentReason = "All Users"
-                            }
-                            '#microsoft.graph.groupAssignmentTarget' {
-                                if ($groupMemberships.id -contains $assignment.target.groupId) {
-                                    $assignmentReason = "Group Assignment"
-                                }
-                            }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                                if ($groupMemberships.id -contains $assignment.target.groupId) {
-                                    $assignmentReason = "Group Exclusion"
-                                }
-                            }
-                        }
-
-                        if ($assignmentReason) {
-                            $rawFilterId   = $assignment.target.deviceAndAppManagementAssignmentFilterId
-                            $rawFilterType = $assignment.target.deviceAndAppManagementAssignmentFilterType
-                            $effFilterId   = $null
-                            $effFilterType = $null
-                            if ($rawFilterType -and $rawFilterType -ne 'none' -and $rawFilterId -and $rawFilterId -ne '00000000-0000-0000-0000-000000000000') {
-                                $effFilterId   = $rawFilterId
-                                $effFilterType = $rawFilterType
-                            }
-                            $assignments += @{
-                                Reason     = $assignmentReason
-                                GroupId    = $assignment.target.groupId
-                                FilterId   = $effFilterId
-                                FilterType = $effFilterType
-                            }
-                        }
-                    }
-
-                    if ($assignments.Count -gt 0) {
-                        $assignmentSummary = $assignments | ForEach-Object {
-                            Format-AssignmentSummaryLine -Assignment ([PSCustomObject]$_)
-                        }
-                        $policy | Add-Member -NotePropertyName 'AssignmentSummary' -NotePropertyValue ($assignmentSummary -join "; ") -Force
-                        $relevantPolicies.AppProtectionPolicies += $policy
-                    }
-                }
-                catch {
-                    Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-                }
-            }
-        }
-
-        # Get App Configuration Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching App Configuration Policies..." -ForegroundColor Yellow
-        $appConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-        foreach ($policy in $appConfigPolicies) {
-            $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.AppConfigurationPolicies += $policy
-            }
-        }
-
-        # Fetch and process Applications
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Applications..." -ForegroundColor Yellow
-        $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-        $allApps = $appResponse.value
-        while ($appResponse.'@odata.nextLink') {
-            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-            $allApps += $appResponse.value
-        }
-        $totalApps = $allApps.Count
-        $currentApp = 0
-
-        foreach ($app in $allApps) {
-            # Filter out irrelevant apps
-            if ($app.isFeatured -or $app.isBuiltIn) {
-                continue
-            }
-
-            $currentApp++
-            Write-Host "`rFetching Application $currentApp of $totalApps" -NoNewline
-            $appId = $app.id
-            $assignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            $isExcluded = $false
-            $isIncluded = $false
-            $winningAssignment = $null
-
-            foreach ($assignment in $assignmentResponse.value) {
-                if ($assignment.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' -and
-                    $groupMemberships.id -contains $assignment.target.groupId) {
-                    $isExcluded = $true
-                    $winningAssignment = $assignment
-                    break
-                }
-                elseif ($assignment.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' -or
-                    ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
-                    $groupMemberships.id -contains $assignment.target.groupId)) {
-                    if (-not $isIncluded) { $winningAssignment = $assignment }
-                    $isIncluded = $true
-                }
-            }
-
-            $filterSuffix = ''
-            if ($winningAssignment) {
-                $filterSuffix = Format-AssignmentFilter `
-                    -FilterId   $winningAssignment.target.deviceAndAppManagementAssignmentFilterId `
-                    -FilterType $winningAssignment.target.deviceAndAppManagementAssignmentFilterType
-            }
-
-            if ($isIncluded -and -not $isExcluded) {
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Included$filterSuffix" -Force
-                switch ($winningAssignment.intent) {
-                    "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
-                    "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
-                    "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
-                }
-            }
-            elseif ($isExcluded) {
-                $appWithReason = $app.PSObject.Copy()
-                $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$filterSuffix" -Force
-                switch ($winningAssignment.intent) {
-                    "required" { $relevantPolicies.AppsRequired += $appWithReason; break }
-                    "available" { $relevantPolicies.AppsAvailable += $appWithReason; break }
-                    "uninstall" { $relevantPolicies.AppsUninstall += $appWithReason; break }
-                }
-            }
-        }
-        Write-Host "`rFetching Application $totalApps of $totalApps" -NoNewline
-        Start-Sleep -Milliseconds 100
-        Write-Host ""  # Move to the next line after the loop
-
-        # Get Platform Scripts
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Platform Scripts..." -ForegroundColor Yellow
-        $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-        foreach ($script in $platformScripts) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.PlatformScripts += $script
-            }
-        }
-
-        # Get Proactive Remediation Scripts
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-        $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-        foreach ($script in $healthScripts) {
-            $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-            if ($reason) {
-                $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                $relevantPolicies.HealthScripts += $script
-            }
-        }
-
-        # Get Endpoint Security - Antivirus Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Antivirus Policies..." -ForegroundColor Yellow
-        $antivirusPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedAntivirusIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForAntivirus = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesAntivirus = $configPoliciesForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-        if ($matchingConfigPoliciesAntivirus) {
-            foreach ($policy in $matchingConfigPoliciesAntivirus) {
-                if ($processedAntivirusIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$antivirusPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForAntivirus = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAntivirus
-        $matchingIntentsAntivirus = $allIntentsForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-
-        if ($matchingIntentsAntivirus) {
-            foreach ($policy in $matchingIntentsAntivirus) {
-                if ($processedAntivirusIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$antivirusPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AntivirusProfiles = $antivirusPoliciesFound
-
-        # Get Endpoint Security - Disk Encryption Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Disk Encryption Policies..." -ForegroundColor Yellow
-        $diskEncryptionPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedDiskEncryptionIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForDiskEncryption = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesDiskEnc = $configPoliciesForDiskEncryption | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-        if ($matchingConfigPoliciesDiskEnc) {
-            foreach ($policy in $matchingConfigPoliciesDiskEnc) {
-                if ($processedDiskEncryptionIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$diskEncryptionPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents (excluding those already found)
-        $allIntentsForDiskEncryption = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForDiskEncryption
-        $matchingIntentsDiskEnc = $allIntentsForDiskEncryption | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-
-        if ($matchingIntentsDiskEnc) {
-            foreach ($policy in $matchingIntentsDiskEnc) {
-                if ($processedDiskEncryptionIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$diskEncryptionPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.DiskEncryptionProfiles = $diskEncryptionPoliciesFound
-
-        # Get Endpoint Security - Firewall Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Firewall Policies..." -ForegroundColor Yellow
-        $firewallPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedFirewallIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForFirewall = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesFirewall = $configPoliciesForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-        if ($matchingConfigPoliciesFirewall) {
-            foreach ($policy in $matchingConfigPoliciesFirewall) {
-                if ($processedFirewallIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$firewallPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForFirewall = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForFirewall
-        $matchingIntentsFirewall = $allIntentsForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-
-        if ($matchingIntentsFirewall) {
-            foreach ($policy in $matchingIntentsFirewall) {
-                if ($processedFirewallIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$firewallPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.FirewallProfiles = $firewallPoliciesFound
-
-        # Get Endpoint Security - Endpoint Detection and Response Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Endpoint Detection and Response Policies..." -ForegroundColor Yellow
-        $edrPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedEDRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForEDR = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesEDR = $configPoliciesForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-        if ($matchingConfigPoliciesEDR) {
-            foreach ($policy in $matchingConfigPoliciesEDR) {
-                if ($processedEDRIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$edrPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForEDR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForEDR
-        $matchingIntentsEDR = $allIntentsForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-
-        if ($matchingIntentsEDR) {
-            foreach ($policy in $matchingIntentsEDR) {
-                if ($processedEDRIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$edrPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.EndpointDetectionProfiles = $edrPoliciesFound
-
-        # Get Endpoint Security - Attack Surface Reduction Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Attack Surface Reduction Policies..." -ForegroundColor Yellow
-        $asrPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedASRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForASR = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesASR = $configPoliciesForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-        if ($matchingConfigPoliciesASR) {
-            foreach ($policy in $matchingConfigPoliciesASR) {
-                if ($processedASRIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$asrPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForASR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForASR
-        $matchingIntentsASR = $allIntentsForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-
-        if ($matchingIntentsASR) {
-            foreach ($policy in $matchingIntentsASR) {
-                if ($processedASRIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$asrPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AttackSurfaceProfiles = $asrPoliciesFound
-
-        # Get Endpoint Security - Account Protection Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Account Protection Policies..." -ForegroundColor Yellow
-        $accountProtectionPoliciesFound = [System.Collections.ArrayList]::new()
-        $processedAccountProtectionIds = [System.Collections.Generic.HashSet[string]]::new()
-
-        # 1. Check configurationPolicies
-        $configPoliciesForAccountProtection = Get-IntuneEntities -EntityType "configurationPolicies"
-        $matchingConfigPoliciesAccountProtection = $configPoliciesForAccountProtection | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-        if ($matchingConfigPoliciesAccountProtection) {
-            foreach ($policy in $matchingConfigPoliciesAccountProtection) {
-                if ($processedAccountProtectionIds.Add($policy.id)) {
-                    $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$accountProtectionPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-
-        # 2. Check deviceManagement/intents
-        $allIntentsForAccountProtection = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $allIntentsForAccountProtection
-        $matchingIntentsAccountProtection = $allIntentsForAccountProtection | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-
-        if ($matchingIntentsAccountProtection) {
-            foreach ($policy in $matchingIntentsAccountProtection) {
-                if ($processedAccountProtectionIds.Add($policy.id)) {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $assignments = $assignmentsResponse.value
-                    $assignmentDetailsList = foreach ($assignment in $assignments) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    $reason = Resolve-AssignmentReason -Assignments $assignmentDetailsList -GroupMembershipIds $groupMemberships.id -IncludeReasons @("All Users")
-                    if ($reason) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $reason -Force
-                        [void]$accountProtectionPoliciesFound.Add($policy)
-                    }
-                }
-            }
-        }
-        $relevantPolicies.AccountProtectionProfiles = $accountProtectionPoliciesFound
-
-        # Get Windows 365 Cloud PC Provisioning Policies
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-        try {
-            $cloudPCProvisioningPolicies = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-            foreach ($policy in $cloudPCProvisioningPolicies) {
-                $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-                foreach ($assignment in $assignments) {
-                    if ($assignment.Reason -eq "All Users" -or
-                        ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                        $relevantPolicies.CloudPCProvisioningPolicies += $policy
-                        break
-                    }
-                    elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                        $relevantPolicies.CloudPCProvisioningPolicies += $policy
-                        break
-                    }
-                }
-            }
-        }
-        catch {
-            Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-        }
-
-        # Get Windows 365 Cloud PC User Settings
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-        try {
-            $cloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-            foreach ($setting in $cloudPCUserSettings) {
-                $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-                foreach ($assignment in $assignments) {
-                    if ($assignment.Reason -eq "All Users" -or
-                        ($assignment.Reason -eq "Group Assignment" -and $groupMemberships.id -contains $assignment.GroupId)) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "$($assignment.Reason)$suffix" -Force
-                        $relevantPolicies.CloudPCUserSettings += $setting
-                        break
-                    }
-                    elseif ($assignment.Reason -eq "Group Exclusion" -and $groupMemberships.id -contains $assignment.GroupId) {
-                        $suffix = Format-AssignmentFilter -FilterId $assignment.FilterId -FilterType $assignment.FilterType
-                        $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Excluded$suffix" -Force
-                        $relevantPolicies.CloudPCUserSettings += $setting
-                        break
-                    }
-                }
-            }
-        }
-        catch {
-            Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-        }
+        $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -ShowProgress -EntityCache $entityCache
+        $relevantPolicies = $scanResult.Buckets
 
         # Apply scope tag filter if specified
         if ($ScopeTagFilter) {
@@ -727,37 +259,23 @@ function Get-IntuneUserAssignment {
         $totalDisplayCategories = $categoryNames.Count
         Write-Host "`nFound assignments in $nonEmptyCount of $totalDisplayCategories categories." -ForegroundColor Cyan
 
-        # Display Device Configurations
+        # Display Device Configurations (bespoke four-column table with Platform)
         if ($relevantPolicies.DeviceConfigs.Count -gt 0) {
             Write-Host "`n------- Device Configurations -------" -ForegroundColor Cyan
-            # Create table header
             $headerFormat = "{0,-45} {1,-20} {2,-35} {3,-20}" -f "Configuration Name", "Platform", "Configuration ID", "Assignment"
             $separator = Get-Separator
             Write-Host $separator
             Write-Host $headerFormat -ForegroundColor Yellow
             Write-Host $separator
-
             foreach ($config in $relevantPolicies.DeviceConfigs) {
                 $configName = if ([string]::IsNullOrWhiteSpace($config.name)) { $config.displayName } else { $config.name }
-                if ($configName.Length -gt 42) {
-                    $configName = $configName.Substring(0, 39) + "..."
-                }
-
+                if ($configName.Length -gt 42) { $configName = $configName.Substring(0, 39) + "..." }
                 $platform = Get-PolicyPlatform -Policy $config
-                if ($platform.Length -gt 17) {
-                    $platform = $platform.Substring(0, 14) + "..."
-                }
-
+                if ($platform.Length -gt 17) { $platform = $platform.Substring(0, 14) + "..." }
                 $configId = $config.id
-                if ($configId.Length -gt 32) {
-                    $configId = $configId.Substring(0, 29) + "..."
-                }
-
+                if ($configId.Length -gt 32) { $configId = $configId.Substring(0, 29) + "..." }
                 $assignment = $config.AssignmentReason
-                if ($assignment.Length -gt 17) {
-                    $assignment = $assignment.Substring(0, 14) + "..."
-                }
-
+                if ($assignment.Length -gt 17) { $assignment = $assignment.Substring(0, 14) + "..." }
                 $rowFormat = "{0,-45} {1,-20} {2,-35} {3,-20}" -f $configName, $platform, $configId, $assignment
                 if ($assignment -like "Excluded*") {
                     Write-Host $rowFormat -ForegroundColor Red
@@ -769,113 +287,31 @@ function Get-IntuneUserAssignment {
             Write-Host $separator
         }
 
-        # Display Settings Catalog Policies
-        if ($relevantPolicies.SettingsCatalog.Count -gt 0) {
-            Write-Host "`n------- Settings Catalog Policies -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Policy Name", "Policy ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
+        Show-UserSectionTable -Title 'Settings Catalog Policies' -Items @($relevantPolicies.SettingsCatalog) -NameLabel 'Policy Name' -IdLabel 'Policy ID' -GetName $nameFirst
+        Show-UserSectionTable -Title 'Compliance Policies' -Items @($relevantPolicies.CompliancePolicies) -NameLabel 'Policy Name' -IdLabel 'Policy ID' -GetName $nameFirst
 
-            foreach ($policy in $relevantPolicies.SettingsCatalog) {
-                $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-                if ($policyName.Length -gt 47) {
-                    $policyName = $policyName.Substring(0, 44) + "..."
-                }
-
-                $policyId = $policy.id
-                if ($policyId.Length -gt 37) {
-                    $policyId = $policyId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policy.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $policyName, $policyId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Compliance Policies
-        if ($relevantPolicies.CompliancePolicies.Count -gt 0) {
-            Write-Host "`n------- Compliance Policies -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Policy Name", "Policy ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policy in $relevantPolicies.CompliancePolicies) {
-                $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-                if ($policyName.Length -gt 47) {
-                    $policyName = $policyName.Substring(0, 44) + "..."
-                }
-
-                $policyId = $policy.id
-                if ($policyId.Length -gt 37) {
-                    $policyId = $policyId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policy.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $policyName, $policyId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display App Protection Policies
+        # Display App Protection Policies (bespoke four-column table with Type; the legacy
+        # table reads AssignmentReason, which this category never sets, so the column stays blank)
         if ($relevantPolicies.AppProtectionPolicies.Count -gt 0) {
             Write-Host "`n------- App Protection Policies -------" -ForegroundColor Cyan
-            # Create table header
             $headerFormat = "{0,-40} {1,-30} {2,-20} {3,-30}" -f "Policy Name", "Policy ID", "Type", "Assignment"
             $separator = Get-Separator
             Write-Host $separator
             Write-Host $headerFormat -ForegroundColor Yellow
             Write-Host $separator
-
             foreach ($policy in $relevantPolicies.AppProtectionPolicies) {
                 $policyName = $policy.displayName
-                if ($policyName.Length -gt 37) {
-                    $policyName = $policyName.Substring(0, 34) + "..."
-                }
-
+                if ($policyName.Length -gt 37) { $policyName = $policyName.Substring(0, 34) + "..." }
                 $policyId = $policy.id
-                if ($policyId.Length -gt 27) {
-                    $policyId = $policyId.Substring(0, 24) + "..."
-                }
-
+                if ($policyId.Length -gt 27) { $policyId = $policyId.Substring(0, 24) + "..." }
                 $policyType = switch ($policy.'@odata.type') {
                     "#microsoft.graph.androidManagedAppProtection" { "Android" }
                     "#microsoft.graph.iosManagedAppProtection" { "iOS" }
                     "#microsoft.graph.windowsManagedAppProtection" { "Windows" }
                     default { "Unknown" }
                 }
-
                 $assignment = $policy.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
+                if ($assignment.Length -gt 27) { $assignment = $assignment.Substring(0, 24) + "..." }
                 $rowFormat = "{0,-40} {1,-30} {2,-20} {3,-30}" -f $policyName, $policyId, $policyType, $assignment
                 if ($assignment -like "Excluded*") {
                     Write-Host $rowFormat -ForegroundColor Red
@@ -887,551 +323,57 @@ function Get-IntuneUserAssignment {
             Write-Host $separator
         }
 
-        # Display App Configuration Policies
-        if ($relevantPolicies.AppConfigurationPolicies.Count -gt 0) {
-            Write-Host "`n------- App Configuration Policies -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Policy Name", "Policy ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policy in $relevantPolicies.AppConfigurationPolicies) {
-                $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
-                if ($policyName.Length -gt 47) {
-                    $policyName = $policyName.Substring(0, 44) + "..."
-                }
-
-                $policyId = $policy.id
-                if ($policyId.Length -gt 37) {
-                    $policyId = $policyId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policy.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $policyName, $policyId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
+        # Remaining sections in the legacy display order. App rows keep the legacy
+        # "*Exclusion*" red-row pattern, which never matches "Excluded..." reasons.
+        $displaySections = @(
+            @{ Title = 'App Configuration Policies'; Bucket = 'AppConfigurationPolicies'; NameLabel = 'Policy Name'; IdLabel = 'Policy ID'; GetName = $nameFirst }
+            @{ Title = 'Platform Scripts'; Bucket = 'PlatformScripts'; NameLabel = 'Script Name'; IdLabel = 'Script ID'; GetName = $nameFirst }
+            @{ Title = 'Proactive Remediation Scripts'; Bucket = 'HealthScripts'; NameLabel = 'Script Name'; IdLabel = 'Script ID'; GetName = $nameFirst }
+            @{ Title = 'Required Apps'; Bucket = 'AppsRequired'; NameLabel = 'App Name'; IdLabel = 'App ID'; GetName = $displayNameOnly; RedPattern = '*Exclusion*' }
+            @{ Title = 'Available Apps'; Bucket = 'AppsAvailable'; NameLabel = 'App Name'; IdLabel = 'App ID'; GetName = $displayNameOnly; RedPattern = '*Exclusion*' }
+            @{ Title = 'Uninstall Apps'; Bucket = 'AppsUninstall'; NameLabel = 'App Name'; IdLabel = 'App ID'; GetName = $displayNameOnly; RedPattern = '*Exclusion*' }
+            @{ Title = 'Endpoint Security - Antivirus Profiles'; Bucket = 'AntivirusProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Endpoint Security - Disk Encryption Profiles'; Bucket = 'DiskEncryptionProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Endpoint Security - Firewall Profiles'; Bucket = 'FirewallProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Endpoint Security - Endpoint Detection and Response Profiles'; Bucket = 'EndpointDetectionProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Endpoint Security - Attack Surface Reduction Profiles'; Bucket = 'AttackSurfaceProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Endpoint Security - Account Protection Profiles'; Bucket = 'AccountProtectionProfiles'; NameLabel = 'Profile Name'; IdLabel = 'Profile ID'; GetName = $profileNameFirst }
+            @{ Title = 'Windows 365 Cloud PC Provisioning Policies'; Bucket = 'CloudPCProvisioningPolicies'; NameLabel = 'Policy Name'; IdLabel = 'Policy ID'; GetName = $policyNameFirst }
+            @{ Title = 'Windows 365 Cloud PC User Settings'; Bucket = 'CloudPCUserSettings'; NameLabel = 'Setting Name'; IdLabel = 'Setting ID'; GetName = $settingNameFirst }
+        )
+        foreach ($section in $displaySections) {
+            $sectionParams = @{
+                Title     = $section.Title
+                Items     = @($relevantPolicies[$section.Bucket])
+                NameLabel = $section.NameLabel
+                IdLabel   = $section.IdLabel
+                GetName   = $section.GetName
             }
-            Write-Host $separator
+            if ($section.RedPattern) { $sectionParams.RedPattern = $section.RedPattern }
+            Show-UserSectionTable @sectionParams
         }
 
-        # Display Platform Scripts
-        if ($relevantPolicies.PlatformScripts.Count -gt 0) {
-            Write-Host "`n------- Platform Scripts -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Script Name", "Script ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($script in $relevantPolicies.PlatformScripts) {
-                $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-                if ($scriptName.Length -gt 47) {
-                    $scriptName = $scriptName.Substring(0, 44) + "..."
-                }
-
-                $scriptId = $script.id
-                if ($scriptId.Length -gt 37) {
-                    $scriptId = $scriptId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $script.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $scriptName, $scriptId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Proactive Remediation Scripts
-        if ($relevantPolicies.HealthScripts.Count -gt 0) {
-            Write-Host "`n------- Proactive Remediation Scripts -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Script Name", "Script ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($script in $relevantPolicies.HealthScripts) {
-                $scriptName = if ([string]::IsNullOrWhiteSpace($script.name)) { $script.displayName } else { $script.name }
-                if ($scriptName.Length -gt 47) {
-                    $scriptName = $scriptName.Substring(0, 44) + "..."
-                }
-
-                $scriptId = $script.id
-                if ($scriptId.Length -gt 37) {
-                    $scriptId = $scriptId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $script.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $scriptName, $scriptId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Required Apps
-        if ($relevantPolicies.AppsRequired.Count -gt 0) {
-            Write-Host "`n------- Required Apps -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "App Name", "App ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($app in $relevantPolicies.AppsRequired) {
-                $appName = $app.displayName
-                if ($appName.Length -gt 47) {
-                    $appName = $appName.Substring(0, 44) + "..."
-                }
-
-                $appId = $app.id
-                if ($appId.Length -gt 37) {
-                    $appId = $appId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $app.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $appName, $appId, $assignment
-                if ($assignment -like "*Exclusion*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Available Apps
-        if ($relevantPolicies.AppsAvailable.Count -gt 0) {
-            Write-Host "`n------- Available Apps -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "App Name", "App ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($app in $relevantPolicies.AppsAvailable) {
-                $appName = $app.displayName
-                if ($appName.Length -gt 47) {
-                    $appName = $appName.Substring(0, 44) + "..."
-                }
-
-                $appId = $app.id
-                if ($appId.Length -gt 37) {
-                    $appId = $appId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $app.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $appName, $appId, $assignment
-                if ($assignment -like "*Exclusion*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Uninstall Apps
-        if ($relevantPolicies.AppsUninstall.Count -gt 0) {
-            Write-Host "`n------- Uninstall Apps -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "App Name", "App ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($app in $relevantPolicies.AppsUninstall) {
-                $appName = $app.displayName
-                if ($appName.Length -gt 47) {
-                    $appName = $appName.Substring(0, 44) + "..."
-                }
-
-                $appId = $app.id
-                if ($appId.Length -gt 37) {
-                    $appId = $appId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $app.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $appName, $appId, $assignment
-                if ($assignment -like "*Exclusion*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Antivirus Profiles
-        if ($relevantPolicies.AntivirusProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Antivirus Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.AntivirusProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Disk Encryption Profiles
-        if ($relevantPolicies.DiskEncryptionProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Disk Encryption Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.DiskEncryptionProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Firewall Profiles
-        if ($relevantPolicies.FirewallProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Firewall Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.FirewallProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Endpoint Detection and Response Profiles
-        if ($relevantPolicies.EndpointDetectionProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Endpoint Detection and Response Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.EndpointDetectionProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Attack Surface Reduction Profiles
-        if ($relevantPolicies.AttackSurfaceProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Attack Surface Reduction Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.AttackSurfaceProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Endpoint Security - Account Protection Profiles
-        if ($relevantPolicies.AccountProtectionProfiles.Count -gt 0) {
-            Write-Host "`n------- Endpoint Security - Account Protection Profiles -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Profile Name", "Profile ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policyProfile in $relevantPolicies.AccountProtectionProfiles) {
-                $profileName = if (-not [string]::IsNullOrWhiteSpace($policyProfile.displayName)) { $policyProfile.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policyProfile.name)) { $policyProfile.name } else { "Unnamed Profile" }
-                if ($profileName.Length -gt 47) {
-                    $profileName = $profileName.Substring(0, 44) + "..."
-                }
-
-                $profileId = $policyProfile.id
-                if ($profileId.Length -gt 37) {
-                    $profileId = $profileId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policyProfile.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $profileName, $profileId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Windows 365 Cloud PC Provisioning Policies
-        if ($relevantPolicies.CloudPCProvisioningPolicies.Count -gt 0) {
-            Write-Host "`n------- Windows 365 Cloud PC Provisioning Policies -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Policy Name", "Policy ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($policy in $relevantPolicies.CloudPCProvisioningPolicies) {
-                $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } elseif (-not [string]::IsNullOrWhiteSpace($policy.name)) { $policy.name } else { "Unnamed Policy" }
-                if ($policyName.Length -gt 47) {
-                    $policyName = $policyName.Substring(0, 44) + "..."
-                }
-
-                $policyId = $policy.id
-                if ($policyId.Length -gt 37) {
-                    $policyId = $policyId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $policy.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $policyName, $policyId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Display Windows 365 Cloud PC User Settings
-        if ($relevantPolicies.CloudPCUserSettings.Count -gt 0) {
-            Write-Host "`n------- Windows 365 Cloud PC User Settings -------" -ForegroundColor Cyan
-            # Create table header
-            $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Setting Name", "Setting ID", "Assignment"
-            $separator = Get-Separator
-            Write-Host $separator
-            Write-Host $headerFormat -ForegroundColor Yellow
-            Write-Host $separator
-
-            foreach ($setting in $relevantPolicies.CloudPCUserSettings) {
-                $settingName = if (-not [string]::IsNullOrWhiteSpace($setting.displayName)) { $setting.displayName } elseif (-not [string]::IsNullOrWhiteSpace($setting.name)) { $setting.name } else { "Unnamed Setting" }
-                if ($settingName.Length -gt 47) {
-                    $settingName = $settingName.Substring(0, 44) + "..."
-                }
-
-                $settingId = $setting.id
-                if ($settingId.Length -gt 37) {
-                    $settingId = $settingId.Substring(0, 34) + "..."
-                }
-
-                $assignment = $setting.AssignmentReason
-                if ($assignment.Length -gt 27) {
-                    $assignment = $assignment.Substring(0, 24) + "..."
-                }
-
-                $rowFormat = "{0,-50} {1,-40} {2,-30}" -f $settingName, $settingId, $assignment
-                if ($assignment -like "Excluded*") {
-                    Write-Host $rowFormat -ForegroundColor Red
-                }
-                else {
-                    Write-Host $rowFormat -ForegroundColor White
-                }
-            }
-            Write-Host $separator
-        }
-
-        # Add all data to export
+        # Add all data to export: the User row first, then categories in the legacy CSV order
+        # (Endpoint Security after the Windows 365 categories, the app buckets last).
         Add-ExportData -ExportData $exportData -Category "User" -Items @([PSCustomObject]@{
                 displayName      = $upn
                 id               = $userInfo.Id
                 AssignmentReason = "N/A"
             })
 
-        Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items $relevantPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy" -Items $relevantPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Compliance Policy" -Items $relevantPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "App Protection Policy" -Items $relevantPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentSummary }
-        Add-ExportData -ExportData $exportData -Category "App Configuration Policy" -Items $relevantPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Platform Scripts" -Items $relevantPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Proactive Remediation Scripts" -Items $relevantPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Autopilot Deployment Profile" -Items $relevantPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Enrollment Status Page" -Items $relevantPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC Provisioning Policy" -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Windows 365 Cloud PC User Setting" -Items $relevantPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Antivirus" -Items $relevantPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Disk Encryption" -Items $relevantPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Firewall" -Items $relevantPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - EDR" -Items $relevantPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - ASR" -Items $relevantPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Endpoint Security - Account Protection" -Items $relevantPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Required Apps" -Items $relevantPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Available Apps" -Items $relevantPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-        Add-ExportData -ExportData $exportData -Category "Uninstall Apps" -Items $relevantPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
+        $reasonProperty = { param($item) $item.AssignmentReason }
+        $exportBatches = @(
+            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            # App Protection rows export the AssignmentSummary built during the scan
+            @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
+            @{ Ids = @('AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'DeploymentProfiles', 'ESPProfiles',
+                    'CloudPCProvisioningPolicies', 'CloudPCUserSettings', 'ESAntivirus', 'ESDiskEncryption', 'ESFirewall',
+                    'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection', 'Applications'); Reason = $reasonProperty }
+        )
+        foreach ($batch in $exportBatches) {
+            $batchCategories = foreach ($id in $batch.Ids) { $categories | Where-Object { $_.Id -eq $id } }
+            Add-CategoryExportData -ExportData $exportData -Categories $batchCategories -Buckets $relevantPolicies -AssignmentReason $batch.Reason
+        }
     }
 
     # Export results if requested

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
@@ -184,12 +184,12 @@ function Get-IntuneUserDeviceAssignment {
         }
     }
 
-    # Helper: ES intents-based fetch
+    # Helper: ES intents-based fetch. Entity sets are fetched once by the caller
+    # and passed in so each family invocation does not re-query Graph.
     $processIntent = {
-        param($templateFamily, $bucketKey, $processedSet)
+        param($templateFamily, $bucketKey, $processedSet, $configPolicies, $intents)
 
         # configurationPolicies branch
-        $configPolicies = Get-IntuneEntities -EntityType "configurationPolicies"
         $matching = $configPolicies | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $templateFamily }
         foreach ($policy in $matching) {
             if (-not $processedSet.Add($policy.id)) { continue }
@@ -204,12 +204,17 @@ function Get-IntuneUserDeviceAssignment {
         }
 
         # deviceManagement/intents branch
-        $intents = Get-IntuneEntities -EntityType "deviceManagement/intents"
-        Add-IntentTemplateFamilyInfo -IntentPolicies $intents
         $matchingIntents = $intents | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq $templateFamily }
         foreach ($policy in $matchingIntents) {
             if (-not $processedSet.Add($policy.id)) { continue }
-            $resp = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            try {
+                $resp = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+            }
+            catch {
+                Write-Host "Error fetching assignments for intent $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
+                Write-Error -Message "Assignments fetch failed for '$($policy.displayName)': $($_.Exception.Message)"
+                continue
+            }
             $assignmentList = foreach ($a in $resp.value) {
                 [PSCustomObject]@{
                     Reason  = switch ($a.target.'@odata.type') {
@@ -303,12 +308,7 @@ function Get-IntuneUserDeviceAssignment {
     $appProt = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
     foreach ($policy in $appProt) {
         if (-not (Test-PlatformCompatibility -DeviceOS $deviceOS -Policy $policy)) { continue }
-        $assignmentsUri = switch ($policy.'@odata.type') {
-            "#microsoft.graph.androidManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection"     { "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
+        $assignmentsUri = Get-AppProtectionAssignmentUri -Policy $policy
         if (-not $assignmentsUri) { continue }
         try {
             $resp = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
@@ -344,20 +344,31 @@ function Get-IntuneUserDeviceAssignment {
         @{ Family = 'endpointSecurityAttackSurfaceReduction';       Bucket = 'AttackSurfaceProfiles'     }
         @{ Family = 'endpointSecurityAccountProtection';            Bucket = 'AccountProtectionProfiles' }
     )
+    # Fetch each entity set once and reuse it for every family below.
+    # $allConfigPolicies was already fetched for the Settings Catalog section above.
+    $allIntents = Get-IntuneEntities -EntityType "deviceManagement/intents"
+    Add-IntentTemplateFamilyInfo -IntentPolicies $allIntents
     foreach ($f in $esFamilies) {
         Write-Host "  Endpoint Security: $($f.Family)..." -ForegroundColor Yellow
         $processed = [System.Collections.Generic.HashSet[string]]::new()
-        & $processIntent $f.Family $f.Bucket $processed
+        & $processIntent $f.Family $f.Bucket $processed $allConfigPolicies $allIntents
     }
 
     # ── Applications ─────────────────────────────────────────────────────────
     Write-Host "  Applications..." -ForegroundColor Yellow
     $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-    $allApps = $appResponse.value
-    while ($appResponse.'@odata.nextLink') {
-        $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-        $allApps += $appResponse.value
+    $allApps = [System.Collections.Generic.List[object]]::new()
+    try {
+        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
+        if ($appResponse.value) { $allApps.AddRange([object[]]$appResponse.value) }
+        while ($appResponse.'@odata.nextLink') {
+            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
+            if ($appResponse.value) { $allApps.AddRange([object[]]$appResponse.value) }
+        }
+    }
+    catch {
+        Write-Host "Error fetching applications: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Error -Message "Applications fetch failed: $($_.Exception.Message)"
     }
 
     foreach ($app in $allApps) {

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
@@ -562,5 +562,5 @@ function Get-IntuneUserDeviceAssignment {
     Add-ExportData -ExportData $exportData -Category "Cloud PC Provisioning Policy"          -Items $relevantPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
     Add-ExportData -ExportData $exportData -Category "Cloud PC User Setting"                 -Items $relevantPolicies.CloudPCUserSettings         -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
 
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUserDeviceAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneUserDeviceAssignments.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Invoke-IntuneAssignmentChecker.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Invoke-IntuneAssignmentChecker.ps1
@@ -11,8 +11,11 @@ function Invoke-IntuneAssignmentChecker {
         [Parameter(Mandatory = $false, HelpMessage = "Certificate Thumbprint for authentication")]
         [string]$CertificateThumbprint,
 
-        [Parameter(Mandatory = $false, HelpMessage = "Client Secret for authentication")]
+        [Parameter(Mandatory = $false, HelpMessage = "Client Secret for authentication (plain text; retained for compatibility, prefer -ClientSecretCredential)")]
         [string]$ClientSecret,
+
+        [Parameter(Mandatory = $false, HelpMessage = "Client Secret as PSCredential (UserName = App ID, Password = client secret); preferred over -ClientSecret")]
+        [PSCredential]$ClientSecretCredential,
 
         [Parameter(Mandatory = $false, HelpMessage = "Pre-fetched Microsoft Graph access token (SecureString)")]
         [SecureString]$AccessToken,
@@ -144,6 +147,7 @@ function Invoke-IntuneAssignmentChecker {
     if ($TenantId)              { $connectParams['TenantId']              = $TenantId }
     if ($CertificateThumbprint) { $connectParams['CertificateThumbprint'] = $CertificateThumbprint }
     if ($ClientSecret)          { $connectParams['ClientSecret']          = $ClientSecret }
+    if ($ClientSecretCredential){ $connectParams['ClientSecretCredential'] = $ClientSecretCredential }
     if ($AccessToken -and $AccessToken.Length -gt 0) { $connectParams['AccessToken'] = $AccessToken }
     if ($Environment)           { $connectParams['Environment']           = $Environment }
 

--- a/Module/IntuneAssignmentChecker/Public/Search-IntunePolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Search-IntunePolicy.ps1
@@ -28,10 +28,17 @@ function Search-IntunePolicy {
 
     Write-Host "Searching for policies matching '$searchTerm'..." -ForegroundColor Yellow
 
-    $allSearchResults = [System.Collections.ArrayList]::new()
     $groupNameCache = @{}
-    $totalCategories = 18
-    $currentCategory = 0
+
+    # Cached group display name lookup shared by all row emitters
+    function Get-SearchTargetGroupName {
+        param([string]$GroupId)
+        if (-not $groupNameCache.ContainsKey($GroupId)) {
+            $groupInfo = Get-GroupInfo -GroupId $GroupId
+            $groupNameCache[$GroupId] = if ($groupInfo.Success) { $groupInfo.DisplayName } else { "Unknown Group" }
+        }
+        return $groupNameCache[$GroupId]
+    }
 
     # Helper function to resolve assignment targets for a matched policy
     function Resolve-SearchAssignments {
@@ -40,21 +47,20 @@ function Search-IntunePolicy {
             [string]$CategoryLabel,
             [string]$PolicyName,
             [string]$PolicyId,
-            [System.Collections.ArrayList]$Results,
-            [hashtable]$GroupCache
+            [System.Collections.Generic.List[object]]$Results
         )
 
         if ($null -eq $Assignments -or $Assignments.Count -eq 0) {
-            [void]$Results.Add([PSCustomObject]@{
-                Category       = $CategoryLabel
-                PolicyName     = $PolicyName
-                PolicyId       = $PolicyId
-                AssignmentType = "None"
-                TargetName     = "No assignments"
-                TargetGroupId  = ""
-                FilterName     = ""
-                FilterType     = ""
-            })
+            $Results.Add([PSCustomObject]@{
+                    Category       = $CategoryLabel
+                    PolicyName     = $PolicyName
+                    PolicyId       = $PolicyId
+                    AssignmentType = "None"
+                    TargetName     = "No assignments"
+                    TargetGroupId  = ""
+                    FilterName     = ""
+                    FilterType     = ""
+                })
             return
         }
 
@@ -65,26 +71,12 @@ function Search-IntunePolicy {
 
             if ($assignment.Reason -eq "Group Assignment") {
                 $targetGroupId = $assignment.GroupId
-                if ($GroupCache.ContainsKey($targetGroupId)) {
-                    $targetName = $GroupCache[$targetGroupId]
-                }
-                else {
-                    $groupInfo = Get-GroupInfo -GroupId $targetGroupId
-                    $targetName = if ($groupInfo.Success) { $groupInfo.DisplayName } else { "Unknown Group" }
-                    $GroupCache[$targetGroupId] = $targetName
-                }
+                $targetName = Get-SearchTargetGroupName -GroupId $targetGroupId
             }
             elseif ($assignment.Reason -eq "Group Exclusion") {
                 $assignmentType = "Exclude"
                 $targetGroupId = $assignment.GroupId
-                if ($GroupCache.ContainsKey($targetGroupId)) {
-                    $targetName = $GroupCache[$targetGroupId]
-                }
-                else {
-                    $groupInfo = Get-GroupInfo -GroupId $targetGroupId
-                    $targetName = if ($groupInfo.Success) { $groupInfo.DisplayName } else { "Unknown Group" }
-                    $GroupCache[$targetGroupId] = $targetName
-                }
+                $targetName = Get-SearchTargetGroupName -GroupId $targetGroupId
             }
             elseif ($assignment.Reason -eq "All Users") {
                 $targetName = "All Users"
@@ -108,358 +100,107 @@ function Search-IntunePolicy {
                 $filterType = switch ($assignment.FilterType) {
                     'include' { 'Include' }
                     'exclude' { 'Exclude' }
-                    default   { $assignment.FilterType }
+                    default { $assignment.FilterType }
                 }
             }
 
-            [void]$Results.Add([PSCustomObject]@{
-                Category       = $CategoryLabel
-                PolicyName     = $PolicyName
-                PolicyId       = $PolicyId
-                AssignmentType = $assignmentType
-                TargetName     = $targetName
-                TargetGroupId  = $targetGroupId
-                FilterName     = $filterName
-                FilterType     = $filterType
-            })
+            $Results.Add([PSCustomObject]@{
+                    Category       = $CategoryLabel
+                    PolicyName     = $PolicyName
+                    PolicyId       = $PolicyId
+                    AssignmentType = $assignmentType
+                    TargetName     = $targetName
+                    TargetGroupId  = $targetGroupId
+                    FilterName     = $filterName
+                    FilterType     = $filterType
+                })
         }
     }
 
-    # --- 1. Device Configurations ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Device Configurations..." -ForegroundColor Yellow
-    $searchDeviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    $matchedDeviceConfigs = $searchDeviceConfigs | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedDeviceConfigs) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Device Configuration" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
+    # Applications keep their historical row emission: raw target walk with the
+    # install intent appended to include targets (never to exclusions).
+    function Add-SearchAppRows {
+        param(
+            [object]$App,
+            [object[]]$RawAssignments,
+            [System.Collections.Generic.List[object]]$Results
+        )
 
-    # --- 2. Settings Catalog ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Settings Catalog Policies..." -ForegroundColor Yellow
-    $searchSettingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    # Exclude endpoint security policies (they will be handled separately)
-    $searchSettingsCatalogFiltered = $searchSettingsCatalog | Where-Object {
-        -not ($_.templateReference -and $_.templateReference.templateFamily -and $_.templateReference.templateFamily -like 'endpointSecurity*')
-    }
-    $matchedSettingsCatalog = $searchSettingsCatalogFiltered | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedSettingsCatalog) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Settings Catalog" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
+        $appName = if (-not [string]::IsNullOrWhiteSpace($App.displayName)) { $App.displayName } else { $App.name }
 
-    # --- 3. Compliance Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Compliance Policies..." -ForegroundColor Yellow
-    $searchCompliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    $matchedCompliancePolicies = $searchCompliancePolicies | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedCompliancePolicies) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Compliance Policy" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
-
-    # --- 4. App Protection Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching App Protection Policies..." -ForegroundColor Yellow
-    $searchAppProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    $matchedAppProtectionPolicies = $searchAppProtectionPolicies | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedAppProtectionPolicies) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $appProtAssignments = @()
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentReason = $null
-                    $groupId = $null
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { $assignmentReason = "All Users" }
-                        '#microsoft.graph.allDevicesAssignmentTarget' { $assignmentReason = "All Devices" }
-                        '#microsoft.graph.groupAssignmentTarget' {
-                            $assignmentReason = "Group Assignment"
-                            $groupId = $assignment.target.groupId
-                        }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                            $assignmentReason = "Group Exclusion"
-                            $groupId = $assignment.target.groupId
-                        }
-                    }
-                    if ($assignmentReason) {
-                        $appProtAssignments += [PSCustomObject]@{ Reason = $assignmentReason; GroupId = $groupId }
-                    }
-                }
-                Resolve-SearchAssignments -Assignments $appProtAssignments -CategoryLabel "App Protection Policy" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-            }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policyName): $($_.Exception.Message)" -ForegroundColor Red
-            }
-        }
-        else {
-            # Unknown app protection type - add as no assignments
-            [void]$allSearchResults.Add([PSCustomObject]@{
-                Category       = "App Protection Policy"
-                PolicyName     = $policyName
-                PolicyId       = $policy.id
-                AssignmentType = "None"
-                TargetName     = "No assignments"
-                TargetGroupId  = ""
-            })
-        }
-    }
-
-    # --- 5. App Configuration Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching App Configuration Policies..." -ForegroundColor Yellow
-    $searchAppConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    $matchedAppConfigPolicies = $searchAppConfigPolicies | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedAppConfigPolicies) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "App Configuration Policy" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
-
-    # --- 6. Applications ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Applications..." -ForegroundColor Yellow
-    $searchAppUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $searchAppResponse = Invoke-MgGraphRequest -Uri $searchAppUri -Method Get
-    $searchAllApps = $searchAppResponse.value
-    while ($searchAppResponse.'@odata.nextLink') {
-        $searchAppResponse = Invoke-MgGraphRequest -Uri $searchAppResponse.'@odata.nextLink' -Method Get
-        $searchAllApps += $searchAppResponse.value
-    }
-    $matchedApps = $searchAllApps | Where-Object {
-        -not ($_.isFeatured -or $_.isBuiltIn) -and
-        ($_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*")
-    }
-    foreach ($app in $matchedApps) {
-        $appName = if (-not [string]::IsNullOrWhiteSpace($app.displayName)) { $app.displayName } else { $app.name }
-        $appId = $app.id
-        try {
-            $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            if ($null -eq $assignmentResponse.value -or $assignmentResponse.value.Count -eq 0) {
-                [void]$allSearchResults.Add([PSCustomObject]@{
+        if ($null -eq $RawAssignments -or $RawAssignments.Count -eq 0) {
+            $Results.Add([PSCustomObject]@{
                     Category       = "Application"
                     PolicyName     = $appName
-                    PolicyId       = $appId
+                    PolicyId       = $App.id
                     AssignmentType = "None"
                     TargetName     = "No assignments"
                     TargetGroupId  = ""
                 })
-            }
-            else {
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentType = "Include"
-                    $targetName = ""
-                    $targetGroupId = ""
-                    $intentLabel = if ($assignment.intent) { " ($($assignment.intent))" } else { "" }
+            return
+        }
 
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' {
-                            $targetName = "All Users$intentLabel"
-                        }
-                        '#microsoft.graph.allDevicesAssignmentTarget' {
-                            $targetName = "All Devices$intentLabel"
-                        }
-                        '#microsoft.graph.groupAssignmentTarget' {
-                            $targetGroupId = $assignment.target.groupId
-                            if ($groupNameCache.ContainsKey($targetGroupId)) {
-                                $targetName = $groupNameCache[$targetGroupId]
-                            }
-                            else {
-                                $groupInfo = Get-GroupInfo -GroupId $targetGroupId
-                                $targetName = if ($groupInfo.Success) { $groupInfo.DisplayName } else { "Unknown Group" }
-                                $groupNameCache[$targetGroupId] = $targetName
-                            }
-                            $targetName = "$targetName$intentLabel"
-                        }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' {
-                            $assignmentType = "Exclude"
-                            $targetGroupId = $assignment.target.groupId
-                            if ($groupNameCache.ContainsKey($targetGroupId)) {
-                                $targetName = $groupNameCache[$targetGroupId]
-                            }
-                            else {
-                                $groupInfo = Get-GroupInfo -GroupId $targetGroupId
-                                $targetName = if ($groupInfo.Success) { $groupInfo.DisplayName } else { "Unknown Group" }
-                                $groupNameCache[$targetGroupId] = $targetName
-                            }
-                        }
-                        default { continue }
-                    }
+        foreach ($assignment in $RawAssignments) {
+            $assignmentType = "Include"
+            $targetName = ""
+            $targetGroupId = ""
+            $intentLabel = if ($assignment.intent) { " ($($assignment.intent))" } else { "" }
 
-                    [void]$allSearchResults.Add([PSCustomObject]@{
-                        Category       = "Application"
-                        PolicyName     = $appName
-                        PolicyId       = $appId
-                        AssignmentType = $assignmentType
-                        TargetName     = $targetName
-                        TargetGroupId  = $targetGroupId
-                    })
+            switch ($assignment.target.'@odata.type') {
+                '#microsoft.graph.allLicensedUsersAssignmentTarget' {
+                    $targetName = "All Users$intentLabel"
                 }
-            }
-        }
-        catch {
-            Write-Host "Error fetching assignments for app $($appName): $($_.Exception.Message)" -ForegroundColor Red
-        }
-    }
-
-    # --- 7. Platform Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Platform Scripts..." -ForegroundColor Yellow
-    $searchPlatformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    $matchedPlatformScripts = $searchPlatformScripts | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedPlatformScripts) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Platform Script" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
-
-    # --- 8. Proactive Remediation Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $searchHealthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    $matchedHealthScripts = $searchHealthScripts | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedHealthScripts) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Proactive Remediation Script" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
-
-    # --- 9-14. Endpoint Security (fetch configurationPolicies and intents once, filter for all 6 subtypes) ---
-    $searchConfigPolicies = Get-IntuneEntities -EntityType "configurationPolicies"
-    $searchAllIntents = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $searchAllIntents
-
-    $endpointSecurityFamilies = @(
-        @{ Family = "endpointSecurityAntivirus";                      Label = "Endpoint Security - Antivirus" }
-        @{ Family = "endpointSecurityDiskEncryption";                 Label = "Endpoint Security - Disk Encryption" }
-        @{ Family = "endpointSecurityFirewall";                       Label = "Endpoint Security - Firewall" }
-        @{ Family = "endpointSecurityEndpointDetectionAndResponse";   Label = "Endpoint Security - EDR" }
-        @{ Family = "endpointSecurityAttackSurfaceReduction";         Label = "Endpoint Security - ASR" }
-        @{ Family = "endpointSecurityAccountProtection";              Label = "Endpoint Security - Account Protection" }
-    )
-
-    $searchProcessedESIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    foreach ($esFamily in $endpointSecurityFamilies) {
-        $currentCategory++
-        Write-Host "[$currentCategory/$totalCategories] Searching $($esFamily.Label)..." -ForegroundColor Yellow
-
-        # Check configurationPolicies
-        $matchingConfigES = $searchConfigPolicies | Where-Object {
-            $_.templateReference -and $_.templateReference.templateFamily -eq $esFamily.Family -and
-            ($_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*")
-        }
-        foreach ($policy in $matchingConfigES) {
-            if ($searchProcessedESIds.Add($policy.id)) {
-                $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                Resolve-SearchAssignments -Assignments $assignments -CategoryLabel $esFamily.Label -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-            }
-        }
-
-        # Check intents (legacy)
-        $matchingIntentsES = $searchAllIntents | Where-Object {
-            $_.templateReference -and $_.templateReference.templateFamily -eq $esFamily.Family -and
-            ($_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*")
-        }
-        foreach ($policy in $matchingIntentsES) {
-            if ($searchProcessedESIds.Add($policy.id)) {
-                $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-                try {
-                    $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                    $intentAssignments = foreach ($assignment in $assignmentsResponse.value) {
-                        [PSCustomObject]@{
-                            Reason  = switch ($assignment.target.'@odata.type') {
-                                '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                                '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                                '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                                '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                                default { "Unknown" }
-                            }
-                            GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                        }
-                    }
-                    Resolve-SearchAssignments -Assignments $intentAssignments -CategoryLabel $esFamily.Label -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
+                '#microsoft.graph.allDevicesAssignmentTarget' {
+                    $targetName = "All Devices$intentLabel"
                 }
-                catch {
-                    Write-Host "Error fetching assignments for intent policy $($policyName): $($_.Exception.Message)" -ForegroundColor Red
+                '#microsoft.graph.groupAssignmentTarget' {
+                    $targetGroupId = $assignment.target.groupId
+                    $targetName = "$(Get-SearchTargetGroupName -GroupId $targetGroupId)$intentLabel"
                 }
+                '#microsoft.graph.exclusionGroupAssignmentTarget' {
+                    $assignmentType = "Exclude"
+                    $targetGroupId = $assignment.target.groupId
+                    $targetName = Get-SearchTargetGroupName -GroupId $targetGroupId
+                }
+                default { continue }
             }
+
+            $Results.Add([PSCustomObject]@{
+                    Category       = "Application"
+                    PolicyName     = $appName
+                    PolicyId       = $App.id
+                    AssignmentType = $assignmentType
+                    TargetName     = $targetName
+                    TargetGroupId  = $targetGroupId
+                })
         }
     }
 
-    # --- 15. Autopilot Deployment Profiles ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-    $searchAutopilotProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    $matchedAutopilotProfiles = $searchAutopilotProfiles | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-    foreach ($policy in $matchedAutopilotProfiles) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Autopilot Deployment Profile" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
+    $categories = Get-IntuneCategoryDefinition -Audience 'Search'
+
+    # Name matching happens BEFORE any per-entity assignment fetch: only entities
+    # passing this pre-filter ever trigger an assignments request.
+    $entityPreFilter = {
+        param($entity, $category)
+        $entity.displayName -like "*$searchTerm*" -or $entity.name -like "*$searchTerm*"
     }
 
-    # --- 16. Enrollment Status Page ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-    $searchEnrollmentConfigs = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $searchESPProfiles = $searchEnrollmentConfigs | Where-Object {
-        $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' -and
-        ($_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*")
-    }
-    foreach ($policy in $searchESPProfiles) {
-        $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $policy.id
-        Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Enrollment Status Page" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-    }
+    $processEntity = {
+        param($ctx)
 
-    # --- 17. Cloud PC Provisioning Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-    try {
-        $searchCloudPCProvisioning = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-        $matchedCloudPCProvisioning = $searchCloudPCProvisioning | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-        foreach ($policy in $matchedCloudPCProvisioning) {
-            $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-            Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Cloud PC Provisioning Policy" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
+        $results = $ctx.Buckets['SearchResults']
+
+        if ($ctx.Category.Id -eq 'Applications') {
+            Add-SearchAppRows -App $ctx.Entity -RawAssignments $ctx.RawAssignments -Results $results
+            return
         }
-    }
-    catch {
-        Write-Warning "Unable to fetch Cloud PC Provisioning Policies: $($_.Exception.Message)"
+
+        $policyName = if (-not [string]::IsNullOrWhiteSpace($ctx.Entity.displayName)) { $ctx.Entity.displayName } else { $ctx.Entity.name }
+        Resolve-SearchAssignments -Assignments $ctx.Assignments -CategoryLabel $ctx.Category.ExportCategory -PolicyName $policyName -PolicyId $ctx.Entity.id -Results $results
     }
 
-    # --- 18. Cloud PC User Settings ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Searching Cloud PC User Settings..." -ForegroundColor Yellow
-    try {
-        $searchCloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-        $matchedCloudPCUserSettings = $searchCloudPCUserSettings | Where-Object { $_.displayName -like "*$searchTerm*" -or $_.name -like "*$searchTerm*" }
-        foreach ($policy in $matchedCloudPCUserSettings) {
-            $policyName = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $policy.id
-            Resolve-SearchAssignments -Assignments $assignments -CategoryLabel "Cloud PC User Setting" -PolicyName $policyName -PolicyId $policy.id -Results $allSearchResults -GroupCache $groupNameCache
-        }
-    }
-    catch {
-        Write-Warning "Unable to fetch Cloud PC User Settings: $($_.Exception.Message)"
-    }
+    $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -EntityPreFilter $entityPreFilter -ShowProgress -ProgressVerb 'Searching'
+    $allSearchResults = $scanResult.Buckets['SearchResults']
 
     # --- Display Results ---
     $uniquePolicies = $allSearchResults | Select-Object -Property PolicyId -Unique
@@ -520,24 +261,24 @@ function Search-IntunePolicy {
     # --- Export ---
     $exportData = [System.Collections.ArrayList]::new()
     $null = $exportData.Add([PSCustomObject]@{
-        Category         = "Search Info"
-        Item             = "Search term: $searchTerm"
-        ScopeTags        = ""
-        AssignmentReason = "Found $totalMatches policies"
-        FilterName       = ""
-        FilterType       = ""
-    })
+            Category         = "Search Info"
+            Item             = "Search term: $searchTerm"
+            ScopeTags        = ""
+            AssignmentReason = "Found $totalMatches policies"
+            FilterName       = ""
+            FilterType       = ""
+        })
 
     foreach ($result in $allSearchResults) {
         $filterLabel = if ($result.FilterName) { " (Filter: $($result.FilterName) [$($result.FilterType)])" } else { "" }
         $null = $exportData.Add([PSCustomObject]@{
-            Category         = $result.Category
-            Item             = "$($result.PolicyName) (ID: $($result.PolicyId))"
-            ScopeTags        = ""
-            AssignmentReason = "[$($result.AssignmentType)] $($result.TargetName)$(if ($result.TargetGroupId) { " (ID: $($result.TargetGroupId))" })$filterLabel"
-            FilterName       = $result.FilterName
-            FilterType       = $result.FilterType
-        })
+                Category         = $result.Category
+                Item             = "$($result.PolicyName) (ID: $($result.PolicyId))"
+                ScopeTags        = ""
+                AssignmentReason = "[$($result.AssignmentType)] $($result.TargetName)$(if ($result.TargetGroupId) { " (ID: $($result.TargetGroupId))" })$filterLabel"
+                FilterName       = $result.FilterName
+                FilterType       = $result.FilterType
+            })
     }
 
     Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntunePolicySearch.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode

--- a/Module/IntuneAssignmentChecker/Public/Search-IntunePolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Search-IntunePolicy.ps1
@@ -540,5 +540,5 @@ function Search-IntunePolicy {
         })
     }
 
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntunePolicySearch.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntunePolicySearch.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Search-IntuneSetting.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Search-IntuneSetting.ps1
@@ -289,7 +289,7 @@ function Search-IntuneSetting {
     Write-Host (Get-Separator -Character "=") -ForegroundColor Cyan
 
     # ── Export ───────────────────────────────────────────────────────────
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneSettingSearch.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneSettingSearch.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }
 
 # ── Helper: extract configured value from a setting instance ─────────

--- a/Module/IntuneAssignmentChecker/Public/Search-IntuneSetting.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Search-IntuneSetting.ps1
@@ -52,7 +52,14 @@ function Search-IntuneSetting {
     }
 
     # ── Load setting definitions ─────────────────────────────────────────
-    $dataPath = Join-Path $PSScriptRoot ".." "Data" "SettingDefinitions.json"
+    # Prefer the user-writable copy (created by Update-IntuneSettingDefinition), fall back to the module Data file
+    $userDataPath = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'IntuneAssignmentChecker' 'SettingDefinitions.json'
+    $dataPath = if (Test-Path $userDataPath) {
+        $userDataPath
+    }
+    else {
+        Join-Path $PSScriptRoot ".." "Data" "SettingDefinitions.json"
+    }
     if (-not (Test-Path $dataPath)) {
         Write-Host "Setting definitions file not found at: $dataPath" -ForegroundColor Red
         Write-Host "Run Update-IntuneSettingDefinition first to download the catalog." -ForegroundColor Yellow

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
@@ -106,7 +106,7 @@ function Test-IntuneGroupMembership {
     else {
         # Single quotes escaped for the OData filter (F9)
         $escapedSimGroupName = $simGroupInput -replace "'", "''"
-        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
+        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
@@ -1029,5 +1029,5 @@ function Test-IntuneGroupMembership {
         })
     }
 
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupMembershipImpact.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupMembershipImpact.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
@@ -1,26 +1,13 @@
 function Test-IntuneGroupMembership {
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [string]$UserPrincipalNames,
-
-        [Parameter()]
-        [string]$DeviceNames,
-
-        [Parameter()]
-        [string]$SimulateTargetGroup,
-
-        [Parameter()]
-        [string]$GroupNames,
-
-        [Parameter()]
-        [switch]$ExportToCSV,
-
-        [Parameter()]
-        [string]$ExportPath,
-
-        [Parameter()]
-        [string]$ScopeTagFilter
+        [Parameter()][string]$UserPrincipalNames,
+        [Parameter()][string]$DeviceNames,
+        [Parameter()][string]$SimulateTargetGroup,
+        [Parameter()][string]$GroupNames,
+        [Parameter()][switch]$ExportToCSV,
+        [Parameter()][string]$ExportPath,
+        [Parameter()][string]$ScopeTagFilter
     )
 
     Write-Host "Group Membership Impact Analysis selected" -ForegroundColor Green
@@ -51,22 +38,15 @@ function Test-IntuneGroupMembership {
         }
     }
 
-    $simDeviceName = $null
-    if (-not [string]::IsNullOrWhiteSpace($simDeviceInput)) {
-        $simDeviceName = ($simDeviceInput -split ',')[0].Trim()
-    }
+    $simDeviceName = if (-not [string]::IsNullOrWhiteSpace($simDeviceInput)) { ($simDeviceInput -split ',')[0].Trim() } else { $null }
 
     # Get Target Group - SimulateTargetGroup takes precedence over GroupNames
-    if ($SimulateTargetGroup) {
-        $simGroupInput = $SimulateTargetGroup
-    }
-    elseif ($GroupNames) {
-        $simGroupInput = $GroupNames
-    }
+    $simGroupInput = if ($SimulateTargetGroup) { $SimulateTargetGroup }
+    elseif ($GroupNames) { $GroupNames }
     else {
         Write-Host "Please enter the Target Group name or Object ID: " -ForegroundColor Cyan
         Write-Host "Example: 'Marketing Team' or '12345678-1234-1234-1234-123456789012'" -ForegroundColor Gray
-        $simGroupInput = Read-Host
+        Read-Host
     }
 
     if ([string]::IsNullOrWhiteSpace($simGroupInput)) {
@@ -114,9 +94,6 @@ function Test-IntuneGroupMembership {
 
     # Resolve target group
     Write-Host "Looking up group: $simGroupInput" -ForegroundColor Yellow
-    $simTargetGroupId = $null
-    $simTargetGroupName = $null
-
     if ($simGroupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
         $simGroupInfo = Get-GroupInfo -GroupId $simGroupInput
         if (-not $simGroupInfo.Success) {
@@ -127,6 +104,7 @@ function Test-IntuneGroupMembership {
         $simTargetGroupName = $simGroupInfo.DisplayName
     }
     else {
+        # Single quotes escaped for the OData filter (F9)
         $escapedSimGroupName = $simGroupInput -replace "'", "''"
         $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
@@ -153,12 +131,10 @@ function Test-IntuneGroupMembership {
     $simCurrentGroupIds = @()
     try {
         if ($hasUserPersp) {
-            $simUserGroups = Get-GroupMemberships -ObjectId $simUserInfo.Id -ObjectType "User"
-            $simCurrentGroupIds += @($simUserGroups | Where-Object { $_.id } | ForEach-Object { $_.id })
+            $simCurrentGroupIds += @(Get-GroupMemberships -ObjectId $simUserInfo.Id -ObjectType "User" | Where-Object { $_.id } | ForEach-Object { $_.id })
         }
         if ($hasDevicePersp) {
-            $simDeviceGroups = Get-GroupMemberships -ObjectId $simDeviceInfo.Id -ObjectType "Device"
-            $simCurrentGroupIds += @($simDeviceGroups | Where-Object { $_.id } | ForEach-Object { $_.id })
+            $simCurrentGroupIds += @(Get-GroupMemberships -ObjectId $simDeviceInfo.Id -ObjectType "Device" | Where-Object { $_.id } | ForEach-Object { $_.id })
         }
         $simCurrentGroupIds = @($simCurrentGroupIds | Select-Object -Unique)
     }
@@ -176,186 +152,59 @@ function Test-IntuneGroupMembership {
     # Get target group's parent groups (transitive)
     $simTargetParentGroups = Get-TransitiveGroupMembership -GroupId $simTargetGroupId
     $simTargetAllGroupIds = @($simTargetGroupId)
-    if ($simTargetParentGroups) {
-        $simTargetAllGroupIds += $simTargetParentGroups.id
-    }
+    if ($simTargetParentGroups) { $simTargetAllGroupIds += $simTargetParentGroups.id }
 
     # Build simulated group set (current + target + target's parents, deduplicated)
     $simSimulatedGroupIds = @($simCurrentGroupIds + $simTargetAllGroupIds | Select-Object -Unique)
 
     Write-Host "Analyzing impact..." -ForegroundColor Yellow
 
-    $totalCategories = 18
-    $currentCategory = 0
+    # The legacy 18-step walk matches the UserContext registry entries (same display names, no
+    # Settings Catalog ES filter): reorder to the legacy sequence and make Autopilot/ESP fetchable.
+    $categoriesById = @{}
+    foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoriesById[$category.Id] = $category }
+    $categoriesById['DeploymentProfiles'].BucketOnly = $false
+    $categoriesById['ESPProfiles'].BucketOnly = $false
+    $categories = @(
+        @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies', 'AppConfigurationPolicies',
+            'Applications', 'PlatformScripts', 'HealthScripts', 'ESAntivirus', 'ESDiskEncryption', 'ESFirewall',
+            'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles',
+            'CloudPCProvisioningPolicies', 'CloudPCUserSettings') | ForEach-Object { $categoriesById[$_] })
 
-    # Initialize delta collections
-    $deltaPolicies = @{
-        DeviceConfigs               = [System.Collections.ArrayList]::new()
-        SettingsCatalog             = [System.Collections.ArrayList]::new()
-        CompliancePolicies          = [System.Collections.ArrayList]::new()
-        AppProtectionPolicies       = [System.Collections.ArrayList]::new()
-        AppConfigurationPolicies    = [System.Collections.ArrayList]::new()
-        AppsRequired                = [System.Collections.ArrayList]::new()
-        AppsAvailable               = [System.Collections.ArrayList]::new()
-        AppsUninstall               = [System.Collections.ArrayList]::new()
-        PlatformScripts             = [System.Collections.ArrayList]::new()
-        HealthScripts               = [System.Collections.ArrayList]::new()
-        AntivirusProfiles           = [System.Collections.ArrayList]::new()
-        DiskEncryptionProfiles      = [System.Collections.ArrayList]::new()
-        FirewallProfiles            = [System.Collections.ArrayList]::new()
-        EndpointDetectionProfiles   = [System.Collections.ArrayList]::new()
-        AttackSurfaceProfiles       = [System.Collections.ArrayList]::new()
-        AccountProtectionProfiles   = [System.Collections.ArrayList]::new()
-        DeploymentProfiles          = [System.Collections.ArrayList]::new()
-        ESPProfiles                 = [System.Collections.ArrayList]::new()
-        CloudPCProvisioningPolicies = [System.Collections.ArrayList]::new()
-        CloudPCUserSettings         = [System.Collections.ArrayList]::new()
+    # Legacy conflict-row category labels: registry export labels except these five
+    $conflictLabelOverrides = @{
+        SettingsCatalog             = 'Settings Catalog'
+        PlatformScripts             = 'Platform Script'
+        HealthScripts               = 'Proactive Remediation Script'
+        CloudPCProvisioningPolicies = 'Cloud PC Provisioning'
+        CloudPCUserSettings         = 'Cloud PC User Setting'
     }
+
     $conflictPolicies = [System.Collections.ArrayList]::new()
+    # One shared cache: each entity set (configurationPolicies, intents, ...) hits Graph once per run
+    $entityCache = @{}
+    $appProgress = @{ Current = 0; Total = $null; FilteredTotal = $null }
 
-    # --- Device Configurations ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Device Configurations..." -ForegroundColor Yellow
-    $simDeviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    foreach ($config in $simDeviceConfigs) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.DeviceConfigs.Add($config)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Device Configuration"; PolicyName = if ($config.displayName) { $config.displayName } else { $config.name }; PolicyId = $config.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
+    $processEntity = {
+        param($ctx)
 
-    # --- Settings Catalog ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-    $simSettingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    foreach ($policy in $simSettingsCatalog) {
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.SettingsCatalog.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Settings Catalog"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
+        $entity = $ctx.Entity
 
-    # --- Compliance Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Compliance Policies..." -ForegroundColor Yellow
-    $simCompliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    foreach ($policy in $simCompliancePolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.CompliancePolicies.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Compliance Policy"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
-
-    # --- App Protection Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching App Protection Policies..." -ForegroundColor Yellow
-    $simAppProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    foreach ($policy in $simAppProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $assignments = @()
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentReason = $null
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { $assignmentReason = "All Users" }
-                        '#microsoft.graph.groupAssignmentTarget' { $assignmentReason = "Group Assignment" }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { $assignmentReason = "Group Exclusion" }
-                    }
-                    if ($assignmentReason) {
-                        $assignments += @{ Reason = $assignmentReason; GroupId = $assignment.target.groupId }
-                    }
-                }
-
-                if ($assignments.Count -gt 0) {
-                    $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                    if ($delta.IsNewPolicy) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                        [void]$deltaPolicies.AppProtectionPolicies.Add($policy)
-                    }
-                    elseif ($delta.IsConflict) {
-                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "App Protection Policy"; PolicyName = $policy.displayName; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                    }
-                }
+        if ($ctx.Category.Kind -eq 'MobileApps') {
+            if ($null -eq $appProgress.Total) {
+                # Legacy progress counted against the unfiltered app list
+                $allCachedApps = @($entityCache[$ctx.Category.EntityType])
+                $appProgress.Total = $allCachedApps.Count
+                $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
             }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-            }
-        }
-    }
+            $appProgress.Current++
+            Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
 
-    # --- App Configuration Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching App Configuration Policies..." -ForegroundColor Yellow
-    $simAppConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    foreach ($policy in $simAppConfigPolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.AppConfigurationPolicies.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "App Configuration Policy"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
+            # Legacy per-app walk: current vs simulated inclusion/exclusion tracked side by side
+            $currentExcluded = $currentIncluded = $simExcluded = $simIncluded = $false
+            $appIntent = $simWinningTarget = $null
 
-    # --- Applications ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Applications..." -ForegroundColor Yellow
-    $simAppUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $simAppResponse = Invoke-MgGraphRequest -Uri $simAppUri -Method Get
-    $simAllApps = $simAppResponse.value
-    while ($simAppResponse.'@odata.nextLink') {
-        $simAppResponse = Invoke-MgGraphRequest -Uri $simAppResponse.'@odata.nextLink' -Method Get
-        $simAllApps += $simAppResponse.value
-    }
-    $simTotalApps = $simAllApps.Count
-    $simCurrentApp = 0
-
-    foreach ($app in $simAllApps) {
-        if ($app.isFeatured -or $app.isBuiltIn) { continue }
-
-        $simCurrentApp++
-        Write-Host "`rFetching Application $simCurrentApp of $simTotalApps" -NoNewline
-        $appId = $app.id
-
-        try {
-            $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            # Check current assignment status
-            $currentExcluded = $false
-            $currentIncluded = $false
-            $simExcluded = $false
-            $simIncluded = $false
-            $appIntent = $null
-            $simWinningTarget = $null
-
-            foreach ($assignment in $assignmentResponse.value) {
+            foreach ($assignment in $ctx.RawAssignments) {
                 $targetType = $assignment.target.'@odata.type'
                 $targetGroupId = $assignment.target.groupId
 
@@ -363,16 +212,9 @@ function Test-IntuneGroupMembership {
                     if ($simCurrentGroupIds -contains $targetGroupId) { $currentExcluded = $true }
                     if ($simSimulatedGroupIds -contains $targetGroupId) { $simExcluded = $true }
                 }
-                elseif ($targetType -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
-                    if ($includeReasons -contains "All Users") {
-                        $currentIncluded = $true
-                        $simIncluded = $true
-                        $appIntent = $assignment.intent
-                        if (-not $simWinningTarget) { $simWinningTarget = $assignment.target }
-                    }
-                }
-                elseif ($targetType -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-                    if ($includeReasons -contains "All Devices") {
+                elseif ($targetType -in @('#microsoft.graph.allLicensedUsersAssignmentTarget', '#microsoft.graph.allDevicesAssignmentTarget')) {
+                    $allTargetReason = if ($targetType -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { "All Users" } else { "All Devices" }
+                    if ($includeReasons -contains $allTargetReason) {
                         $currentIncluded = $true
                         $simIncluded = $true
                         $appIntent = $assignment.intent
@@ -397,466 +239,62 @@ function Test-IntuneGroupMembership {
                 if ($simWinningTarget) {
                     $filterSuffix = Format-AssignmentFilter -FilterId $simWinningTarget.deviceAndAppManagementAssignmentFilterId -FilterType $simWinningTarget.deviceAndAppManagementAssignmentFilterType
                 }
-                $appWithReason = $app.PSObject.Copy()
+                $appWithReason = $entity.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Group Assignment$filterSuffix" -Force
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentIntent' -NotePropertyValue $appIntent -Force
                 switch ($appIntent) {
-                    "required" { [void]$deltaPolicies.AppsRequired.Add($appWithReason) }
-                    "available" { [void]$deltaPolicies.AppsAvailable.Add($appWithReason) }
-                    "uninstall" { [void]$deltaPolicies.AppsUninstall.Add($appWithReason) }
+                    "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason) }
+                    "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason) }
+                    "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason) }
                 }
             }
             elseif ($currentExcluded -and $simExcluded) {
                 # Check if target group specifically includes this app while user is excluded
-                foreach ($assignment in $assignmentResponse.value) {
+                foreach ($assignment in $ctx.RawAssignments) {
                     if ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
                         $simTargetAllGroupIds -contains $assignment.target.groupId -and
                         $simCurrentGroupIds -notcontains $assignment.target.groupId) {
-                        $appName = if ($app.displayName) { $app.displayName } else { $app.name }
-                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Application ($($assignment.intent))"; PolicyName = $appName; PolicyId = $app.id; ConflictType = "Currently excluded; target group includes it" })
+                        $appName = if ($entity.displayName) { $entity.displayName } else { $entity.name }
+                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Application ($($assignment.intent))"; PolicyName = $appName; PolicyId = $entity.id; ConflictType = "Currently excluded; target group includes it" })
                         break
                     }
                 }
             }
-        }
-        catch {
-            Write-Host "`nError fetching assignments for app $($app.displayName): $($_.Exception.Message)" -ForegroundColor Red
-        }
-    }
-    Write-Host "`rFetching Application $simTotalApps of $simTotalApps" -NoNewline
-    Start-Sleep -Milliseconds 100
-    Write-Host ""
 
-    # --- Platform Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Platform Scripts..." -ForegroundColor Yellow
-    $simPlatformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    foreach ($script in $simPlatformScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
+            if ($appProgress.Current -eq $appProgress.FilteredTotal) {
+                # Legacy final overwrite before the next category header
+                Write-Host "`rFetching Application $($appProgress.Total) of $($appProgress.Total)" -NoNewline
+                Start-Sleep -Milliseconds 100
+                Write-Host ""
+            }
+            return
+        }
+
+        $assignments = $ctx.Assignments
+        if ($null -ne $ctx.RawAssignments) {
+            # App Protection and intent-phase Endpoint Security detail rows historically carried
+            # Reason/GroupId only, so the delta reason gets no filter suffix. App Protection
+            # additionally never matched All Devices targets.
+            $assignments = @($assignments | ForEach-Object { [PSCustomObject]@{ Reason = $_.Reason; GroupId = $_.GroupId } })
+            if ($ctx.Category.Kind -eq 'AppProtection') {
+                $assignments = @($assignments | Where-Object { $_.Reason -ne 'All Devices' })
+            }
+        }
+
         $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
         if ($delta.IsNewPolicy) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.PlatformScripts.Add($script)
+            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
+            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
         }
         elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Platform Script"; PolicyName = if ($script.displayName) { $script.displayName } else { $script.name }; PolicyId = $script.id; ConflictType = "Currently excluded; target group includes it" })
+            $conflictLabel = if ($conflictLabelOverrides.ContainsKey($ctx.Category.Id)) { $conflictLabelOverrides[$ctx.Category.Id] } else { $ctx.Category.ExportCategory }
+            $policyName = if ($entity.displayName) { $entity.displayName } else { $entity.name }
+            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = $conflictLabel; PolicyName = $policyName; PolicyId = $entity.id; ConflictType = "Currently excluded; target group includes it" })
         }
     }
 
-    # --- Proactive Remediation Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $simHealthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    foreach ($script in $simHealthScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.HealthScripts.Add($script)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Proactive Remediation Script"; PolicyName = if ($script.displayName) { $script.displayName } else { $script.name }; PolicyId = $script.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
-
-    # --- Endpoint Security: Antivirus ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Antivirus Policies..." -ForegroundColor Yellow
-    $simProcessedAntivirusIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForAntivirus = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingAntivirus = $simConfigPoliciesForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($simMatchingAntivirus) {
-        foreach ($policy in $simMatchingAntivirus) {
-            if ($simProcessedAntivirusIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AntivirusProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Antivirus"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForAntivirus = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForAntivirus
-    $simMatchingIntentsAntivirus = $simAllIntentsForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($simMatchingIntentsAntivirus) {
-        foreach ($policy in $simMatchingIntentsAntivirus) {
-            if ($simProcessedAntivirusIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AntivirusProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Antivirus"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Disk Encryption ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Disk Encryption Policies..." -ForegroundColor Yellow
-    $simProcessedDiskEncIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForDiskEnc = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingDiskEnc = $simConfigPoliciesForDiskEnc | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($simMatchingDiskEnc) {
-        foreach ($policy in $simMatchingDiskEnc) {
-            if ($simProcessedDiskEncIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.DiskEncryptionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Disk Encryption"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForDiskEnc = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForDiskEnc
-    $simMatchingIntentsDiskEnc = $simAllIntentsForDiskEnc | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($simMatchingIntentsDiskEnc) {
-        foreach ($policy in $simMatchingIntentsDiskEnc) {
-            if ($simProcessedDiskEncIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.DiskEncryptionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Disk Encryption"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Firewall ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Firewall Policies..." -ForegroundColor Yellow
-    $simProcessedFirewallIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForFirewall = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingFirewall = $simConfigPoliciesForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($simMatchingFirewall) {
-        foreach ($policy in $simMatchingFirewall) {
-            if ($simProcessedFirewallIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.FirewallProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Firewall"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForFirewall = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForFirewall
-    $simMatchingIntentsFirewall = $simAllIntentsForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($simMatchingIntentsFirewall) {
-        foreach ($policy in $simMatchingIntentsFirewall) {
-            if ($simProcessedFirewallIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.FirewallProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Firewall"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: EDR ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Endpoint Detection and Response Policies..." -ForegroundColor Yellow
-    $simProcessedEDRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForEDR = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingEDR = $simConfigPoliciesForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($simMatchingEDR) {
-        foreach ($policy in $simMatchingEDR) {
-            if ($simProcessedEDRIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.EndpointDetectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - EDR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForEDR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForEDR
-    $simMatchingIntentsEDR = $simAllIntentsForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($simMatchingIntentsEDR) {
-        foreach ($policy in $simMatchingIntentsEDR) {
-            if ($simProcessedEDRIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.EndpointDetectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - EDR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Attack Surface Reduction ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Attack Surface Reduction Policies..." -ForegroundColor Yellow
-    $simProcessedASRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForASR = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingASR = $simConfigPoliciesForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($simMatchingASR) {
-        foreach ($policy in $simMatchingASR) {
-            if ($simProcessedASRIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AttackSurfaceProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - ASR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForASR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForASR
-    $simMatchingIntentsASR = $simAllIntentsForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($simMatchingIntentsASR) {
-        foreach ($policy in $simMatchingIntentsASR) {
-            if ($simProcessedASRIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AttackSurfaceProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - ASR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Account Protection ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Account Protection Policies..." -ForegroundColor Yellow
-    $simProcessedAcctProtIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForAcctProt = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingAcctProt = $simConfigPoliciesForAcctProt | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($simMatchingAcctProt) {
-        foreach ($policy in $simMatchingAcctProt) {
-            if ($simProcessedAcctProtIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AccountProtectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Account Protection"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForAcctProt = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForAcctProt
-    $simMatchingIntentsAcctProt = $simAllIntentsForAcctProt | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($simMatchingIntentsAcctProt) {
-        foreach ($policy in $simMatchingIntentsAcctProt) {
-            if ($simProcessedAcctProtIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsNewPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                    [void]$deltaPolicies.AccountProtectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Account Protection"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-                }
-            }
-        }
-    }
-
-    # --- Autopilot Deployment Profiles ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-    $simAutoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($profile in $simAutoProfiles) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $profile.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $profile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.DeploymentProfiles.Add($profile)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Autopilot Deployment Profile"; PolicyName = if ($profile.displayName) { $profile.displayName } else { $profile.name }; PolicyId = $profile.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
-
-    # --- Enrollment Status Page Profiles ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-    $simEnrollmentConfigs = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $simEspProfiles = $simEnrollmentConfigs | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    foreach ($esp in $simEspProfiles) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsNewPolicy) {
-            $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-            [void]$deltaPolicies.ESPProfiles.Add($esp)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Enrollment Status Page"; PolicyName = if ($esp.displayName) { $esp.displayName } else { $esp.name }; PolicyId = $esp.id; ConflictType = "Currently excluded; target group includes it" })
-        }
-    }
-
-    # --- Windows 365 Cloud PC Provisioning Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-    try {
-        $simCloudPCProvisioning = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-        foreach ($policy in $simCloudPCProvisioning) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-            $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-            if ($delta.IsNewPolicy) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                [void]$deltaPolicies.CloudPCProvisioningPolicies.Add($policy)
-            }
-            elseif ($delta.IsConflict) {
-                [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Cloud PC Provisioning"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently excluded; target group includes it" })
-            }
-        }
-    }
-    catch {
-        Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-    }
-
-    # --- Windows 365 Cloud PC User Settings ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-    try {
-        $simCloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-        foreach ($setting in $simCloudPCUserSettings) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-            $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-            if ($delta.IsNewPolicy) {
-                $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.AssignmentReason -Force
-                [void]$deltaPolicies.CloudPCUserSettings.Add($setting)
-            }
-            elseif ($delta.IsConflict) {
-                [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Cloud PC User Setting"; PolicyName = if ($setting.displayName) { $setting.displayName } else { $setting.name }; PolicyId = $setting.id; ConflictType = "Currently excluded; target group includes it" })
-            }
-        }
-    }
-    catch {
-        Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-    }
+    $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -ShowProgress -EntityCache $entityCache
+    $deltaPolicies = $scanResult.Buckets
 
     # Apply scope tag filter if specified
     if ($ScopeTagFilter) {
@@ -879,29 +317,22 @@ function Test-IntuneGroupMembership {
     }
     Write-Host (Get-Separator -Character "=") -ForegroundColor Yellow
 
-    # Category display mapping
+    # Category display mapping (legacy section order and labels)
     $categoryDisplay = [ordered]@{
-        DeviceConfigs               = "Device Configurations"
-        SettingsCatalog             = "Settings Catalog Policies"
-        CompliancePolicies          = "Compliance Policies"
-        AppProtectionPolicies       = "App Protection Policies"
-        AppConfigurationPolicies    = "App Configuration Policies"
-        AppsRequired                = "Required Apps"
-        AppsAvailable               = "Available Apps"
-        AppsUninstall               = "Uninstall Apps"
-        PlatformScripts             = "Platform Scripts"
-        HealthScripts               = "Proactive Remediation Scripts"
-        AntivirusProfiles           = "Endpoint Security - Antivirus"
-        DiskEncryptionProfiles      = "Endpoint Security - Disk Encryption"
-        FirewallProfiles            = "Endpoint Security - Firewall"
-        EndpointDetectionProfiles   = "Endpoint Security - EDR"
-        AttackSurfaceProfiles       = "Endpoint Security - ASR"
-        AccountProtectionProfiles   = "Endpoint Security - Account Protection"
-        DeploymentProfiles          = "Autopilot Deployment Profiles"
-        ESPProfiles                 = "Enrollment Status Page Profiles"
-        CloudPCProvisioningPolicies = "Windows 365 Cloud PC Provisioning"
-        CloudPCUserSettings         = "Windows 365 Cloud PC User Settings"
+        DeviceConfigs = "Device Configurations"; SettingsCatalog = "Settings Catalog Policies"
+        CompliancePolicies = "Compliance Policies"; AppProtectionPolicies = "App Protection Policies"
+        AppConfigurationPolicies = "App Configuration Policies"; AppsRequired = "Required Apps"
+        AppsAvailable = "Available Apps"; AppsUninstall = "Uninstall Apps"
+        PlatformScripts = "Platform Scripts"; HealthScripts = "Proactive Remediation Scripts"
+        AntivirusProfiles = "Endpoint Security - Antivirus"; DiskEncryptionProfiles = "Endpoint Security - Disk Encryption"
+        FirewallProfiles = "Endpoint Security - Firewall"; EndpointDetectionProfiles = "Endpoint Security - EDR"
+        AttackSurfaceProfiles = "Endpoint Security - ASR"; AccountProtectionProfiles = "Endpoint Security - Account Protection"
+        DeploymentProfiles = "Autopilot Deployment Profiles"; ESPProfiles = "Enrollment Status Page Profiles"
+        CloudPCProvisioningPolicies = "Windows 365 Cloud PC Provisioning"; CloudPCUserSettings = "Windows 365 Cloud PC User Settings"
     }
+
+    # Legacy cell truncation: over Max chars becomes (Max - 3) chars plus "..."
+    $truncate = { param($Text, $Max) if ($Text.Length -gt $Max) { $Text.Substring(0, $Max - 3) + "..." } else { $Text } }
 
     $totalNewPolicies = 0
     foreach ($catKey in $categoryDisplay.Keys) {
@@ -919,15 +350,9 @@ function Test-IntuneGroupMembership {
             foreach ($item in $items) {
                 $itemName = if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } else { $item.name }
                 if (-not $itemName) { $itemName = "Unnamed" }
-                if ($itemName.Length -gt 47) { $itemName = $itemName.Substring(0, 44) + "..." }
-
                 $itemId = if ($item.id) { $item.id } else { "Unknown" }
-                if ($itemId.Length -gt 37) { $itemId = $itemId.Substring(0, 34) + "..." }
-
                 $reason = if ($item.AssignmentReason) { $item.AssignmentReason } else { "Unknown" }
-                if ($reason.Length -gt 27) { $reason = $reason.Substring(0, 24) + "..." }
-
-                Write-Host ("{0,-50} {1,-40} {2,-30}" -f $itemName, $itemId, $reason) -ForegroundColor White
+                Write-Host ("{0,-50} {1,-40} {2,-30}" -f (& $truncate $itemName 47), (& $truncate $itemId 37), (& $truncate $reason 27)) -ForegroundColor White
             }
             Write-Host $separator
         }
@@ -944,13 +369,7 @@ function Test-IntuneGroupMembership {
         Write-Host $separator
 
         foreach ($conflict in $conflictPolicies) {
-            $cName = $conflict.PolicyName
-            if ($cName.Length -gt 47) { $cName = $cName.Substring(0, 44) + "..." }
-            $cCat = $conflict.Category
-            if ($cCat.Length -gt 32) { $cCat = $cCat.Substring(0, 29) + "..." }
-            $cType = $conflict.ConflictType
-            if ($cType.Length -gt 32) { $cType = $cType.Substring(0, 29) + "..." }
-            Write-Host ("{0,-50} {1,-35} {2,-35}" -f $cName, $cCat, $cType) -ForegroundColor Red
+            Write-Host ("{0,-50} {1,-35} {2,-35}" -f (& $truncate $conflict.PolicyName 47), (& $truncate $conflict.Category 32), (& $truncate $conflict.ConflictType 32)) -ForegroundColor Red
         }
         Write-Host $separator
     }
@@ -1000,26 +419,22 @@ function Test-IntuneGroupMembership {
         AssignmentReason = if ($alreadyMember) { "Already a member" } else { "Impact Analysis" }
     })
 
-    Add-ExportData -ExportData $exportData -Category "NEW: Device Configuration" -Items $deltaPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Settings Catalog Policy" -Items $deltaPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Compliance Policy" -Items $deltaPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: App Protection Policy" -Items $deltaPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: App Configuration Policy" -Items $deltaPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Required App" -Items $deltaPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Available App" -Items $deltaPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Uninstall App" -Items $deltaPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Platform Script" -Items $deltaPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Proactive Remediation Script" -Items $deltaPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - Antivirus" -Items $deltaPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - Disk Encryption" -Items $deltaPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - Firewall" -Items $deltaPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - EDR" -Items $deltaPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - ASR" -Items $deltaPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Endpoint Security - Account Protection" -Items $deltaPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Autopilot Deployment Profile" -Items $deltaPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Enrollment Status Page Profile" -Items $deltaPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Cloud PC Provisioning Policy" -Items $deltaPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "NEW: Cloud PC User Setting" -Items $deltaPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
+    # Legacy CSV order and labels for the NEW-policy rows
+    $exportSections = [ordered]@{
+        'NEW: Device Configuration' = 'DeviceConfigs'; 'NEW: Settings Catalog Policy' = 'SettingsCatalog'
+        'NEW: Compliance Policy' = 'CompliancePolicies'; 'NEW: App Protection Policy' = 'AppProtectionPolicies'
+        'NEW: App Configuration Policy' = 'AppConfigurationPolicies'; 'NEW: Required App' = 'AppsRequired'
+        'NEW: Available App' = 'AppsAvailable'; 'NEW: Uninstall App' = 'AppsUninstall'
+        'NEW: Platform Script' = 'PlatformScripts'; 'NEW: Proactive Remediation Script' = 'HealthScripts'
+        'NEW: Endpoint Security - Antivirus' = 'AntivirusProfiles'; 'NEW: Endpoint Security - Disk Encryption' = 'DiskEncryptionProfiles'
+        'NEW: Endpoint Security - Firewall' = 'FirewallProfiles'; 'NEW: Endpoint Security - EDR' = 'EndpointDetectionProfiles'
+        'NEW: Endpoint Security - ASR' = 'AttackSurfaceProfiles'; 'NEW: Endpoint Security - Account Protection' = 'AccountProtectionProfiles'
+        'NEW: Autopilot Deployment Profile' = 'DeploymentProfiles'; 'NEW: Enrollment Status Page Profile' = 'ESPProfiles'
+        'NEW: Cloud PC Provisioning Policy' = 'CloudPCProvisioningPolicies'; 'NEW: Cloud PC User Setting' = 'CloudPCUserSettings'
+    }
+    foreach ($section in $exportSections.GetEnumerator()) {
+        Add-ExportData -ExportData $exportData -Category $section.Key -Items $deltaPolicies[$section.Value] -AssignmentReason { param($item) $item.AssignmentReason }
+    }
 
     foreach ($conflict in $conflictPolicies) {
         $null = $exportData.Add([PSCustomObject]@{

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
@@ -127,7 +127,8 @@ function Test-IntuneGroupMembership {
         $simTargetGroupName = $simGroupInfo.DisplayName
     }
     else {
-        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$simGroupInput'"
+        $escapedSimGroupName = $simGroupInput -replace "'", "''"
+        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
@@ -128,7 +128,7 @@ function Test-IntuneGroupRemoval {
     }
     else {
         $escapedSimGroupName = $simGroupInput -replace "'", "''"
-        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
+        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
@@ -195,190 +195,60 @@ function Test-IntuneGroupRemoval {
 
     Write-Host "Analyzing removal impact..." -ForegroundColor Yellow
 
-    $totalCategories = 18
-    $currentCategory = 0
-
-    # Initialize delta collections
-    $deltaPolicies = @{
-        DeviceConfigs               = [System.Collections.ArrayList]::new()
-        SettingsCatalog             = [System.Collections.ArrayList]::new()
-        CompliancePolicies          = [System.Collections.ArrayList]::new()
-        AppProtectionPolicies       = [System.Collections.ArrayList]::new()
-        AppConfigurationPolicies    = [System.Collections.ArrayList]::new()
-        AppsRequired                = [System.Collections.ArrayList]::new()
-        AppsAvailable               = [System.Collections.ArrayList]::new()
-        AppsUninstall               = [System.Collections.ArrayList]::new()
-        PlatformScripts             = [System.Collections.ArrayList]::new()
-        HealthScripts               = [System.Collections.ArrayList]::new()
-        AntivirusProfiles           = [System.Collections.ArrayList]::new()
-        DiskEncryptionProfiles      = [System.Collections.ArrayList]::new()
-        FirewallProfiles            = [System.Collections.ArrayList]::new()
-        EndpointDetectionProfiles   = [System.Collections.ArrayList]::new()
-        AttackSurfaceProfiles       = [System.Collections.ArrayList]::new()
-        AccountProtectionProfiles   = [System.Collections.ArrayList]::new()
-        DeploymentProfiles          = [System.Collections.ArrayList]::new()
-        ESPProfiles                 = [System.Collections.ArrayList]::new()
-        CloudPCProvisioningPolicies = [System.Collections.ArrayList]::new()
-        CloudPCUserSettings         = [System.Collections.ArrayList]::new()
+    # UserContext supplies this cmdlet's legacy display names and the unfiltered Settings
+    # Catalog fetch; reorder to the legacy 18-step walk and fetch the Autopilot/ESP
+    # categories that UserContext keeps bucket-only.
+    $categoryIndex = @{}
+    foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoryIndex[$category.Id] = $category }
+    $categories = foreach ($id in @(
+            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'AppConfigurationPolicies', 'Applications', 'PlatformScripts', 'HealthScripts',
+            'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection',
+            'ESAttackSurface', 'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles',
+            'CloudPCProvisioningPolicies', 'CloudPCUserSettings')) {
+        $categoryIndex[$id].BucketOnly = $false
+        $categoryIndex[$id]
     }
+
+    # Conflict rows keep the legacy category labels; where those differ from the registry
+    # export label the override below wins.
+    $conflictLabels = @{
+        SettingsCatalog             = 'Settings Catalog'
+        PlatformScripts             = 'Platform Script'
+        HealthScripts               = 'Proactive Remediation Script'
+        CloudPCProvisioningPolicies = 'Cloud PC Provisioning'
+        CloudPCUserSettings         = 'Cloud PC User Setting'
+    }
+
     $conflictPolicies = [System.Collections.ArrayList]::new()
+    # Caller-owned cache: each entity set is fetched from Graph once (the legacy walk
+    # re-fetched configurationPolicies and intents for every Endpoint Security family)
+    $entityCache = @{}
+    $appProgress = @{ Current = 0; Total = $null; FilteredTotal = $null }
 
-    # --- Device Configurations ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Device Configurations..." -ForegroundColor Yellow
-    $simDeviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
-    foreach ($config in $simDeviceConfigs) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $config | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.DeviceConfigs.Add($config)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Device Configuration"; PolicyName = if ($config.displayName) { $config.displayName } else { $config.name }; PolicyId = $config.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
+    $processEntity = {
+        param($ctx)
 
-    # --- Settings Catalog ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Settings Catalog Policies..." -ForegroundColor Yellow
-    $simSettingsCatalog = Get-IntuneEntities -EntityType "configurationPolicies"
-    foreach ($policy in $simSettingsCatalog) {
-        $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.SettingsCatalog.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Settings Catalog"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
+        $entity = $ctx.Entity
 
-    # --- Compliance Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Compliance Policies..." -ForegroundColor Yellow
-    $simCompliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
-    foreach ($policy in $simCompliancePolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.CompliancePolicies.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Compliance Policy"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
-
-    # --- App Protection Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching App Protection Policies..." -ForegroundColor Yellow
-    $simAppProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
-    foreach ($policy in $simAppProtectionPolicies) {
-        $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.iosManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments" }
-            "#microsoft.graph.windowsManagedAppProtection" { "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments" }
-            default { $null }
-        }
-
-        if ($assignmentsUri) {
-            try {
-                $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                $assignments = @()
-                foreach ($assignment in $assignmentResponse.value) {
-                    $assignmentReason = $null
-                    switch ($assignment.target.'@odata.type') {
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { $assignmentReason = "All Users" }
-                        '#microsoft.graph.groupAssignmentTarget' { $assignmentReason = "Group Assignment" }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { $assignmentReason = "Group Exclusion" }
-                    }
-                    if ($assignmentReason) {
-                        $rawFilterId   = $assignment.target.deviceAndAppManagementAssignmentFilterId
-                        $rawFilterType = $assignment.target.deviceAndAppManagementAssignmentFilterType
-                        $effFilterId   = $null
-                        $effFilterType = $null
-                        if ($rawFilterType -and $rawFilterType -ne 'none' -and $rawFilterId -and $rawFilterId -ne '00000000-0000-0000-0000-000000000000') {
-                            $effFilterId   = $rawFilterId
-                            $effFilterType = $rawFilterType
-                        }
-                        $assignments += @{
-                            Reason     = $assignmentReason
-                            GroupId    = $assignment.target.groupId
-                            FilterId   = $effFilterId
-                            FilterType = $effFilterType
-                        }
-                    }
-                }
-
-                if ($assignments.Count -gt 0) {
-                    $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                    if ($delta.IsLostPolicy) {
-                        $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                        [void]$deltaPolicies.AppProtectionPolicies.Add($policy)
-                    }
-                    elseif ($delta.IsConflict) {
-                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "App Protection Policy"; PolicyName = $policy.displayName; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                    }
-                }
+        if ($ctx.Category.Kind -eq 'MobileApps') {
+            if ($null -eq $appProgress.Total) {
+                $allCachedApps = @($entityCache[$ctx.Category.EntityType])
+                $appProgress.Total = $allCachedApps.Count
+                $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
             }
-            catch {
-                Write-Host "Error fetching assignments for policy $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
-            }
-        }
-    }
+            $appProgress.Current++
+            Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
 
-    # --- App Configuration Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching App Configuration Policies..." -ForegroundColor Yellow
-    $simAppConfigPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/mobileAppConfigurations"
-    foreach ($policy in $simAppConfigPolicies) {
-        $assignments = Get-IntuneAssignments -EntityType "mobileAppConfigurations" -EntityId $policy.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.AppConfigurationPolicies.Add($policy)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "App Configuration Policy"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
-
-    # --- Applications ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Applications..." -ForegroundColor Yellow
-    $simAppUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $simAppResponse = Invoke-MgGraphRequest -Uri $simAppUri -Method Get
-    $simAllApps = $simAppResponse.value
-    while ($simAppResponse.'@odata.nextLink') {
-        $simAppResponse = Invoke-MgGraphRequest -Uri $simAppResponse.'@odata.nextLink' -Method Get
-        $simAllApps += $simAppResponse.value
-    }
-    $simTotalApps = $simAllApps.Count
-    $simCurrentApp = 0
-
-    foreach ($app in $simAllApps) {
-        if ($app.isFeatured -or $app.isBuiltIn) { continue }
-
-        $simCurrentApp++
-        Write-Host "`rFetching Application $simCurrentApp of $simTotalApps" -NoNewline
-        $appId = $app.id
-
-        try {
-            $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-
-            # Check current assignment status
-            $currentExcluded = $false
-            $currentIncluded = $false
-            $simExcluded = $false
-            $simIncluded = $false
+            # Legacy app walk: track inclusion/exclusion against the current and the
+            # simulated group sets. The first matching inclusion wins the filter suffix,
+            # the last matching inclusion wins the intent.
+            $currentExcluded = $false; $currentIncluded = $false
+            $simExcluded = $false; $simIncluded = $false
             $currentAppIntent = $null
             $currentWinningTarget = $null
 
-            foreach ($assignment in $assignmentResponse.value) {
+            foreach ($assignment in $ctx.RawAssignments) {
                 $targetType = $assignment.target.'@odata.type'
                 $targetGroupId = $assignment.target.groupId
 
@@ -386,16 +256,9 @@ function Test-IntuneGroupRemoval {
                     if ($simCurrentGroupIds -contains $targetGroupId) { $currentExcluded = $true }
                     if ($simSimulatedGroupIds -contains $targetGroupId) { $simExcluded = $true }
                 }
-                elseif ($targetType -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
-                    if ($includeReasons -contains "All Users") {
-                        $currentIncluded = $true
-                        $simIncluded = $true
-                        $currentAppIntent = $assignment.intent
-                        if (-not $currentWinningTarget) { $currentWinningTarget = $assignment.target }
-                    }
-                }
-                elseif ($targetType -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-                    if ($includeReasons -contains "All Devices") {
+                elseif ($targetType -in @('#microsoft.graph.allLicensedUsersAssignmentTarget', '#microsoft.graph.allDevicesAssignmentTarget')) {
+                    $allTargetReason = if ($targetType -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { "All Users" } else { "All Devices" }
+                    if ($includeReasons -contains $allTargetReason) {
                         $currentIncluded = $true
                         $simIncluded = $true
                         $currentAppIntent = $assignment.intent
@@ -420,466 +283,65 @@ function Test-IntuneGroupRemoval {
                 if ($currentWinningTarget) {
                     $filterSuffix = Format-AssignmentFilter -FilterId $currentWinningTarget.deviceAndAppManagementAssignmentFilterId -FilterType $currentWinningTarget.deviceAndAppManagementAssignmentFilterType
                 }
-                $appWithReason = $app.PSObject.Copy()
+                $appWithReason = $entity.PSObject.Copy()
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue "Group Assignment$filterSuffix" -Force
                 $appWithReason | Add-Member -NotePropertyName 'AssignmentIntent' -NotePropertyValue $currentAppIntent -Force
                 switch ($currentAppIntent) {
-                    "required" { [void]$deltaPolicies.AppsRequired.Add($appWithReason) }
-                    "available" { [void]$deltaPolicies.AppsAvailable.Add($appWithReason) }
-                    "uninstall" { [void]$deltaPolicies.AppsUninstall.Add($appWithReason) }
+                    "required" { $ctx.Buckets['AppsRequired'].Add($appWithReason) }
+                    "available" { $ctx.Buckets['AppsAvailable'].Add($appWithReason) }
+                    "uninstall" { $ctx.Buckets['AppsUninstall'].Add($appWithReason) }
                 }
             }
             elseif ($currentExcluded -and $simExcluded) {
-                # Check if target group specifically includes this app while user is excluded
-                foreach ($assignment in $assignmentResponse.value) {
+                # Check if target group specifically includes this app while the subject is excluded
+                foreach ($assignment in $ctx.RawAssignments) {
                     if ($assignment.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
                         $simTargetAllGroupIds -contains $assignment.target.groupId -and
                         $simCurrentGroupIds -notcontains $assignment.target.groupId) {
-                        $appName = if ($app.displayName) { $app.displayName } else { $app.name }
-                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Application ($($assignment.intent))"; PolicyName = $appName; PolicyId = $app.id; ConflictType = "Currently included; removal would expose exclusion" })
+                        $appName = if ($entity.displayName) { $entity.displayName } else { $entity.name }
+                        [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Application ($($assignment.intent))"; PolicyName = $appName; PolicyId = $entity.id; ConflictType = "Currently included; removal would expose exclusion" })
                         break
                     }
                 }
             }
-        }
-        catch {
-            Write-Host "`nError fetching assignments for app $($app.displayName): $($_.Exception.Message)" -ForegroundColor Red
-        }
-    }
-    Write-Host "`rFetching Application $simTotalApps of $simTotalApps" -NoNewline
-    Start-Sleep -Milliseconds 100
-    Write-Host ""
 
-    # --- Platform Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Platform Scripts..." -ForegroundColor Yellow
-    $simPlatformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
-    foreach ($script in $simPlatformScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
+            if ($appProgress.Current -eq $appProgress.FilteredTotal) {
+                # Legacy final overwrite before the next category header
+                Write-Host "`rFetching Application $($appProgress.Total) of $($appProgress.Total)"
+            }
+            return
+        }
+
+        $assignments = $ctx.Assignments
+        if ($ctx.Category.Kind -eq 'AppProtection') {
+            # The legacy App Protection walk never mapped All Devices targets and only
+            # evaluated policies that had at least one relevant assignment
+            $assignments = @($assignments | Where-Object { $_.Reason -ne 'All Devices' })
+            if ($assignments.Count -eq 0) { return }
+        }
+        elseif ($ctx.Category.Kind -eq 'EndpointSecurity' -and $null -ne $ctx.RawAssignments) {
+            # Intent-phase detail rows historically carried no filter info, so the resolved
+            # status strings get no filter suffix (unlike the config-policy phase)
+            $assignments = @($assignments | ForEach-Object { [PSCustomObject]@{ Reason = $_.Reason; GroupId = $_.GroupId } })
+        }
+
         $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
         if ($delta.IsLostPolicy) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.PlatformScripts.Add($script)
+            $entity | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
+            $ctx.Buckets[$ctx.Category.BucketKeys[0]].Add($entity)
         }
         elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Platform Script"; PolicyName = if ($script.displayName) { $script.displayName } else { $script.name }; PolicyId = $script.id; ConflictType = "Currently included; removal would expose exclusion" })
+            $conflictCategory = if ($conflictLabels.ContainsKey($ctx.Category.Id)) { $conflictLabels[$ctx.Category.Id] } else { $ctx.Category.ExportCategory }
+            # Legacy App Protection conflict rows read displayName without a name fallback
+            $conflictName = if ($ctx.Category.Kind -eq 'AppProtection') { $entity.displayName }
+            elseif ($entity.displayName) { $entity.displayName }
+            else { $entity.name }
+            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = $conflictCategory; PolicyName = $conflictName; PolicyId = $entity.id; ConflictType = "Currently included; removal would expose exclusion" })
         }
     }
 
-    # --- Proactive Remediation Scripts ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Proactive Remediation Scripts..." -ForegroundColor Yellow
-    $simHealthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
-    foreach ($script in $simHealthScripts) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $script | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.HealthScripts.Add($script)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Proactive Remediation Script"; PolicyName = if ($script.displayName) { $script.displayName } else { $script.name }; PolicyId = $script.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
-
-    # --- Endpoint Security: Antivirus ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Antivirus Policies..." -ForegroundColor Yellow
-    $simProcessedAntivirusIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForAntivirus = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingAntivirus = $simConfigPoliciesForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($simMatchingAntivirus) {
-        foreach ($policy in $simMatchingAntivirus) {
-            if ($simProcessedAntivirusIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AntivirusProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Antivirus"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForAntivirus = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForAntivirus
-    $simMatchingIntentsAntivirus = $simAllIntentsForAntivirus | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAntivirus' }
-    if ($simMatchingIntentsAntivirus) {
-        foreach ($policy in $simMatchingIntentsAntivirus) {
-            if ($simProcessedAntivirusIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AntivirusProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Antivirus"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Disk Encryption ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Disk Encryption Policies..." -ForegroundColor Yellow
-    $simProcessedDiskEncIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForDiskEnc = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingDiskEnc = $simConfigPoliciesForDiskEnc | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($simMatchingDiskEnc) {
-        foreach ($policy in $simMatchingDiskEnc) {
-            if ($simProcessedDiskEncIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.DiskEncryptionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Disk Encryption"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForDiskEnc = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForDiskEnc
-    $simMatchingIntentsDiskEnc = $simAllIntentsForDiskEnc | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityDiskEncryption' }
-    if ($simMatchingIntentsDiskEnc) {
-        foreach ($policy in $simMatchingIntentsDiskEnc) {
-            if ($simProcessedDiskEncIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.DiskEncryptionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Disk Encryption"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Firewall ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Firewall Policies..." -ForegroundColor Yellow
-    $simProcessedFirewallIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForFirewall = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingFirewall = $simConfigPoliciesForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($simMatchingFirewall) {
-        foreach ($policy in $simMatchingFirewall) {
-            if ($simProcessedFirewallIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.FirewallProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Firewall"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForFirewall = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForFirewall
-    $simMatchingIntentsFirewall = $simAllIntentsForFirewall | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityFirewall' }
-    if ($simMatchingIntentsFirewall) {
-        foreach ($policy in $simMatchingIntentsFirewall) {
-            if ($simProcessedFirewallIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.FirewallProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Firewall"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: EDR ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Endpoint Detection and Response Policies..." -ForegroundColor Yellow
-    $simProcessedEDRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForEDR = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingEDR = $simConfigPoliciesForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($simMatchingEDR) {
-        foreach ($policy in $simMatchingEDR) {
-            if ($simProcessedEDRIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.EndpointDetectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - EDR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForEDR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForEDR
-    $simMatchingIntentsEDR = $simAllIntentsForEDR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityEndpointDetectionAndResponse' }
-    if ($simMatchingIntentsEDR) {
-        foreach ($policy in $simMatchingIntentsEDR) {
-            if ($simProcessedEDRIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.EndpointDetectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - EDR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Attack Surface Reduction ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Attack Surface Reduction Policies..." -ForegroundColor Yellow
-    $simProcessedASRIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForASR = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingASR = $simConfigPoliciesForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($simMatchingASR) {
-        foreach ($policy in $simMatchingASR) {
-            if ($simProcessedASRIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AttackSurfaceProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - ASR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForASR = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForASR
-    $simMatchingIntentsASR = $simAllIntentsForASR | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAttackSurfaceReduction' }
-    if ($simMatchingIntentsASR) {
-        foreach ($policy in $simMatchingIntentsASR) {
-            if ($simProcessedASRIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AttackSurfaceProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - ASR"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Endpoint Security: Account Protection ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Account Protection Policies..." -ForegroundColor Yellow
-    $simProcessedAcctProtIds = [System.Collections.Generic.HashSet[string]]::new()
-
-    $simConfigPoliciesForAcctProt = Get-IntuneEntities -EntityType "configurationPolicies"
-    $simMatchingAcctProt = $simConfigPoliciesForAcctProt | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($simMatchingAcctProt) {
-        foreach ($policy in $simMatchingAcctProt) {
-            if ($simProcessedAcctProtIds.Add($policy.id)) {
-                $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AccountProtectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Account Protection"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    $simAllIntentsForAcctProt = Get-IntuneEntities -EntityType "deviceManagement/intents"
-    Add-IntentTemplateFamilyInfo -IntentPolicies $simAllIntentsForAcctProt
-    $simMatchingIntentsAcctProt = $simAllIntentsForAcctProt | Where-Object { $_.templateReference -and $_.templateReference.templateFamily -eq 'endpointSecurityAccountProtection' }
-    if ($simMatchingIntentsAcctProt) {
-        foreach ($policy in $simMatchingIntentsAcctProt) {
-            if ($simProcessedAcctProtIds.Add($policy.id)) {
-                $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                $assignmentDetailsList = foreach ($assignment in $assignmentsResponse.value) {
-                    [PSCustomObject]@{
-                        Reason  = switch ($assignment.target.'@odata.type') {
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { "All Users" }
-                            '#microsoft.graph.allDevicesAssignmentTarget' { "All Devices" }
-                            '#microsoft.graph.groupAssignmentTarget' { "Group Assignment" }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { "Group Exclusion" }
-                            default { "Unknown" }
-                        }
-                        GroupId = if ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { $assignment.target.groupId } else { $null }
-                    }
-                }
-                $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignmentDetailsList -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-                if ($delta.IsLostPolicy) {
-                    $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                    [void]$deltaPolicies.AccountProtectionProfiles.Add($policy)
-                }
-                elseif ($delta.IsConflict) {
-                    [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Endpoint Security - Account Protection"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-                }
-            }
-        }
-    }
-
-    # --- Autopilot Deployment Profiles ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
-    $simAutoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($profile in $simAutoProfiles) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $profile.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $profile | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.DeploymentProfiles.Add($profile)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Autopilot Deployment Profile"; PolicyName = if ($profile.displayName) { $profile.displayName } else { $profile.name }; PolicyId = $profile.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
-
-    # --- Enrollment Status Page Profiles ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Enrollment Status Page Profiles..." -ForegroundColor Yellow
-    $simEnrollmentConfigs = Get-IntuneEntities -EntityType "deviceEnrollmentConfigurations"
-    $simEspProfiles = $simEnrollmentConfigs | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    foreach ($esp in $simEspProfiles) {
-        $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-        if ($delta.IsLostPolicy) {
-            $esp | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-            [void]$deltaPolicies.ESPProfiles.Add($esp)
-        }
-        elseif ($delta.IsConflict) {
-            [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Enrollment Status Page"; PolicyName = if ($esp.displayName) { $esp.displayName } else { $esp.name }; PolicyId = $esp.id; ConflictType = "Currently included; removal would expose exclusion" })
-        }
-    }
-
-    # --- Windows 365 Cloud PC Provisioning Policies ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC Provisioning Policies..." -ForegroundColor Yellow
-    try {
-        $simCloudPCProvisioning = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
-        foreach ($policy in $simCloudPCProvisioning) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-            $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-            if ($delta.IsLostPolicy) {
-                $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                [void]$deltaPolicies.CloudPCProvisioningPolicies.Add($policy)
-            }
-            elseif ($delta.IsConflict) {
-                [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Cloud PC Provisioning"; PolicyName = if ($policy.displayName) { $policy.displayName } else { $policy.name }; PolicyId = $policy.id; ConflictType = "Currently included; removal would expose exclusion" })
-            }
-        }
-    }
-    catch {
-        Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-    }
-
-    # --- Windows 365 Cloud PC User Settings ---
-    $currentCategory++
-    Write-Host "[$currentCategory/$totalCategories] Fetching Windows 365 Cloud PC User Settings..." -ForegroundColor Yellow
-    try {
-        $simCloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
-        foreach ($setting in $simCloudPCUserSettings) {
-            $assignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-            $delta = Resolve-SimulatedAssignmentDelta -Assignments $assignments -CurrentGroupIds $simCurrentGroupIds -SimulatedGroupIds $simSimulatedGroupIds -TargetGroupIds $simTargetAllGroupIds -IncludeReasons $includeReasons
-            if ($delta.IsLostPolicy) {
-                $setting | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $delta.CurrentStatus -Force
-                [void]$deltaPolicies.CloudPCUserSettings.Add($setting)
-            }
-            elseif ($delta.IsConflict) {
-                [void]$conflictPolicies.Add([PSCustomObject]@{ Category = "Cloud PC User Setting"; PolicyName = if ($setting.displayName) { $setting.displayName } else { $setting.name }; PolicyId = $setting.id; ConflictType = "Currently included; removal would expose exclusion" })
-            }
-        }
-    }
-    catch {
-        Write-Verbose "Skipping - Windows 365 may not be licensed for this tenant"
-    }
+    $scanResult = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity $processEntity -ShowProgress -EntityCache $entityCache
+    $deltaPolicies = $scanResult.Buckets
 
     # Apply scope tag filter if specified
     if ($ScopeTagFilter) {
@@ -899,37 +361,39 @@ function Test-IntuneGroupRemoval {
     Write-Host "  Target Group: $simTargetGroupName (ID: $simTargetGroupId)" -ForegroundColor White
     Write-Host (Get-Separator -Character "=") -ForegroundColor Yellow
 
-    # Category display mapping
-    $categoryDisplay = [ordered]@{
-        DeviceConfigs               = "Device Configurations"
-        SettingsCatalog             = "Settings Catalog Policies"
-        CompliancePolicies          = "Compliance Policies"
-        AppProtectionPolicies       = "App Protection Policies"
-        AppConfigurationPolicies    = "App Configuration Policies"
-        AppsRequired                = "Required Apps"
-        AppsAvailable               = "Available Apps"
-        AppsUninstall               = "Uninstall Apps"
-        PlatformScripts             = "Platform Scripts"
-        HealthScripts               = "Proactive Remediation Scripts"
-        AntivirusProfiles           = "Endpoint Security - Antivirus"
-        DiskEncryptionProfiles      = "Endpoint Security - Disk Encryption"
-        FirewallProfiles            = "Endpoint Security - Firewall"
-        EndpointDetectionProfiles   = "Endpoint Security - EDR"
-        AttackSurfaceProfiles       = "Endpoint Security - ASR"
-        AccountProtectionProfiles   = "Endpoint Security - Account Protection"
-        DeploymentProfiles          = "Autopilot Deployment Profiles"
-        ESPProfiles                 = "Enrollment Status Page Profiles"
-        CloudPCProvisioningPolicies = "Windows 365 Cloud PC Provisioning"
-        CloudPCUserSettings         = "Windows 365 Cloud PC User Settings"
-    }
+    # Per-bucket display and export labels in the legacy order
+    $categoryTable = @(
+        @{ Key = 'DeviceConfigs'; Display = 'Device Configurations'; Export = 'Device Configuration' }
+        @{ Key = 'SettingsCatalog'; Display = 'Settings Catalog Policies'; Export = 'Settings Catalog Policy' }
+        @{ Key = 'CompliancePolicies'; Display = 'Compliance Policies'; Export = 'Compliance Policy' }
+        @{ Key = 'AppProtectionPolicies'; Display = 'App Protection Policies'; Export = 'App Protection Policy' }
+        @{ Key = 'AppConfigurationPolicies'; Display = 'App Configuration Policies'; Export = 'App Configuration Policy' }
+        @{ Key = 'AppsRequired'; Display = 'Required Apps'; Export = 'Required App' }
+        @{ Key = 'AppsAvailable'; Display = 'Available Apps'; Export = 'Available App' }
+        @{ Key = 'AppsUninstall'; Display = 'Uninstall Apps'; Export = 'Uninstall App' }
+        @{ Key = 'PlatformScripts'; Display = 'Platform Scripts'; Export = 'Platform Script' }
+        @{ Key = 'HealthScripts'; Display = 'Proactive Remediation Scripts'; Export = 'Proactive Remediation Script' }
+        @{ Key = 'AntivirusProfiles'; Display = 'Endpoint Security - Antivirus'; Export = 'Endpoint Security - Antivirus' }
+        @{ Key = 'DiskEncryptionProfiles'; Display = 'Endpoint Security - Disk Encryption'; Export = 'Endpoint Security - Disk Encryption' }
+        @{ Key = 'FirewallProfiles'; Display = 'Endpoint Security - Firewall'; Export = 'Endpoint Security - Firewall' }
+        @{ Key = 'EndpointDetectionProfiles'; Display = 'Endpoint Security - EDR'; Export = 'Endpoint Security - EDR' }
+        @{ Key = 'AttackSurfaceProfiles'; Display = 'Endpoint Security - ASR'; Export = 'Endpoint Security - ASR' }
+        @{ Key = 'AccountProtectionProfiles'; Display = 'Endpoint Security - Account Protection'; Export = 'Endpoint Security - Account Protection' }
+        @{ Key = 'DeploymentProfiles'; Display = 'Autopilot Deployment Profiles'; Export = 'Autopilot Deployment Profile' }
+        @{ Key = 'ESPProfiles'; Display = 'Enrollment Status Page Profiles'; Export = 'Enrollment Status Page Profile' }
+        @{ Key = 'CloudPCProvisioningPolicies'; Display = 'Windows 365 Cloud PC Provisioning'; Export = 'Cloud PC Provisioning Policy' }
+        @{ Key = 'CloudPCUserSettings'; Display = 'Windows 365 Cloud PC User Settings'; Export = 'Cloud PC User Setting' }
+    )
+
+    # Legacy column truncation (cut at max, keep max-3 characters plus "...")
+    $truncate = { param($text, $max) if ($text.Length -gt $max) { $text.Substring(0, $max - 3) + "..." } else { $text } }
 
     $totalLostPolicies = 0
-    foreach ($catKey in $categoryDisplay.Keys) {
-        $items = $deltaPolicies[$catKey]
+    foreach ($cat in $categoryTable) {
+        $items = $deltaPolicies[$cat.Key]
         if ($items.Count -gt 0) {
-            $catLabel = $categoryDisplay[$catKey]
             $totalLostPolicies += $items.Count
-            Write-Host "`n------- LOST: $catLabel ($($items.Count)) -------" -ForegroundColor Red
+            Write-Host "`n------- LOST: $($cat.Display) ($($items.Count)) -------" -ForegroundColor Red
             $headerFormat = "{0,-50} {1,-40} {2,-30}" -f "Policy Name", "Policy ID", "Assignment Reason"
             $separator = Get-Separator
             Write-Host $separator
@@ -939,14 +403,11 @@ function Test-IntuneGroupRemoval {
             foreach ($item in $items) {
                 $itemName = if (-not [string]::IsNullOrWhiteSpace($item.displayName)) { $item.displayName } else { $item.name }
                 if (-not $itemName) { $itemName = "Unnamed" }
-                if ($itemName.Length -gt 47) { $itemName = $itemName.Substring(0, 44) + "..." }
-
+                $itemName = & $truncate $itemName 47
                 $itemId = if ($item.id) { $item.id } else { "Unknown" }
-                if ($itemId.Length -gt 37) { $itemId = $itemId.Substring(0, 34) + "..." }
-
+                $itemId = & $truncate $itemId 37
                 $reason = if ($item.AssignmentReason) { $item.AssignmentReason } else { "Unknown" }
-                if ($reason.Length -gt 27) { $reason = $reason.Substring(0, 24) + "..." }
-
+                $reason = & $truncate $reason 27
                 Write-Host ("{0,-50} {1,-40} {2,-30}" -f $itemName, $itemId, $reason) -ForegroundColor White
             }
             Write-Host $separator
@@ -964,12 +425,9 @@ function Test-IntuneGroupRemoval {
         Write-Host $separator
 
         foreach ($conflict in $conflictPolicies) {
-            $cName = $conflict.PolicyName
-            if ($cName.Length -gt 47) { $cName = $cName.Substring(0, 44) + "..." }
-            $cCat = $conflict.Category
-            if ($cCat.Length -gt 32) { $cCat = $cCat.Substring(0, 29) + "..." }
-            $cType = $conflict.ConflictType
-            if ($cType.Length -gt 32) { $cType = $cType.Substring(0, 29) + "..." }
+            $cName = & $truncate $conflict.PolicyName 47
+            $cCat = & $truncate $conflict.Category 32
+            $cType = & $truncate $conflict.ConflictType 32
             Write-Host ("{0,-50} {1,-35} {2,-35}" -f $cName, $cCat, $cType) -ForegroundColor Red
         }
         Write-Host $separator
@@ -979,7 +437,7 @@ function Test-IntuneGroupRemoval {
     Write-Host "`n=== Impact Summary ===" -ForegroundColor Cyan
     Write-Host "Removing $subjectLabel from '$simTargetGroupName' would result in:" -ForegroundColor White
 
-    $categoryCount = ($categoryDisplay.Keys | Where-Object { $deltaPolicies[$_].Count -gt 0 }).Count
+    $categoryCount = ($categoryTable | Where-Object { $deltaPolicies[$_.Key].Count -gt 0 }).Count
     $conflictCount = $conflictPolicies.Count
 
     if ($totalLostPolicies -eq 0 -and $conflictCount -eq 0) {
@@ -1005,26 +463,9 @@ function Test-IntuneGroupRemoval {
         AssignmentReason = "Removal Impact Analysis"
     })
 
-    Add-ExportData -ExportData $exportData -Category "LOST: Device Configuration" -Items $deltaPolicies.DeviceConfigs -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Settings Catalog Policy" -Items $deltaPolicies.SettingsCatalog -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Compliance Policy" -Items $deltaPolicies.CompliancePolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: App Protection Policy" -Items $deltaPolicies.AppProtectionPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: App Configuration Policy" -Items $deltaPolicies.AppConfigurationPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Required App" -Items $deltaPolicies.AppsRequired -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Available App" -Items $deltaPolicies.AppsAvailable -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Uninstall App" -Items $deltaPolicies.AppsUninstall -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Platform Script" -Items $deltaPolicies.PlatformScripts -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Proactive Remediation Script" -Items $deltaPolicies.HealthScripts -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - Antivirus" -Items $deltaPolicies.AntivirusProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - Disk Encryption" -Items $deltaPolicies.DiskEncryptionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - Firewall" -Items $deltaPolicies.FirewallProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - EDR" -Items $deltaPolicies.EndpointDetectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - ASR" -Items $deltaPolicies.AttackSurfaceProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Endpoint Security - Account Protection" -Items $deltaPolicies.AccountProtectionProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Autopilot Deployment Profile" -Items $deltaPolicies.DeploymentProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Enrollment Status Page Profile" -Items $deltaPolicies.ESPProfiles -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Cloud PC Provisioning Policy" -Items $deltaPolicies.CloudPCProvisioningPolicies -AssignmentReason { param($item) $item.AssignmentReason }
-    Add-ExportData -ExportData $exportData -Category "LOST: Cloud PC User Setting" -Items $deltaPolicies.CloudPCUserSettings -AssignmentReason { param($item) $item.AssignmentReason }
+    foreach ($cat in $categoryTable) {
+        Add-ExportData -ExportData $exportData -Category "LOST: $($cat.Export)" -Items $deltaPolicies[$cat.Key] -AssignmentReason { param($item) $item.AssignmentReason }
+    }
 
     foreach ($conflict in $conflictPolicies) {
         $null = $exportData.Add([PSCustomObject]@{

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
@@ -1034,5 +1034,5 @@ function Test-IntuneGroupRemoval {
         })
     }
 
-    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupRemovalImpact.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath
+    Export-ResultsIfRequested -ExportData $exportData -DefaultFileName "IntuneGroupRemovalImpact.csv" -ForceExport:$ExportToCSV -CustomExportPath $ExportPath -ExportToCSV:$ExportToCSV -ParameterMode:$parameterMode
 }

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
@@ -127,7 +127,8 @@ function Test-IntuneGroupRemoval {
         $simTargetGroupName = $simGroupInfo.DisplayName
     }
     else {
-        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$simGroupInput'"
+        $escapedSimGroupName = $simGroupInput -replace "'", "''"
+        $simGroupUri = "$GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {

--- a/Module/IntuneAssignmentChecker/Public/Update-IntuneSettingDefinition.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Update-IntuneSettingDefinition.ps1
@@ -8,7 +8,12 @@ function Update-IntuneSettingDefinition {
         return
     }
 
-    $dataPath = Join-Path $PSScriptRoot ".." "Data" "SettingDefinitions.json"
+    # Write to a user-writable location (module Data folder is read-only for PSGallery installs)
+    $dataDir = Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'IntuneAssignmentChecker'
+    if (-not (Test-Path $dataDir)) {
+        $null = New-Item -Path $dataDir -ItemType Directory -Force
+    }
+    $dataPath = Join-Path $dataDir 'SettingDefinitions.json'
 
     Write-Host "Fetching setting definitions from Microsoft Graph..." -ForegroundColor Yellow
     Write-Host "This may take a few minutes (there are thousands of definitions)." -ForegroundColor Gray

--- a/Module/IntuneAssignmentChecker/html-export.ps1
+++ b/Module/IntuneAssignmentChecker/html-export.ps1
@@ -668,18 +668,7 @@ function Export-HTMLReport {
     $appProtectionPolicies = Get-IntuneEntities -EntityType "deviceAppManagement/managedAppPolicies"
     foreach ($policy in $appProtectionPolicies) {
         $policyType = $policy.'@odata.type'
-        $assignmentsUri = switch ($policyType) {
-            "#microsoft.graph.androidManagedAppProtection" {
-                "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments"
-            }
-            "#microsoft.graph.iosManagedAppProtection" {
-                "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments"
-            }
-            "#microsoft.graph.windowsManagedAppProtection" {
-                "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments"
-            }
-            default { $null }
-        }
+        $assignmentsUri = Get-AppProtectionAssignmentUri -Policy $policy
 
         if ($assignmentsUri) {
             try {
@@ -891,11 +880,18 @@ function Export-HTMLReport {
     # Get Apps
     Write-Host "Fetching Applications..." -ForegroundColor Yellow
     $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
-    $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
-    $allApps = $appResponse.value
-    while ($appResponse.'@odata.nextLink') {
-        $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
-        $allApps += $appResponse.value
+    $allApps = [System.Collections.Generic.List[object]]::new()
+    try {
+        $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
+        if ($appResponse.value) { $allApps.AddRange([object[]]$appResponse.value) }
+        while ($appResponse.'@odata.nextLink') {
+            $appResponse = Invoke-MgGraphRequest -Uri $appResponse.'@odata.nextLink' -Method Get
+            if ($appResponse.value) { $allApps.AddRange([object[]]$appResponse.value) }
+        }
+    }
+    catch {
+        Write-Host "Error fetching applications: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Error -Message "Applications fetch failed: $($_.Exception.Message)"
     }
 
     foreach ($app in $allApps) {
@@ -906,7 +902,14 @@ function Export-HTMLReport {
 
         $appId = $app.id
         $assignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
-        $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
+        try {
+            $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
+        }
+        catch {
+            Write-Host "Error fetching assignments for app $($app.displayName): $($_.Exception.Message)" -ForegroundColor Red
+            Write-Error -Message "Assignments fetch failed for '$($app.displayName)': $($_.Exception.Message)"
+            continue
+        }
 
         foreach ($assignment in $assignmentResponse.value) {
             # Get-HtmlAssignmentInfo expects an array of assignment objects.

--- a/Module/IntuneAssignmentChecker/html-export.ps1
+++ b/Module/IntuneAssignmentChecker/html-export.ps1
@@ -1,13 +1,8 @@
-$context = Get-MgContext
-$environment = $context.Environment
-
-$GraphEndpoint = switch ($environment) {
-    "Global" { "https://graph.microsoft.com" }
-    "USGov" { "https://graph.microsoft.us" }
-    "USGovDoD" { "https://dod-graph.microsoft.us" }
-}
-# Function to get assignment information
-function Get-AssignmentInfo {
+# Function to get assignment information for the HTML report.
+# Differs from the module's private Get-HtmlAssignmentInfo: aggregates all assignments
+# (not just the first), understands raw Graph API assignment objects (target with
+# @odata.type), and returns a combined Filter display string.
+function Get-HtmlAssignmentInfo {
     param (
         [Parameter(Mandatory = $true)]
         [AllowNull()]
@@ -135,58 +130,9 @@ function Get-AssignmentInfo {
     }
 }
 
-$script:IntentTemplateSubtypeToFamily = @{
-    'antivirus'                = 'endpointSecurityAntivirus'
-    'diskEncryption'           = 'endpointSecurityDiskEncryption'
-    'firewall'                 = 'endpointSecurityFirewall'
-    'endpointDetectionReponse' = 'endpointSecurityEndpointDetectionAndResponse'
-    'attackSurfaceReduction'   = 'endpointSecurityAttackSurfaceReduction'
-    'accountProtection'        = 'endpointSecurityAccountProtection'
-}
-$script:TemplateIdToFamilyCache = $null
-
-function Get-IntentTemplateFamilyLookup {
-    if ($null -ne $script:TemplateIdToFamilyCache) {
-        return $script:TemplateIdToFamilyCache
-    }
-
-    $script:TemplateIdToFamilyCache = @{}
-    try {
-        $templates = Get-IntuneEntities -EntityType "deviceManagement/templates"
-        foreach ($template in $templates) {
-            $subtype = $template.templateSubtype
-            if ($subtype -and $script:IntentTemplateSubtypeToFamily.ContainsKey($subtype)) {
-                $script:TemplateIdToFamilyCache[$template.id] = $script:IntentTemplateSubtypeToFamily[$subtype]
-            }
-        }
-    }
-    catch {
-        Write-Warning "Unable to fetch deviceManagement/templates for intent enrichment: $($_.Exception.Message)"
-    }
-
-    return $script:TemplateIdToFamilyCache
-}
-
-function Add-IntentTemplateFamilyInfo {
-    param (
-        [Parameter(Mandatory = $false)]
-        $IntentPolicies
-    )
-
-    if (-not $IntentPolicies) { return }
-
-    $lookup = Get-IntentTemplateFamilyLookup
-
-    foreach ($intent in $IntentPolicies) {
-        if ($intent.templateId -and $lookup.ContainsKey($intent.templateId)) {
-            if (-not $intent.templateReference) {
-                $intent | Add-Member -NotePropertyName 'templateReference' -NotePropertyValue @{
-                    templateFamily = $lookup[$intent.templateId]
-                }
-            }
-        }
-    }
-}
+# Intent template family enrichment ($script:IntentTemplateSubtypeToFamily,
+# Get-IntentTemplateFamilyLookup, Add-IntentTemplateFamilyInfo) comes from the
+# module scope, since this file is dot-sourced inside the module.
 
 function Export-HTMLReport {
     param (
@@ -665,7 +611,7 @@ function Export-HTMLReport {
     $deviceConfigs = Get-IntuneEntities -EntityType "deviceConfigurations"
     foreach ($config in $deviceConfigs) {
         $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.DeviceConfigs += @{
             Name           = $config.displayName
             ID             = $config.id
@@ -686,7 +632,7 @@ function Export-HTMLReport {
             continue
         }
         $assignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.SettingsCatalog += @{
             Name           = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
             ID             = $policy.id
@@ -705,7 +651,7 @@ function Export-HTMLReport {
     $compliancePolicies = Get-IntuneEntities -EntityType "deviceCompliancePolicies"
     foreach ($policy in $compliancePolicies) {
         $assignments = Get-IntuneAssignments -EntityType "deviceCompliancePolicies" -EntityId $policy.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.CompliancePolicies += @{
             Name           = $policy.displayName
             ID             = $policy.id
@@ -724,13 +670,13 @@ function Export-HTMLReport {
         $policyType = $policy.'@odata.type'
         $assignmentsUri = switch ($policyType) {
             "#microsoft.graph.androidManagedAppProtection" {
-                "$GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments"
+                "$script:GraphEndpoint/beta/deviceAppManagement/androidManagedAppProtections('$($policy.id)')/assignments"
             }
             "#microsoft.graph.iosManagedAppProtection" {
-                "$GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments"
+                "$script:GraphEndpoint/beta/deviceAppManagement/iosManagedAppProtections('$($policy.id)')/assignments"
             }
             "#microsoft.graph.windowsManagedAppProtection" {
-                "$GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments"
+                "$script:GraphEndpoint/beta/deviceAppManagement/windowsManagedAppProtections('$($policy.id)')/assignments"
             }
             default { $null }
         }
@@ -738,8 +684,8 @@ function Export-HTMLReport {
         if ($assignmentsUri) {
             try {
                 $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
-                # Pass the raw .value to Get-AssignmentInfo as it expects an array of assignment objects
-                $assignmentInfo = Get-AssignmentInfo -Assignments $assignmentResponse.value 
+                # Pass the raw .value to Get-HtmlAssignmentInfo as it expects an array of assignment objects
+                $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignmentResponse.value 
 
                 $policies.AppProtectionPolicies += @{
                     Name           = $policy.displayName
@@ -763,7 +709,7 @@ function Export-HTMLReport {
     $platformScripts = Get-IntuneEntities -EntityType "deviceManagementScripts"
     foreach ($script in $platformScripts) {
         $assignments = Get-IntuneAssignments -EntityType "deviceManagementScripts" -EntityId $script.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.PlatformScripts += @{
             Name           = $script.displayName
             ID             = $script.id
@@ -781,7 +727,7 @@ function Export-HTMLReport {
     $healthScripts = Get-IntuneEntities -EntityType "deviceHealthScripts"
     foreach ($script in $healthScripts) {
         $assignments = Get-IntuneAssignments -EntityType "deviceHealthScripts" -EntityId $script.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.HealthScripts += @{
             Name           = $script.displayName
             ID             = $script.id
@@ -799,7 +745,7 @@ function Export-HTMLReport {
     $autoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
     foreach ($profile in $autoProfiles) {
         $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $profile.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.DeploymentProfiles += @{
             Name           = $profile.displayName
             ID             = $profile.id
@@ -818,7 +764,7 @@ function Export-HTMLReport {
     $espProfiles = $enrollmentConfigs | Where-Object { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
     foreach ($esp in $espProfiles) {
         $assignments = Get-IntuneAssignments -EntityType "deviceEnrollmentConfigurations" -EntityId $esp.id
-        $assignmentInfo = Get-AssignmentInfo -Assignments $assignments
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.ESPProfiles += @{
             Name           = $esp.displayName
             ID             = $esp.id
@@ -837,7 +783,7 @@ function Export-HTMLReport {
         $cloudPCProvisioningPolicies = Get-IntuneEntities -EntityType "virtualEndpoint/provisioningPolicies"
         foreach ($policy in $cloudPCProvisioningPolicies) {
             $rawAssignments = Get-IntuneAssignments -EntityType "virtualEndpoint/provisioningPolicies" -EntityId $policy.id
-            $assignmentInfo = Get-AssignmentInfo -Assignments $rawAssignments
+            $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $rawAssignments
             $policies.CloudPCProvisioningPolicies += @{
                 Name           = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
                 ID             = $policy.id
@@ -860,7 +806,7 @@ function Export-HTMLReport {
         $cloudPCUserSettings = Get-IntuneEntities -EntityType "virtualEndpoint/userSettings"
         foreach ($setting in $cloudPCUserSettings) {
             $rawAssignments = Get-IntuneAssignments -EntityType "virtualEndpoint/userSettings" -EntityId $setting.id
-            $assignmentInfo = Get-AssignmentInfo -Assignments $rawAssignments
+            $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $rawAssignments
             $policies.CloudPCUserSettings += @{
                 Name           = if (-not [string]::IsNullOrWhiteSpace($setting.displayName)) { $setting.displayName } else { $setting.name }
                 ID             = $setting.id
@@ -898,7 +844,7 @@ function Export-HTMLReport {
             foreach ($policy in $configPolicies) {
                 if ($processedIds.Add($policy.id)) {
                     $rawAssignments = Get-IntuneAssignments -EntityType "configurationPolicies" -EntityId $policy.id
-                    $assignmentInfo = Get-AssignmentInfo -Assignments $rawAssignments
+                    $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $rawAssignments
                     $policies[$esCategory.Key] += @{
                         Name           = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
                         ID             = $policy.id
@@ -921,8 +867,8 @@ function Export-HTMLReport {
             foreach ($policy in $intentPolicies) {
                 if ($processedIds.Add($policy.id)) {
                     try {
-                        $assignmentsResponse = Invoke-MgGraphRequest -Uri "$GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
-                        $assignmentInfo = Get-AssignmentInfo -Assignments $assignmentsResponse.value # This expects an array
+                        $assignmentsResponse = Invoke-MgGraphRequest -Uri "$script:GraphEndpoint/beta/deviceManagement/intents/$($policy.id)/assignments" -Method Get
+                        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignmentsResponse.value # This expects an array
                         $policies[$esCategory.Key] += @{
                             Name           = if (-not [string]::IsNullOrWhiteSpace($policy.displayName)) { $policy.displayName } else { $policy.name }
                             ID             = $policy.id
@@ -944,7 +890,7 @@ function Export-HTMLReport {
 
     # Get Apps
     Write-Host "Fetching Applications..." -ForegroundColor Yellow
-    $appUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
+    $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
     $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
     $allApps = $appResponse.value
     while ($appResponse.'@odata.nextLink') {
@@ -959,15 +905,15 @@ function Export-HTMLReport {
         }
 
         $appId = $app.id
-        $assignmentsUri = "$GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
+        $assignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
         $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
 
         foreach ($assignment in $assignmentResponse.value) {
-            # Get-AssignmentInfo expects an array of assignment objects.
+            # Get-HtmlAssignmentInfo expects an array of assignment objects.
             # Here, $assignment is a single assignment object from the loop.
-            # We need to wrap it in an array for Get-AssignmentInfo.
+            # We need to wrap it in an array for Get-HtmlAssignmentInfo.
             $currentAssignmentArray = @($assignment) # Ensure it's an array
-            $assignmentInfo = Get-AssignmentInfo -Assignments $currentAssignmentArray
+            $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $currentAssignmentArray
             
             $appInfo = @{
                 Name           = $app.displayName
@@ -1103,12 +1049,12 @@ function Export-HTMLReport {
                                 default { 'badge-none' }
                             }
                             "<tr>
-                                <td>$($p.Name)</td>
-                                <td>$($p.Platform)</td>
-                                <td>$($p.ScopeTags)</td>
-                                <td><span class='badge $badgeClass'>$($p.AssignmentType)</span></td>
-                                <td>$($p.AssignedTo)</td>
-                                <td>$($p.Filter)</td>
+                                <td>$([System.Net.WebUtility]::HtmlEncode($p.Name))</td>
+                                <td>$([System.Net.WebUtility]::HtmlEncode($p.Platform))</td>
+                                <td>$([System.Net.WebUtility]::HtmlEncode($p.ScopeTags))</td>
+                                <td><span class='badge $badgeClass'>$([System.Net.WebUtility]::HtmlEncode($p.AssignmentType))</span></td>
+                                <td>$([System.Net.WebUtility]::HtmlEncode($p.AssignedTo))</td>
+                                <td>$([System.Net.WebUtility]::HtmlEncode($p.Filter))</td>
                             </tr>"
                         }
                     }
@@ -1153,12 +1099,12 @@ function Export-HTMLReport {
                             default { 'badge-none' }
                         }
                         "<tr>
-                            <td>$($p.Name)</td>
-                            <td>$($p.Platform)</td>
-                            <td>$($p.ScopeTags)</td>
-                            <td><span class='badge $badgeClass'>$($p.AssignmentType)</span></td>
-                            <td>$($p.AssignedTo)</td>
-                            <td>$($p.Filter)</td>
+                            <td>$([System.Net.WebUtility]::HtmlEncode($p.Name))</td>
+                            <td>$([System.Net.WebUtility]::HtmlEncode($p.Platform))</td>
+                            <td>$([System.Net.WebUtility]::HtmlEncode($p.ScopeTags))</td>
+                            <td><span class='badge $badgeClass'>$([System.Net.WebUtility]::HtmlEncode($p.AssignmentType))</span></td>
+                            <td>$([System.Net.WebUtility]::HtmlEncode($p.AssignedTo))</td>
+                            <td>$([System.Net.WebUtility]::HtmlEncode($p.Filter))</td>
                         </tr>"
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ IntuneAssignmentChecker
 - 📱 View all 'All User' and 'All Device' assignments
 - 🎯 See Intune assignment filters (name and Include/Exclude type) inline on every assignment, in the console, CSV exports, and HTML reports
 - 🔐 Support for certificate-based and client secret authentication
-- 🔄 Built-in auto-update functionality
+- 🔄 Version check on connect with an update notice when a newer PSGallery release is available
 - 📊 Detailed reporting of Configuration Profiles, Compliance Policies, and Applications
 - 📈 Interactive HTML reports with charts and filterable tables
 
@@ -123,6 +123,8 @@ Your Entra ID application registration needs these permissions:
 | DeviceManagementScripts.Read.All | Application | Read device management and health scripts |
 | CloudPC.Read.All | Application | Read Windows 365 Cloud PC provisioning policies and settings |
 | DeviceManagementRBAC.Read.All | Application | Read role scope tags for scope tag display and filtering |
+
+> **Note**: The automated setup script ([`Register-IntuneAssignmentCheckerApp.ps1`](./Register-IntuneAssignmentCheckerApp.ps1)) additionally grants `DeviceManagementServiceConfig.Read.All`, which covers Intune service configuration such as enrollment settings. It is not validated by `Connect-IntuneAssignmentChecker`, but granting it avoids gaps when reading enrollment-related configurations.
 
 ## 🔐 Authentication Options
 
@@ -197,7 +199,17 @@ If you prefer a simpler setup than certificates but still need non-interactive a
    - Click "Add"
    - **Copy the secret value immediately** -- it will not be shown again
 
-3. Connect using the client secret:
+3. Connect using the client secret. The preferred way is `-ClientSecretCredential`, a PSCredential whose username is the App ID and whose password is the client secret, so the secret never appears as plain text:
+
+   ```powershell
+   $credential = Get-Credential -UserName 'your-app-id' -Message 'Enter the client secret as the password'
+   Connect-IntuneAssignmentChecker `
+       -TenantId 'your-tenant-id' `
+       -ClientSecretCredential $credential
+   ```
+
+   Alternatively, the plain-text `-ClientSecret` parameter is retained for compatibility:
+
    ```powershell
    Connect-IntuneAssignmentChecker `
        -AppId 'your-app-id' `
@@ -221,6 +233,19 @@ IntuneAssignmentChecker
 
 You'll be asked for the Intune environment (Global, USGov, or USGovDoD). The permissions will be based on your user account's roles in Entra ID.
 
+### Option 4: Pre-fetched Access Token (Managed Identity, Azure Functions, parent scripts)
+
+If you already have a Microsoft Graph access token, for example from a managed identity in Azure Automation or Azure Functions, or from a parent script that handles authentication, you can pass it directly as a SecureString:
+
+```powershell
+# Acquire a token (here via Az.Accounts) and pass it as a SecureString
+$token = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com").Token |
+    ConvertTo-SecureString -AsPlainText -Force
+Connect-IntuneAssignmentChecker -AccessToken $token
+```
+
+The token's permissions come from however it was issued (for example the managed identity's app role assignments), so make sure the identity has the required permissions listed in Prerequisites.
+
 ### Which Option Should I Choose?
 
 - **Choose Certificate Authentication if you**:
@@ -238,10 +263,16 @@ You'll be asked for the Intune environment (Global, USGov, or USGovDoD). The per
   - Prefer not to deal with certificate creation and installation
 
 - **Choose Interactive Authentication if you**:
+
   - Want the simplest setup
   - Don't need automation
   - Are comfortable using your user credentials
   - Only need to run the script occasionally
+
+- **Choose a Pre-fetched Access Token if you**:
+  - Run in Azure Automation, Azure Functions, or another host with a managed identity
+  - Already handle Microsoft Graph authentication in a parent script
+  - Want to reuse an existing token instead of creating a new connection
 
 > **Note**: Keep your certificate and app credentials secure! Anyone with access to these can access your Intune environment with the configured permissions.
 
@@ -306,8 +337,14 @@ New-IntuneHTMLReport -HTMLReportPath "C:\Temp\IntuneAssignmentReport.html"
 # Simulate what policies a user would receive if added to a group
 Test-IntuneGroupMembership -UserPrincipalNames "user@contoso.com" -SimulateTargetGroup "Marketing Team"
 
+# Simulate what policies a device would receive if added to a group (user and device can be combined)
+Test-IntuneGroupMembership -DeviceNames "Laptop123" -SimulateTargetGroup "Marketing Team"
+
 # Simulate what policies a user would lose if removed from a group
 Test-IntuneGroupRemoval -UserPrincipalNames "user@contoso.com" -SimulateRemoveTargetGroup "Marketing Team"
+
+# Simulate what policies a device would lose if removed from a group
+Test-IntuneGroupRemoval -DeviceNames "Laptop123" -SimulateRemoveTargetGroup "Marketing Team"
 
 # Reverse lookup: find all assignment targets for a policy name
 Search-IntunePolicy -PolicySearchTerm "BitLocker"
@@ -332,8 +369,8 @@ Available cmdlets:
 | `Get-IntuneEmptyGroup`             | Check for empty groups used in assignments                            |
 | `Get-IntuneFailedAssignment`       | Show all failed policy assignments                                    |
 | `Compare-IntuneGroupAssignment`    | Compare assignments between two or more groups                        |
-| `Test-IntuneGroupMembership`       | Simulate adding a user to a group and show resulting policies         |
-| `Test-IntuneGroupRemoval`          | Simulate removing a user from a group and show lost policies          |
+| `Test-IntuneGroupMembership`       | Simulate adding a user and/or device to a group and show resulting policies |
+| `Test-IntuneGroupRemoval`          | Simulate removing a user and/or device from a group and show lost policies |
 | `Search-IntunePolicy`              | Reverse lookup: find all assignment targets for a policy name         |
 | `Search-IntuneSetting`             | Search configured settings across all policies                        |
 | `Update-IntuneSettingDefinition`   | Refresh the local Settings Catalog definition cache                   |
@@ -354,8 +391,10 @@ Common parameters on `Connect-IntuneAssignmentChecker`:
 | `-AppId`                 | Application ID for authentication                          |
 | `-TenantId`              | Tenant ID for authentication                               |
 | `-CertificateThumbprint` | Certificate Thumbprint for authentication                  |
-| `-ClientSecret`          | Client Secret for authentication                           |
-| `-Environment`           | Environment (Global, USGov, USGovDoD) — defaults to Global |
+| `-ClientSecret`          | Client Secret for authentication (plain text; retained for compatibility, prefer `-ClientSecretCredential`) |
+| `-ClientSecretCredential`| PSCredential with the App ID as username and the client secret as password (preferred over `-ClientSecret`) |
+| `-AccessToken`           | Pre-fetched Microsoft Graph access token (SecureString), for managed identities or token reuse |
+| `-Environment`           | Environment (Global, USGov, USGovDoD) - defaults to Global |
 
 ### 📋 Interactive Menu Options
 
@@ -432,15 +471,15 @@ Running `IntuneAssignmentChecker` opens a menu-driven interface with the followi
     - Helps identify configuration issues
     - Supports CSV export of findings
 
-12. **Simulate Group Membership Impact**
+12. **Simulate Group Membership Impact (User and/or Device)**
 
-    - Preview what policies and apps a user would receive if added to a group
-    - Shows deltas vs. the user's current assignments
+    - Preview what policies and apps a user and/or device would receive if added to a group
+    - Shows deltas vs. the current assignments
     - Useful for validating planned group changes before applying them
 
-13. **Simulate Removing User from Group**
+13. **Simulate Removing from Group (User and/or Device)**
 
-    - Preview what policies and apps a user would lose if removed from a group
+    - Preview what policies and apps a user and/or device would lose if removed from a group
     - Helps evaluate the impact of offboarding or group cleanup
 
 14. **Search Policy Assignments**

--- a/Register-IntuneAssignmentCheckerApp.ps1
+++ b/Register-IntuneAssignmentCheckerApp.ps1
@@ -21,7 +21,7 @@
 .NOTES
     Author: Stefan Redlin
     Inspired by Ugur Koc's Intune Assignment Checker (@UgurKocDe), which motivated the automation of the App Registration process.
-    Many thanks for sharing this great tool — big shoutout to the IT community!
+    Many thanks for sharing this great tool - big shoutout to the IT community!
 #>
 
 # STEP 1: Connect to Microsoft Graph and get tenant information
@@ -49,7 +49,10 @@ $permissions = @(
     @{ id = "7a6ee1e7-141e-4cec-ae74-d9db155731ff"; displayName = "DeviceManagementApps.Read.All" },
     @{ id = "dc377aa6-52d8-4e23-b271-2a7ae04cedf3"; displayName = "DeviceManagementConfiguration.Read.All" },
     @{ id = "2f51be20-0bb4-4fed-bf7b-db946066c75e"; displayName = "DeviceManagementManagedDevices.Read.All" },
-    @{ id = "06a5fe6d-c49d-46a7-b082-56b1b14103c7"; displayName = "DeviceManagementServiceConfig.Read.All" }
+    @{ id = "06a5fe6d-c49d-46a7-b082-56b1b14103c7"; displayName = "DeviceManagementServiceConfig.Read.All" },
+    @{ id = "c7a5be92-2b3d-4540-8a67-c96dcaae8b43"; displayName = "DeviceManagementScripts.Read.All" },
+    @{ id = "a9e09520-8ed4-4cde-838e-4fdea192c227"; displayName = "CloudPC.Read.All" },
+    @{ id = "58ca0d9a-1575-47e1-a3cb-007ef2e4583b"; displayName = "DeviceManagementRBAC.Read.All" }
 )
 
 $requiredResourceAccess = @(
@@ -136,7 +139,8 @@ $tenantId = $tenant.Id
 $appId = $app.AppId
 
 Write-Host "`n----------------------------" -ForegroundColor Cyan
-Write-Host "You can now run IntuneAssignmentChecker with the following command:" -ForegroundColor Cyan
-Write-Host ".\IntuneAssignmentChecker.ps1 -CertificateThumbprint `"$certificateThumbprint`" -TenantId `"$tenantId`" -AppId `"$appId`"" -ForegroundColor Yellow
+Write-Host "You can now connect IntuneAssignmentChecker with the following command:" -ForegroundColor Cyan
+Write-Host "Connect-IntuneAssignmentChecker -AppId `"$appId`" -TenantId `"$tenantId`" -CertificateThumbprint `"$certificateThumbprint`"" -ForegroundColor Yellow
+Write-Host "Afterwards, run 'IntuneAssignmentChecker' to start the interactive menu." -ForegroundColor Cyan
 Write-Host "----------------------------"
 

--- a/Register-IntuneAssignmentCheckerApp.ps1
+++ b/Register-IntuneAssignmentCheckerApp.ps1
@@ -83,8 +83,8 @@ $cert = New-SelfSignedCertificate `
     -KeySpec Signature `
     -KeyExportPolicy Exportable
 
-$exportFolder = "C:\temp\$shortTenantName"
-$exportPath = "$exportFolder\IntuneAssignmentChecker-$shortTenantName.cer"
+$exportFolder = Join-Path ([System.IO.Path]::GetTempPath()) $shortTenantName
+$exportPath = Join-Path $exportFolder "IntuneAssignmentChecker-$shortTenantName.cer"
 New-Item -Path $exportFolder -ItemType Directory -Force | Out-Null
 Export-Certificate -Cert $cert -FilePath $exportPath | Out-Null
 Write-Host "Certificate exported to: $exportPath" -ForegroundColor Green
@@ -92,8 +92,21 @@ Write-Host "Certificate exported to: $exportPath" -ForegroundColor Green
 $keyCreds = @(
     @{ "Type" = "AsymmetricX509Cert"; "Usage" = "Verify"; "Key" = $cert.RawData }
 )
-Update-MgApplication -ApplicationId $app.Id -KeyCredentials $keyCreds
-Write-Host "Certificate uploaded successfully." -ForegroundColor Green
+try {
+    Update-MgApplication -ApplicationId $app.Id -KeyCredentials $keyCreds
+    Write-Host "Certificate uploaded successfully." -ForegroundColor Green
+}
+catch {
+    Write-Host "Certificate upload failed. Removing temporary Client Secret..." -ForegroundColor Red
+    $passwords = (Get-MgApplication -ApplicationId $app.Id).PasswordCredentials
+    foreach ($secret in $passwords) {
+        if ($secret.DisplayName -eq "TemporaryClientSecret") {
+            Remove-MgApplicationPassword -ApplicationId $app.Id -KeyId $secret.KeyId
+            Write-Host "Temporary Client Secret removed." -ForegroundColor Green
+        }
+    }
+    throw
+}
 
 # STEP 6: Remove Temporary Client Secret
 $passwords = (Get-MgApplication -ApplicationId $app.Id).PasswordCredentials

--- a/Tests/Unit/CategoryScan.Tests.ps1
+++ b/Tests/Unit/CategoryScan.Tests.ps1
@@ -7,6 +7,9 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Add-CategoryExportData.ps1')
 
     $script:GraphEndpoint = 'https://graph.microsoft.com'
 
@@ -370,6 +373,133 @@ Describe 'Invoke-IntuneCategoryScan' {
             $script:emptyContexts.Count | Should -Be 1
             @($script:emptyContexts[0].Assignments).Count | Should -Be 0
         }
+    }
+}
+
+Describe 'Add-CategoryExportData' {
+    BeforeEach {
+        $script:ScopeTagLookup = @{}
+        $script:exportData = [System.Collections.ArrayList]::new()
+    }
+
+    It 'exports buckets in registry order using each category ExportCategory label' {
+        $categories = @(
+            New-TestCategory @{ Id = 'DeviceConfigurations'; BucketKeys = @('DeviceConfigs'); ExportCategory = 'Device Configuration' }
+            New-TestCategory @{ Id = 'CompliancePolicies'; BucketKeys = @('CompliancePolicies'); ExportCategory = 'Compliance Policy' }
+        )
+        $buckets = @{
+            DeviceConfigs      = @([PSCustomObject]@{ id = 'cfg-1'; displayName = 'Config 1'; AssignmentSummary = 'All Users' })
+            CompliancePolicies = @([PSCustomObject]@{ id = 'comp-1'; displayName = 'Compliance 1'; AssignmentSummary = 'All Devices' })
+        }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets
+
+        $script:exportData.Count | Should -Be 2
+        $script:exportData[0].Category | Should -BeExactly 'Device Configuration'
+        $script:exportData[0].Item | Should -BeExactly 'Config 1 (ID: cfg-1)'
+        $script:exportData[1].Category | Should -BeExactly 'Compliance Policy'
+    }
+
+    It 'uses BucketExportCategories labels for multi-bucket categories' {
+        $categories = @(
+            New-TestCategory @{
+                Id                     = 'Applications'
+                BucketKeys             = @('AppsRequired', 'AppsAvailable', 'AppsUninstall')
+                ExportCategory         = $null
+                BucketExportCategories = @{ AppsRequired = 'Required Apps'; AppsAvailable = 'Available Apps'; AppsUninstall = 'Uninstall Apps' }
+            }
+        )
+        $buckets = @{
+            AppsRequired  = @([PSCustomObject]@{ id = 'app-1'; displayName = 'App 1' })
+            AppsAvailable = @([PSCustomObject]@{ id = 'app-2'; displayName = 'App 2' })
+            AppsUninstall = @()
+        }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets
+
+        $script:exportData.Count | Should -Be 2
+        $script:exportData[0].Category | Should -BeExactly 'Required Apps'
+        $script:exportData[1].Category | Should -BeExactly 'Available Apps'
+    }
+
+    It 'exports a bucket shared by multiple categories only once' {
+        $categories = @(
+            New-TestCategory @{ Id = 'PlatformScripts'; BucketKeys = @('PlatformScripts'); ExportCategory = 'Platform Scripts' }
+            New-TestCategory @{ Id = 'ShellScripts'; BucketKeys = @('PlatformScripts'); ExportCategory = 'Platform Scripts' }
+        )
+        $buckets = @{
+            PlatformScripts = @([PSCustomObject]@{ id = 'scr-1'; displayName = 'Script 1' })
+        }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets
+
+        $script:exportData.Count | Should -Be 1
+    }
+
+    It 'emits no rows for empty or missing buckets without erroring' {
+        $categories = @(
+            New-TestCategory @{ Id = 'DeviceConfigurations'; BucketKeys = @('DeviceConfigs'); ExportCategory = 'Device Configuration' }
+            New-TestCategory @{ Id = 'CompliancePolicies'; BucketKeys = @('CompliancePolicies'); ExportCategory = 'Compliance Policy' }
+        )
+        $buckets = @{ DeviceConfigs = [System.Collections.Generic.List[object]]::new() }
+
+        { Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets } | Should -Not -Throw
+        $script:exportData.Count | Should -Be 0
+    }
+
+    It 'passes an AssignmentReason scriptblock through to Add-ExportData' {
+        $categories = @(
+            New-TestCategory @{ Id = 'DeviceConfigurations'; BucketKeys = @('DeviceConfigs'); ExportCategory = 'Device Configuration' }
+        )
+        $buckets = @{
+            DeviceConfigs = @(
+                [PSCustomObject]@{ id = 'cfg-1'; displayName = 'Config 1'; AssignmentSummary = 'Group Assignment - Sales (Filter: Corp Devices [Include])' }
+                [PSCustomObject]@{ id = 'cfg-2'; displayName = 'Config 2'; AssignmentSummary = '' }
+            )
+        }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets -AssignmentReason { param($item) $item.AssignmentSummary }
+
+        $script:exportData.Count | Should -Be 2
+        $script:exportData[0].AssignmentReason | Should -BeExactly 'Group Assignment - Sales (Filter: Corp Devices [Include])'
+        $script:exportData[0].FilterName | Should -BeExactly 'Corp Devices'
+        $script:exportData[0].FilterType | Should -BeExactly 'Include'
+        # The scriptblock returns the raw empty summary rather than the N/A default
+        $script:exportData[1].AssignmentReason | Should -BeExactly ''
+    }
+
+    It 'covers every AllPolicies export label in registry order matching the pre-migration sequence' {
+        $expectedLabels = @(
+            'Device Configuration'
+            'Settings Catalog Policy'
+            'Compliance Policy'
+            'App Protection Policy'
+            'App Configuration Policy'
+            'Platform Scripts'
+            'Proactive Remediation Scripts'
+            'Autopilot Deployment Profile'
+            'Enrollment Status Page'
+            'Windows 365 Cloud PC Provisioning Policy'
+            'Windows 365 Cloud PC User Setting'
+            'Endpoint Security - Antivirus'
+            'Endpoint Security - Disk Encryption'
+            'Endpoint Security - Firewall'
+            'Endpoint Security - EDR'
+            'Endpoint Security - ASR'
+            'Endpoint Security - Account Protection'
+        )
+
+        $categories = Get-IntuneCategoryDefinition -Audience AllPolicies
+        $buckets = @{}
+        foreach ($category in $categories) {
+            foreach ($bucketKey in $category.BucketKeys) {
+                $buckets[$bucketKey] = @([PSCustomObject]@{ id = "$bucketKey-1"; displayName = "$bucketKey item" })
+            }
+        }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets
+
+        @($script:exportData | ForEach-Object { $_.Category }) | Should -Be $expectedLabels
     }
 }
 

--- a/Tests/Unit/CategoryScan.Tests.ps1
+++ b/Tests/Unit/CategoryScan.Tests.ps1
@@ -1,0 +1,455 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $modulePrivate = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker/Private'
+
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+
+    $script:GraphEndpoint = 'https://graph.microsoft.com'
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+
+    function New-TestCategory {
+        param([hashtable]$Props)
+        $entry = [ordered]@{
+            Id                     = 'TestCategory'
+            Kind                   = 'Entity'
+            EntityType             = 'deviceConfigurations'
+            AssignmentEntityType   = $null
+            TemplateFamily         = $null
+            EntityFilter           = $null
+            BucketKeys             = @('DeviceConfigs')
+            DisplayName            = 'Test Category'
+            ExportCategory         = 'Test Category'
+            OptionalFeature        = $false
+            BucketOnly             = $false
+            BucketExportCategories = $null
+        }
+        foreach ($key in $Props.Keys) { $entry[$key] = $Props[$key] }
+        if (-not $entry.AssignmentEntityType) { $entry.AssignmentEntityType = $entry.EntityType }
+        [PSCustomObject]$entry
+    }
+
+    function New-EsPolicy {
+        param([string]$Id, [string]$Family, [string]$Name = 'ES Policy')
+        [PSCustomObject]@{
+            id                = $Id
+            name              = $Name
+            displayName       = $Name
+            templateReference = [PSCustomObject]@{ templateFamily = $Family }
+        }
+    }
+}
+
+Describe 'Get-AppProtectionAssignmentUri' {
+    It 'maps androidManagedAppProtection to the android assignments URI' {
+        $policy = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.androidManagedAppProtection'; id = 'pol-android' }
+        Get-AppProtectionAssignmentUri -Policy $policy |
+            Should -BeExactly "https://graph.microsoft.com/beta/deviceAppManagement/androidManagedAppProtections('pol-android')/assignments"
+    }
+
+    It 'maps iosManagedAppProtection to the ios assignments URI' {
+        $policy = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.iosManagedAppProtection'; id = 'pol-ios' }
+        Get-AppProtectionAssignmentUri -Policy $policy |
+            Should -BeExactly "https://graph.microsoft.com/beta/deviceAppManagement/iosManagedAppProtections('pol-ios')/assignments"
+    }
+
+    It 'maps windowsManagedAppProtection to the windows assignments URI' {
+        $policy = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.windowsManagedAppProtection'; id = 'pol-win' }
+        Get-AppProtectionAssignmentUri -Policy $policy |
+            Should -BeExactly "https://graph.microsoft.com/beta/deviceAppManagement/windowsManagedAppProtections('pol-win')/assignments"
+    }
+
+    It 'returns null for an unknown policy type' {
+        $policy = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.mdmWindowsInformationProtectionPolicy'; id = 'pol-wip' }
+        Get-AppProtectionAssignmentUri -Policy $policy | Should -BeNullOrEmpty
+    }
+
+    It 'returns null when the policy has no @odata.type' {
+        $policy = [PSCustomObject]@{ id = 'pol-untyped' }
+        Get-AppProtectionAssignmentUri -Policy $policy | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-IntuneCategoryScan' {
+    BeforeEach {
+        Mock Write-Host {}
+        Mock Write-Error {}
+        Mock Get-IntuneEntities { @() }
+        Mock Get-IntuneAssignments { @() }
+        Mock Add-IntentTemplateFamilyInfo {}
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+    }
+
+    Context 'entity caching' {
+        It 'fetches configurationPolicies exactly once across SettingsCatalog and six ES categories' {
+            Mock Get-IntuneEntities {
+                if ($EntityType -eq 'configurationPolicies') {
+                    return @(New-EsPolicy -Id 'cp-1' -Family 'endpointSecurityAntivirus')
+                }
+                return @()
+            }
+
+            $categories = Get-IntuneCategoryDefinition -Audience UserContext
+            $null = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {} -EntityCache @{}
+
+            Should -Invoke Get-IntuneEntities -Exactly 1 -ParameterFilter { $EntityType -eq 'configurationPolicies' }
+        }
+
+        It 'fetches deviceManagement/intents exactly once across the six ES categories' {
+            $categories = Get-IntuneCategoryDefinition -Audience UserContext
+            $null = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {} -EntityCache @{}
+
+            Should -Invoke Get-IntuneEntities -Exactly 1 -ParameterFilter { $EntityType -eq 'deviceManagement/intents' }
+        }
+    }
+
+    Context 'endpoint security two-phase dedup' {
+        It 'delivers an id present in both configurationPolicies and intents to the callback only once' {
+            Mock Get-IntuneEntities {
+                switch ($EntityType) {
+                    'configurationPolicies' { return @(New-EsPolicy -Id 'dup-1' -Family 'endpointSecurityAntivirus' -Name 'AV config policy') }
+                    'deviceManagement/intents' { return @(New-EsPolicy -Id 'dup-1' -Family 'endpointSecurityAntivirus' -Name 'AV intent') }
+                    default { return @() }
+                }
+            }
+
+            $script:seenIds = [System.Collections.Generic.List[string]]::new()
+            $antivirusCategory = @(Get-IntuneCategoryDefinition -Audience UserContext | Where-Object { $_.Id -eq 'ESAntivirus' })
+            $null = Invoke-IntuneCategoryScan -Categories $antivirusCategory -ProcessEntity {
+                param($ctx)
+                $script:seenIds.Add($ctx.Entity.id)
+            }
+
+            $script:seenIds.Count | Should -Be 1
+            $script:seenIds[0] | Should -Be 'dup-1'
+        }
+
+        It 'still delivers intents that have no configurationPolicies counterpart' {
+            Mock Get-IntuneEntities {
+                switch ($EntityType) {
+                    'deviceManagement/intents' { return @(New-EsPolicy -Id 'intent-macos-fv' -Family 'endpointSecurityDiskEncryption' -Name 'macOS FileVault') }
+                    default { return @() }
+                }
+            }
+            Mock Invoke-MgGraphRequest {
+                @{ value = @(@{ target = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget' } }) }
+            }
+
+            $script:intentContexts = [System.Collections.Generic.List[object]]::new()
+            $diskEncCategory = @(Get-IntuneCategoryDefinition -Audience UserContext | Where-Object { $_.Id -eq 'ESDiskEncryption' })
+            $null = Invoke-IntuneCategoryScan -Categories $diskEncCategory -ProcessEntity {
+                param($ctx)
+                $script:intentContexts.Add($ctx)
+            }
+
+            $script:intentContexts.Count | Should -Be 1
+            $script:intentContexts[0].Entity.id | Should -Be 'intent-macos-fv'
+            $script:intentContexts[0].Assignments[0].Reason | Should -BeExactly 'All Devices'
+            @($script:intentContexts[0].RawAssignments).Count | Should -Be 1
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter { $Uri -like '*deviceManagement/intents/intent-macos-fv/assignments*' }
+        }
+    }
+
+    Context 'error handling' {
+        It 'continues with other categories and records the failure when a category fetch throws' {
+            Mock Get-IntuneEntities {
+                if ($EntityType -eq 'deviceConfigurations') { throw 'boom' }
+                return @([PSCustomObject]@{ id = 'comp-1'; displayName = 'Compliance 1' })
+            }
+
+            $script:processedIds = [System.Collections.Generic.List[string]]::new()
+            $categories = @(
+                New-TestCategory @{ Id = 'DeviceConfigurations'; EntityType = 'deviceConfigurations'; DisplayName = 'Device Configurations' }
+                New-TestCategory @{ Id = 'CompliancePolicies'; EntityType = 'deviceCompliancePolicies'; BucketKeys = @('CompliancePolicies'); DisplayName = 'Compliance Policies' }
+            )
+
+            $result = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {
+                param($ctx)
+                $script:processedIds.Add($ctx.Entity.id)
+            }
+
+            $script:processedIds | Should -Be @('comp-1')
+            $result.Errors.Count | Should -Be 1
+            $result.Errors[0].CategoryId | Should -Be 'DeviceConfigurations'
+            $result.Errors[0].Message | Should -Match 'boom'
+            Should -Invoke Write-Error -Exactly 1
+        }
+
+        It 'skips OptionalFeature category failures quietly without an error record' {
+            Mock Get-IntuneEntities {
+                if ($EntityType -eq 'virtualEndpoint/provisioningPolicies') { throw 'not licensed' }
+                return @([PSCustomObject]@{ id = 'comp-1'; displayName = 'Compliance 1' })
+            }
+
+            $script:processedIds = [System.Collections.Generic.List[string]]::new()
+            $categories = @(
+                New-TestCategory @{ Id = 'CloudPCProvisioningPolicies'; EntityType = 'virtualEndpoint/provisioningPolicies'; BucketKeys = @('CloudPCProvisioningPolicies'); DisplayName = 'Windows 365 Cloud PC Provisioning Policies'; OptionalFeature = $true }
+                New-TestCategory @{ Id = 'CompliancePolicies'; EntityType = 'deviceCompliancePolicies'; BucketKeys = @('CompliancePolicies'); DisplayName = 'Compliance Policies' }
+            )
+
+            $result = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {
+                param($ctx)
+                $script:processedIds.Add($ctx.Entity.id)
+            }
+
+            $script:processedIds | Should -Be @('comp-1')
+            $result.Errors.Count | Should -Be 0
+            Should -Invoke Write-Error -Exactly 0
+        }
+    }
+
+    Context 'buckets' {
+        It 'returns List[object] buckets and surfaces callback mutations' {
+            Mock Get-IntuneEntities { @([PSCustomObject]@{ id = 'cfg-1'; displayName = 'Config 1' }) }
+
+            $categories = @(New-TestCategory @{})
+            $result = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {
+                param($ctx)
+                $ctx.Buckets['DeviceConfigs'].Add($ctx.Entity)
+            }
+
+            $result.Buckets['DeviceConfigs'].GetType().Name | Should -Be 'List`1'
+            $result.Buckets['DeviceConfigs'].Count | Should -Be 1
+            $result.Buckets['DeviceConfigs'][0].id | Should -Be 'cfg-1'
+        }
+
+        It 'creates empty buckets for BucketOnly categories without fetching them' {
+            $categories = @(
+                New-TestCategory @{ Id = 'DeploymentProfiles'; EntityType = 'windowsAutopilotDeploymentProfiles'; BucketKeys = @('DeploymentProfiles'); BucketOnly = $true }
+            )
+            $result = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {}
+
+            $result.Buckets.ContainsKey('DeploymentProfiles') | Should -BeTrue
+            $result.Buckets['DeploymentProfiles'].Count | Should -Be 0
+            $result.CategoryCount | Should -Be 0
+            Should -Invoke Get-IntuneEntities -Exactly 0
+        }
+    }
+
+    Context 'assignment group ids' {
+        It 'passes AssignmentGroupIds through to Get-IntuneAssignments' {
+            Mock Get-IntuneEntities { @([PSCustomObject]@{ id = 'cfg-1' }) }
+
+            $categories = @(New-TestCategory @{})
+            $null = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {} -AssignmentGroupIds @('grp-1', 'grp-2')
+
+            Should -Invoke Get-IntuneAssignments -Exactly 1 -ParameterFilter {
+                $EntityId -eq 'cfg-1' -and $GroupIds.Count -eq 2 -and $GroupIds -contains 'grp-1' -and $GroupIds -contains 'grp-2'
+            }
+        }
+    }
+
+    Context 'entity prefilter' {
+        It 'never fetches assignments for entities that fail the prefilter' {
+            Mock Get-IntuneEntities {
+                @(
+                    [PSCustomObject]@{ id = 'cfg-match'; displayName = 'Corp Baseline' }
+                    [PSCustomObject]@{ id = 'cfg-nomatch'; displayName = 'Pilot Policy' }
+                )
+            }
+
+            $script:processedIds = [System.Collections.Generic.List[string]]::new()
+            $categories = @(New-TestCategory @{})
+            $null = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {
+                param($ctx)
+                $script:processedIds.Add($ctx.Entity.id)
+            } -EntityPreFilter { param($entity) $entity.displayName -like '*Corp*' }
+
+            $script:processedIds | Should -Be @('cfg-match')
+            Should -Invoke Get-IntuneAssignments -Exactly 1
+            Should -Invoke Get-IntuneAssignments -Exactly 1 -ParameterFilter { $EntityId -eq 'cfg-match' }
+            Should -Invoke Get-IntuneAssignments -Exactly 0 -ParameterFilter { $EntityId -eq 'cfg-nomatch' }
+        }
+    }
+
+    Context 'mobile apps' {
+        It 'skips isFeatured/isBuiltIn apps and passes RawAssignments to the callback' {
+            Mock Invoke-MgGraphRequest {
+                if ($Uri.Contains('mobileApps?$filter=isAssigned')) {
+                    return @{ value = @(
+                            @{ id = 'app-1'; displayName = 'Real App'; isFeatured = $false; isBuiltIn = $false }
+                            @{ id = 'app-2'; displayName = 'Featured App'; isFeatured = $true; isBuiltIn = $false }
+                            @{ id = 'app-3'; displayName = 'BuiltIn App'; isFeatured = $false; isBuiltIn = $true }
+                        )
+                    }
+                }
+                if ($Uri -like "*mobileApps('app-1')/assignments*") {
+                    return @{ value = @(
+                            @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                        )
+                    }
+                }
+                return @{ value = @() }
+            }
+
+            $script:appContexts = [System.Collections.Generic.List[object]]::new()
+            $appsCategory = @(Get-IntuneCategoryDefinition -Audience UserContext | Where-Object { $_.Id -eq 'Applications' })
+            $null = Invoke-IntuneCategoryScan -Categories $appsCategory -ProcessEntity {
+                param($ctx)
+                $script:appContexts.Add($ctx)
+            }
+
+            $script:appContexts.Count | Should -Be 1
+            $script:appContexts[0].Entity.id | Should -Be 'app-1'
+            @($script:appContexts[0].RawAssignments).Count | Should -Be 1
+            $script:appContexts[0].RawAssignments[0].intent | Should -Be 'required'
+            $script:appContexts[0].Assignments[0].Reason | Should -BeExactly 'All Users'
+        }
+    }
+
+    Context 'app protection normalization' {
+        It 'reproduces the GroupIds label duality for raw App Protection assignments' {
+            Mock Get-IntuneEntities {
+                if ($EntityType -eq 'deviceAppManagement/managedAppPolicies') {
+                    return @([PSCustomObject]@{ id = 'app-prot-1'; displayName = 'iOS MAM'; '@odata.type' = '#microsoft.graph.iosManagedAppProtection' })
+                }
+                return @()
+            }
+            Mock Invoke-MgGraphRequest {
+                @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'grp-1' } }
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = 'grp-other' } }
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                    )
+                }
+            }
+
+            $appProtectionCategory = @(Get-IntuneCategoryDefinition -Audience GroupContext | Where-Object { $_.Id -eq 'AppProtectionPolicies' })
+
+            # Group-scoped run: only Direct Assignment for the matching group survives
+            $script:groupScoped = [System.Collections.Generic.List[object]]::new()
+            $null = Invoke-IntuneCategoryScan -Categories $appProtectionCategory -AssignmentGroupIds @('grp-1') -ProcessEntity {
+                param($ctx)
+                $script:groupScoped.Add($ctx)
+            }
+            @($script:groupScoped[0].Assignments).Count | Should -Be 1
+            $script:groupScoped[0].Assignments[0].Reason | Should -BeExactly 'Direct Assignment'
+            @($script:groupScoped[0].RawAssignments).Count | Should -Be 3
+
+            # Unscoped run: group labels plus All Users pass through
+            $script:unscoped = [System.Collections.Generic.List[object]]::new()
+            $null = Invoke-IntuneCategoryScan -Categories $appProtectionCategory -ProcessEntity {
+                param($ctx)
+                $script:unscoped.Add($ctx)
+            }
+            @($script:unscoped[0].Assignments).Reason | Should -Be @('Group Assignment', 'Group Exclusion', 'All Users')
+        }
+    }
+
+    Context 'zero-assignment entities' {
+        It 'invokes the callback for entities without any assignment' {
+            Mock Get-IntuneEntities { @([PSCustomObject]@{ id = 'cfg-empty'; displayName = 'Unassigned Config' }) }
+            Mock Get-IntuneAssignments { @() }
+
+            $script:emptyContexts = [System.Collections.Generic.List[object]]::new()
+            $categories = @(New-TestCategory @{})
+            $null = Invoke-IntuneCategoryScan -Categories $categories -ProcessEntity {
+                param($ctx)
+                $script:emptyContexts.Add($ctx)
+            }
+
+            $script:emptyContexts.Count | Should -Be 1
+            @($script:emptyContexts[0].Assignments).Count | Should -Be 0
+        }
+    }
+}
+
+Describe 'Get-IntuneCategoryDefinition' {
+    It 'returns 16 fetchable categories plus Autopilot/ESP bucket placeholders for UserContext' {
+        $categories = Get-IntuneCategoryDefinition -Audience UserContext
+        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 16
+        @($categories | Where-Object { $_.BucketOnly }).Id | Should -Be @('DeploymentProfiles', 'ESPProfiles')
+    }
+
+    It 'returns 16 fetchable categories plus Autopilot/ESP bucket placeholders for DeviceContext' {
+        $categories = Get-IntuneCategoryDefinition -Audience DeviceContext
+        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 16
+        @($categories | Where-Object { $_.BucketOnly }).Id | Should -Be @('DeploymentProfiles', 'ESPProfiles')
+    }
+
+    It 'returns 18 categories including Autopilot and ESP for GroupContext' {
+        $categories = Get-IntuneCategoryDefinition -Audience GroupContext
+        @($categories).Count | Should -Be 18
+        @($categories | Where-Object { $_.BucketOnly }).Count | Should -Be 0
+        $categories.Id | Should -Contain 'DeploymentProfiles'
+        $categories.Id | Should -Contain 'ESPProfiles'
+    }
+
+    It 'returns 17 categories without Applications for AllPolicies' {
+        $categories = Get-IntuneCategoryDefinition -Audience AllPolicies
+        @($categories).Count | Should -Be 17
+        $categories.Id | Should -Not -Contain 'Applications'
+    }
+
+    It 'returns 18 categories with a shared SearchResults bucket for Search' {
+        $categories = Get-IntuneCategoryDefinition -Audience Search
+        @($categories).Count | Should -Be 18
+        foreach ($category in $categories) {
+            $category.BucketKeys | Should -Be @('SearchResults')
+        }
+    }
+
+    It 'returns 13 categories for Compare' {
+        $categories = Get-IntuneCategoryDefinition -Audience Compare
+        @($categories).Count | Should -Be 13
+        $categories.Id | Should -Contain 'ShellScripts'
+    }
+
+    Context 'audience-specific SettingsCatalog filters' {
+        BeforeAll {
+            $script:windowsOnlyEsPolicy = [PSCustomObject]@{
+                id                = 'sc-win-es'
+                templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityFirewall' }
+                platforms         = @('windows10')
+            }
+            $script:macOsEsPolicy = [PSCustomObject]@{
+                id                = 'sc-mac-es'
+                templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityDiskEncryption' }
+                platforms         = @('macOS')
+            }
+            $script:plainPolicy = [PSCustomObject]@{
+                id                = 'sc-plain'
+                templateReference = $null
+                platforms         = @('windows10AndLater')
+            }
+        }
+
+        It 'GroupContext skips Windows-only ES settings-catalog policies but keeps the macOS ones' {
+            $settingsCatalog = @(Get-IntuneCategoryDefinition -Audience GroupContext | Where-Object { $_.Id -eq 'SettingsCatalog' })[0]
+            $kept = @(@($script:windowsOnlyEsPolicy, $script:macOsEsPolicy, $script:plainPolicy) | Where-Object $settingsCatalog.EntityFilter)
+            $kept.id | Should -Be @('sc-mac-es', 'sc-plain')
+        }
+
+        It 'Search skips all ES settings-catalog policies' {
+            $settingsCatalog = @(Get-IntuneCategoryDefinition -Audience Search | Where-Object { $_.Id -eq 'SettingsCatalog' })[0]
+            $kept = @(@($script:windowsOnlyEsPolicy, $script:macOsEsPolicy, $script:plainPolicy) | Where-Object $settingsCatalog.EntityFilter)
+            $kept.id | Should -Be @('sc-plain')
+        }
+
+        It 'UserContext and AllPolicies apply no SettingsCatalog filter' {
+            foreach ($audience in @('UserContext', 'AllPolicies')) {
+                $settingsCatalog = @(Get-IntuneCategoryDefinition -Audience $audience | Where-Object { $_.Id -eq 'SettingsCatalog' })[0]
+                $settingsCatalog.EntityFilter | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Unit/CompareGroupAssignment.Tests.ps1
+++ b/Tests/Unit/CompareGroupAssignment.Tests.ps1
@@ -1,0 +1,292 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $moduleRoot 'Public/Compare-IntuneGroupAssignment.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:AssignmentFilterLookup = @{}
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Get-TransitiveGroupMembership {
+        param([string]$GroupId)
+        @()
+    }
+}
+
+Describe 'Compare-IntuneGroupAssignment' {
+    BeforeEach {
+        $script:groupA = '11111111-1111-1111-1111-111111111111'
+        $script:groupB = '22222222-2222-2222-2222-222222222222'
+        $script:csvPath = Join-Path $TestDrive 'comparison.csv'
+
+        Mock Write-Host {}
+        Mock Get-TransitiveGroupMembership { @() }
+        Mock Add-IntentTemplateFamilyInfo {}
+
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'deviceConfigurations' {
+                    @(
+                        [PSCustomObject]@{ id = 'dc-1'; displayName = 'Shared Config' }
+                        [PSCustomObject]@{ id = 'dc-2'; displayName = 'A Only Config' }
+                        [PSCustomObject]@{ id = 'dc-3'; displayName = 'Excluded Config' }
+                        [PSCustomObject]@{ id = 'dc-4'; displayName = 'Inherited Config' }
+                        [PSCustomObject]@{ id = 'dc-5'; displayName = 'Filtered Config' }
+                    )
+                }
+                'configurationPolicies' {
+                    # ES-family Settings Catalog policy: legacy Compare surfaced it under
+                    # Settings Catalog only, never under Endpoint Security (intents-only scope)
+                    @(
+                        [PSCustomObject]@{ id = 'escp-1'; name = 'ES CP Policy'; templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' } }
+                    )
+                }
+                'deviceManagementScripts' {
+                    @(
+                        [PSCustomObject]@{ id = 'ps-1'; displayName = 'PS One' }
+                        [PSCustomObject]@{ id = 'ps-2'; displayName = 'Excluded PS' }
+                    )
+                }
+                'deviceHealthScripts' {
+                    @(
+                        [PSCustomObject]@{ id = 'hs-1'; displayName = 'Health One' }
+                        [PSCustomObject]@{ id = 'hs-2'; displayName = 'Excluded Health' }
+                    )
+                }
+                'deviceShellScripts' {
+                    @(
+                        [PSCustomObject]@{ id = 'ss-1'; displayName = 'Shell One' }
+                    )
+                }
+                'deviceManagement/intents' {
+                    @(
+                        [PSCustomObject]@{ id = 'intent-av'; displayName = 'AV Intent Policy'; templateId = 'tmpl-av'; templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' } }
+                    )
+                }
+                default { @() }
+            }
+        }
+
+        Mock Get-IntuneAssignments {
+            $records = switch ($EntityId) {
+                'dc-1' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupB; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'dc-2' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                'dc-3' { @([PSCustomObject]@{ Reason = 'Direct Exclusion'; GroupId = $script:groupB; FilterId = $null; FilterType = $null }) }
+                'dc-4' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = 'parent-a'; FilterId = $null; FilterType = $null }) }
+                'dc-5' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = 'f-1'; FilterType = 'include' }) }
+                'escp-1' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                'ps-1' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                'ps-2' { @([PSCustomObject]@{ Reason = 'Direct Exclusion'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                'hs-1' { @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                'hs-2' { @([PSCustomObject]@{ Reason = 'Direct Exclusion'; GroupId = $script:groupA; FilterId = $null; FilterType = $null }) }
+                default { @() }
+            }
+            # Mirror the real helper: only assignments targeting the requested group ids
+            @($records | Where-Object { $GroupIds -contains $_.GroupId })
+        }
+
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like "*/v1.0/groups*displayName eq*") {
+                if ($Uri -like "*O''Brien Team*") {
+                    return @{ value = @(@{ id = $script:groupB; displayName = "O'Brien Team" }) }
+                }
+                return @{ value = @() }
+            }
+            if ($Uri -like "*/v1.0/groups/$($script:groupA)") { return @{ id = $script:groupA; displayName = 'Group A' } }
+            if ($Uri -like "*/v1.0/groups/$($script:groupB)") { return @{ id = $script:groupB; displayName = 'Group B' } }
+            if ($Uri -like '*mobileApps*isAssigned eq true*') {
+                return @{ value = @(
+                        [PSCustomObject]@{ id = 'app-shared'; displayName = 'Shared App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-excluded'; displayName = 'Excluded App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-builtin'; displayName = 'Builtin App'; isFeatured = $false; isBuiltIn = $true }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-shared')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupA } }
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupB } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-excluded')/assignments*") {
+                # Exclusion-only app assignment (issue #126 shape): stays visible, tagged [EXCLUDED]
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:groupA } }
+                    )
+                }
+            }
+            if ($Uri -like "*deviceManagement/intents/intent-av/assignments*") {
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupB } }
+                    )
+                }
+            }
+            if ($Uri -like "*deviceShellScripts('ss-1')/groupAssignments*") {
+                return @{ value = @(
+                        @{ targetGroupId = $script:groupB }
+                    )
+                }
+            }
+            return @{ value = @() }
+        }
+    }
+
+    Context 'input validation' {
+        It 'requires at least two groups' {
+            Compare-IntuneGroupAssignment -CompareGroupNames 'Only One Group'
+
+            Should -Invoke Write-Host -ParameterFilter { $Object -eq 'Please provide at least two groups to compare.' }
+            Should -Invoke Get-IntuneEntities -Exactly 0
+        }
+
+        It 'escapes single quotes in group name lookups' {
+            Compare-IntuneGroupAssignment -CompareGroupNames "O'Brien Team, $($script:groupA)" -ExportToCSV -ExportPath $script:csvPath
+
+            Should -Invoke Invoke-MgGraphRequest -ParameterFilter { $Uri -like "*displayName eq 'O''Brien Team'*" }
+        }
+    }
+
+    Context 'two-group comparison matrix' {
+        BeforeEach {
+            Compare-IntuneGroupAssignment -CompareGroupNames "$($script:groupA), $($script:groupB)" -ExportToCSV -ExportPath $script:csvPath
+            $script:rows = @(Import-Csv $script:csvPath)
+        }
+
+        It 'marks a policy assigned to both groups as Included for both' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Shared Config' }
+            $row.Category | Should -BeExactly 'Device Configurations'
+            $row.'Group A' | Should -BeExactly 'Included'
+            $row.'Group B' | Should -BeExactly 'Included'
+        }
+
+        It 'marks a policy assigned to one group only in that column' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'A Only Config' }
+            $row.'Group A' | Should -BeExactly 'Included'
+            $row.'Group B' | Should -BeExactly ''
+        }
+
+        It 'marks group exclusions on policies as Excluded' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Excluded Config' }
+            $row.'Group A' | Should -BeExactly ''
+            $row.'Group B' | Should -BeExactly 'Excluded'
+        }
+
+        It 'keeps the assignment filter suffix on the policy name' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Filtered Config (Filter: Unknown Filter (f-1) [Include])' }
+            $row.'Group A' | Should -BeExactly 'Included'
+        }
+
+        It 'keeps exclusion-only app assignments visible and tagged Excluded' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Excluded App' }
+            $row.Category | Should -BeExactly 'Required Apps'
+            $row.'Group A' | Should -BeExactly 'Excluded'
+            $row.'Group B' | Should -BeExactly ''
+        }
+
+        It 'buckets apps by assignment intent and skips built-in apps' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Shared App' }
+            $row.Category | Should -BeExactly 'Required Apps'
+            $row.'Group A' | Should -BeExactly 'Included'
+            $row.'Group B' | Should -BeExactly 'Included'
+            @($script:rows | Where-Object { $_.PolicyName -like 'Builtin App*' }).Count | Should -Be 0
+        }
+
+        It 'labels platform and shell scripts with their type marker' {
+            $psRow = $script:rows | Where-Object { $_.PolicyName -eq 'PS One (PowerShell)' }
+            $psRow.Category | Should -BeExactly 'Platform Scripts'
+            $psRow.'Group A' | Should -BeExactly 'Included'
+
+            $shellRow = $script:rows | Where-Object { $_.PolicyName -eq 'Shell One (Shell)' }
+            $shellRow.Category | Should -BeExactly 'Platform Scripts'
+            $shellRow.'Group B' | Should -BeExactly 'Included'
+            $shellRow.'Group A' | Should -BeExactly ''
+        }
+
+        It 'keeps the legacy quirk that platform script exclusions count as Included' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Excluded PS (PowerShell)' }
+            $row.'Group A' | Should -BeExactly 'Included'
+        }
+
+        It 'keeps the legacy inclusion-only matching for health scripts' {
+            $row = $script:rows | Where-Object { $_.PolicyName -eq 'Health One' }
+            $row.Category | Should -BeExactly 'Proactive Remediation Scripts'
+            $row.'Group A' | Should -BeExactly 'Included'
+            @($script:rows | Where-Object { $_.PolicyName -like 'Excluded Health*' }).Count | Should -Be 0
+        }
+
+        It 'keeps the legacy intents-only Endpoint Security scope' {
+            $intentRow = $script:rows | Where-Object { $_.PolicyName -eq 'AV Intent Policy' }
+            $intentRow.Category | Should -BeExactly 'Endpoint Security - Antivirus'
+            $intentRow.'Group B' | Should -BeExactly 'Included'
+
+            # The ES-family configurationPolicies policy stays under Settings Catalog only
+            $cpRows = @($script:rows | Where-Object { $_.PolicyName -eq 'ES CP Policy' })
+            $cpRows.Count | Should -Be 1
+            $cpRows[0].Category | Should -BeExactly 'Settings Catalog'
+            $cpRows[0].'Group A' | Should -BeExactly 'Included'
+        }
+
+        It 'never fetches assignments for ES configurationPolicies policies (prefilter)' {
+            # escp-1 assignments are fetched once per group by the Settings Catalog
+            # category; the Endpoint Security phase 1 must not add extra fetches
+            Should -Invoke Get-IntuneAssignments -Exactly 2 -ParameterFilter { $EntityId -eq 'escp-1' }
+        }
+
+        It 'fetches each entity set from Graph once across both groups' {
+            Should -Invoke Get-IntuneEntities -Exactly 1 -ParameterFilter { $EntityType -eq 'deviceConfigurations' }
+            Should -Invoke Get-IntuneEntities -Exactly 1 -ParameterFilter { $EntityType -eq 'deviceManagement/intents' }
+            Should -Invoke Get-IntuneEntities -Exactly 1 -ParameterFilter { $EntityType -eq 'deviceShellScripts' }
+            Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter { $Uri -like '*mobileApps*isAssigned eq true*' }
+        }
+    }
+
+    Context 'nested group support' {
+        It 'tags assignments inherited from parent groups' {
+            Mock Get-TransitiveGroupMembership {
+                if ($GroupId -eq $script:groupA) {
+                    return @([PSCustomObject]@{ id = 'parent-a'; displayName = 'Parent A' })
+                }
+                @()
+            }
+
+            Compare-IntuneGroupAssignment -CompareGroupNames "$($script:groupA), $($script:groupB)" -IncludeNestedGroups -ExportToCSV -ExportPath $script:csvPath
+            $rows = @(Import-Csv $script:csvPath)
+
+            $row = $rows | Where-Object { $_.PolicyName -eq 'Inherited Config' }
+            $row.'Group A' | Should -BeExactly 'Inherited'
+            $row.'Group B' | Should -BeExactly ''
+
+            Should -Invoke Get-IntuneAssignments -ParameterFilter {
+                $EntityId -eq 'dc-1' -and $GroupIds.Count -eq 2 -and $GroupIds -contains $script:groupA -and $GroupIds -contains 'parent-a'
+            }
+        }
+    }
+}

--- a/Tests/Unit/DeviceAssignment.Tests.ps1
+++ b/Tests/Unit/DeviceAssignment.Tests.ps1
@@ -1,0 +1,328 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-Separator.ps1')
+    . (Join-Path $modulePrivate 'Get-PolicyPlatform.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentSummaryLine.ps1')
+    . (Join-Path $modulePrivate 'Resolve-AssignmentReason.ps1')
+    . (Join-Path $modulePrivate 'Test-PlatformCompatibility.ps1')
+    . (Join-Path $modulePrivate 'Test-AppPlatformCompatibility.ps1')
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Add-CategoryExportData.ps1')
+    . (Join-Path $moduleRoot 'Public/Get-IntuneDeviceAssignment.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:ScopeTagLookup = @{}
+    $script:AssignmentFilterLookup = @{ 'filter-1' = @{ Name = 'Test Filter' } }
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Get-GroupInfo {
+        param([string]$GroupId)
+        @{ Id = $GroupId; DisplayName = 'Group One'; Success = $true }
+    }
+    function Get-DeviceInfo {
+        param([string]$DeviceName)
+        @{ Id = $null; DisplayName = $DeviceName; OperatingSystem = $null; Success = $false; MultipleFound = $false; AllDevices = $null }
+    }
+    function Get-GroupMemberships {
+        param([string]$ObjectId, [string]$ObjectType)
+        @()
+    }
+    function Filter-ByScopeTag {
+        param($Items, $FilterTag, $ScopeTagLookup)
+        $Items
+    }
+    function Export-ResultsIfRequested {
+        param([System.Collections.ArrayList]$ExportData, [string]$DefaultFileName, [switch]$ForceExport, [string]$CustomExportPath, [switch]$ExportToCSV, [switch]$ParameterMode)
+    }
+}
+
+Describe 'Get-IntuneDeviceAssignment' {
+    BeforeEach {
+        $script:memberGroupId = '11111111-1111-1111-1111-111111111111'
+        $script:capturedExport = $null
+        $script:consoleLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { $script:consoleLines.Add("$Object") }
+        Mock Get-IntuneEntities { @() }
+        Mock Get-IntuneAssignments { @() }
+        Mock Add-IntentTemplateFamilyInfo {}
+        Mock Get-GroupInfo { @{ Id = $GroupId; DisplayName = 'Group One'; Success = $true } }
+        Mock Get-DeviceInfo {
+            $os = if ($DeviceName -like 'MAC*') { 'macOS' } else { 'Windows' }
+            @{ Id = "dev-$DeviceName"; DisplayName = $DeviceName; OperatingSystem = $os; Success = $true; MultipleFound = $false; AllDevices = $null }
+        }
+        Mock Get-GroupMemberships { @([PSCustomObject]@{ id = $script:memberGroupId; displayName = 'Group One' }) }
+        Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+    }
+
+    It 'exports the Device row first' {
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $script:capturedExport[0].Category | Should -BeExactly 'Device'
+        $script:capturedExport[0].Item | Should -BeExactly 'PC-1 (ID: dev-PC-1)'
+        $script:capturedExport[0].AssignmentReason | Should -BeExactly 'N/A'
+    }
+
+    It 'renders the legacy display sections in order with device-specific empty messages' {
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $sectionTitles = @($script:consoleLines | Where-Object { $_ -match '^------- (.+) -------$' } | ForEach-Object { $Matches[1] })
+        $sectionTitles | Should -Be @(
+            'Device Configurations', 'Settings Catalog Policies', 'Compliance Policies', 'App Protection Policies',
+            'App Configuration Policies', 'Platform Scripts', 'Proactive Remediation Scripts',
+            'Autopilot Deployment Profiles', 'Enrollment Status Page Profiles',
+            'Required Apps', 'Available Apps', 'Uninstall Apps',
+            'Endpoint Security - Antivirus Profiles', 'Endpoint Security - Disk Encryption Profiles',
+            'Endpoint Security - Firewall Profiles', 'Endpoint Security - EDR Profiles',
+            'Endpoint Security - ASR Profiles', 'Endpoint Security - Account Protection Profiles')
+        $script:consoleLines | Should -Contain 'No Device Configurations found for this device.'
+    }
+
+    It 'resolves reasons for member groups and All Devices and drops other-platform policies' {
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceConfigurations') {
+                return @(
+                    [PSCustomObject]@{ id = 'cfg-win'; displayName = 'Win Config'; '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration' }
+                    [PSCustomObject]@{ id = 'cfg-ios'; displayName = 'iOS Config'; '@odata.type' = '#microsoft.graph.iosGeneralDeviceConfiguration' }
+                    [PSCustomObject]@{ id = 'cfg-excl'; displayName = 'Excluded Config'; '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration' }
+                )
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            switch ($EntityId) {
+                'cfg-win' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = $script:memberGroupId; FilterId = 'filter-1'; FilterType = 'include' }) }
+                'cfg-ios' { @([PSCustomObject]@{ Reason = 'All Devices'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+                'cfg-excl' { @([PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = $script:memberGroupId; FilterId = $null; FilterType = $null }) }
+                default { @() }
+            }
+        }
+
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $rows = @($script:capturedExport | Where-Object { $_.Category -eq 'Device Configuration' })
+        $rows.Count | Should -Be 2
+        $rows[0].Item | Should -BeExactly 'Win Config (ID: cfg-win)'
+        $rows[0].AssignmentReason | Should -BeExactly 'Group Assignment (Filter: Test Filter [Include])'
+        $rows[1].AssignmentReason | Should -BeExactly 'Excluded'
+        # The iOS-only policy must be dropped for a Windows device
+        @($rows | Where-Object { $_.Item -like '*cfg-ios*' }).Count | Should -Be 0
+    }
+
+    Context 'applications' {
+        BeforeEach {
+            Mock Invoke-MgGraphRequest {
+                if ($Uri -like '*mobileApps?*isAssigned*') {
+                    return @{ value = @(
+                            @{ id = 'app-f14'; displayName = 'F14 App'; isFeatured = $false; isBuiltIn = $false; '@odata.type' = '#microsoft.graph.win32LobApp' }
+                            @{ id = 'app-excl'; displayName = 'Excluded App'; isFeatured = $false; isBuiltIn = $false; '@odata.type' = '#microsoft.graph.win32LobApp' }
+                            @{ id = 'app-ios'; displayName = 'iOS App'; isFeatured = $false; isBuiltIn = $false; '@odata.type' = '#microsoft.graph.iosStoreApp' }
+                        )
+                    }
+                }
+                if ($Uri -like "*mobileApps('app-f14')/assignments*") {
+                    # F14 fixture: intent comes from the first inclusion assignment (available),
+                    # the reason text from the last matching one (member group assignment)
+                    return @{ value = @(
+                            @{ intent = 'available'; target = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget'; deviceAndAppManagementAssignmentFilterId = 'filter-1'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                            @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:memberGroupId } }
+                        )
+                    }
+                }
+                if ($Uri -like "*mobileApps('app-excl')/assignments*") {
+                    return @{ value = @(
+                            @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:memberGroupId } }
+                            @{ intent = 'uninstall'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:memberGroupId } }
+                        )
+                    }
+                }
+                return @{ value = @() }
+            }
+        }
+
+        It 'buckets a multi-assignment app by the first inclusion intent with the last inclusion reason (F14)' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+            $availableRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Available Apps' })
+            $availableRows.Count | Should -Be 1
+            $availableRows[0].Item | Should -BeExactly 'F14 App (ID: app-f14)'
+            $availableRows[0].AssignmentReason | Should -BeExactly 'Group Assignment - Group One (Filter: Test Filter [Include])'
+            @($script:capturedExport | Where-Object { $_.Category -eq 'Required Apps' -and $_.Item -like '*app-f14*' }).Count | Should -Be 0
+        }
+
+        It 'shows excluded apps under the excluding assignment intent' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+            $uninstallRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Uninstall Apps' })
+            $uninstallRows.Count | Should -Be 1
+            $uninstallRows[0].Item | Should -BeExactly 'Excluded App (ID: app-excl)'
+            $uninstallRows[0].AssignmentReason | Should -BeExactly 'Excluded via group: Group One'
+        }
+
+        It 'never fetches assignments for apps of another platform' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+            Should -Invoke Invoke-MgGraphRequest -Times 0 -ParameterFilter { $Uri -like "*mobileApps('app-ios')*" }
+            @($script:capturedExport | Where-Object { $_.Item -like '*app-ios*' }).Count | Should -Be 0
+        }
+    }
+
+    It 'keeps App Protection policies only when the device is targeted and drops All Users targets' {
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceAppManagement/managedAppPolicies') {
+                return @(
+                    [PSCustomObject]@{ id = 'mam-member'; displayName = 'Member MAM'; '@odata.type' = '#microsoft.graph.windowsManagedAppProtection' }
+                    [PSCustomObject]@{ id = 'mam-other'; displayName = 'Nonmember MAM'; '@odata.type' = '#microsoft.graph.windowsManagedAppProtection' }
+                    [PSCustomObject]@{ id = 'mam-android'; displayName = 'Android MAM'; '@odata.type' = '#microsoft.graph.androidManagedAppProtection' }
+                )
+            }
+            @()
+        }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like "*windowsManagedAppProtections('mam-member')/assignments*") {
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:memberGroupId } }
+                    )
+                }
+            }
+            if ($Uri -like "*windowsManagedAppProtections('mam-other')/assignments*") {
+                return @{ value = @(@{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'not-a-member' } }) }
+            }
+            return @{ value = @() }
+        }
+
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $rows = @($script:capturedExport | Where-Object { $_.Category -eq 'App Protection Policy' })
+        $rows.Count | Should -Be 1
+        $rows[0].Item | Should -BeExactly 'Member MAM (ID: mam-member)'
+        $rows[0].AssignmentReason | Should -BeExactly 'Group Assignment - Group One'
+        # Platform-incompatible policies never trigger an assignment fetch
+        Should -Invoke Invoke-MgGraphRequest -Times 0 -ParameterFilter { $Uri -like '*androidManagedAppProtections*' }
+    }
+
+    It 'surfaces Endpoint Security policies from both configurationPolicies and intents' {
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'configurationPolicies' {
+                    return @([PSCustomObject]@{ id = 'av-1'; name = 'AV Policy'; platforms = @('windows10'); technologies = 'mdm'; templateReference = @{ templateFamily = 'endpointSecurityAntivirus' } })
+                }
+                'deviceManagement/intents' {
+                    return @([PSCustomObject]@{ id = 'av-int-1'; displayName = 'AV Intent'; templateId = 'tmpl-av'; templateReference = @{ templateFamily = 'endpointSecurityAntivirus' } })
+                }
+                default { return @() }
+            }
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityId -eq 'av-1') { return @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = $script:memberGroupId; FilterId = $null; FilterType = $null }) }
+            @()
+        }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*intents/av-int-1/assignments*') {
+                return @{ value = @(@{ target = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget' } }) }
+            }
+            return @{ value = @() }
+        }
+
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $rows = @($script:capturedExport | Where-Object { $_.Category -eq 'Endpoint Security - Antivirus' })
+        $rows.Count | Should -Be 2
+        $rows[0].Item | Should -BeExactly 'AV Policy (ID: av-1)'
+        $rows[0].AssignmentReason | Should -BeExactly 'Group Assignment'
+        $rows[1].Item | Should -BeExactly 'AV Intent (ID: av-int-1)'
+        $rows[1].AssignmentReason | Should -BeExactly 'All Devices'
+    }
+
+    Context 'Windows-conditional categories' {
+        It 'fetches Autopilot, ESP and Windows 365 categories for a Windows device' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+            foreach ($windowsEntityType in @('windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
+                Should -Invoke Get-IntuneEntities -Exactly -Times 1 -ParameterFilter { $EntityType -eq $windowsEntityType }
+            }
+        }
+
+        It 'never fetches Autopilot, ESP or Windows 365 categories for a macOS device' {
+            Get-IntuneDeviceAssignment -DeviceNames 'MAC-1'
+
+            foreach ($windowsEntityType in @('windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
+                Should -Invoke Get-IntuneEntities -Times 0 -ParameterFilter { $EntityType -eq $windowsEntityType }
+            }
+        }
+    }
+
+    Context 'multiple devices' {
+        It 'processes every device from a comma-separated parameter' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1,PC-2'
+
+            $deviceRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Device' })
+            $deviceRows.Count | Should -Be 2
+            $deviceRows[0].Item | Should -BeExactly 'PC-1 (ID: dev-PC-1)'
+            $deviceRows[1].Item | Should -BeExactly 'PC-2 (ID: dev-PC-2)'
+        }
+
+        It 'fetches each entity set once for the whole run (shared entity cache)' {
+            Get-IntuneDeviceAssignment -DeviceNames 'PC-1,PC-2'
+
+            Should -Invoke Get-IntuneEntities -Exactly -Times 1 -ParameterFilter { $EntityType -eq 'configurationPolicies' }
+            Should -Invoke Get-IntuneEntities -Exactly -Times 1 -ParameterFilter { $EntityType -eq 'deviceManagement/intents' }
+            Should -Invoke Invoke-MgGraphRequest -Exactly -Times 1 -ParameterFilter { $Uri -like '*mobileApps?*isAssigned*' }
+        }
+    }
+
+    It 'exports categories in the legacy CSV order' {
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'deviceConfigurations' { return @([PSCustomObject]@{ id = 'cfg-1'; displayName = 'Cfg'; '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration' }) }
+                'windowsAutopilotDeploymentProfiles' { return @([PSCustomObject]@{ id = 'ap-1'; displayName = 'AP' }) }
+                'virtualEndpoint/provisioningPolicies' { return @([PSCustomObject]@{ id = 'cpc-1'; displayName = 'CPC' }) }
+                'configurationPolicies' { return @([PSCustomObject]@{ id = 'av-1'; name = 'AV'; platforms = @('windows10'); technologies = 'mdm'; templateReference = @{ templateFamily = 'endpointSecurityAntivirus' } }) }
+                default { return @() }
+            }
+        }
+        Mock Get-IntuneAssignments { @([PSCustomObject]@{ Reason = 'All Devices'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*mobileApps?*isAssigned*') {
+                return @{ value = @(@{ id = 'app-1'; displayName = 'App'; isFeatured = $false; isBuiltIn = $false; '@odata.type' = '#microsoft.graph.win32LobApp' }) }
+            }
+            if ($Uri -like "*mobileApps('app-1')/assignments*") {
+                return @{ value = @(@{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget' } }) }
+            }
+            return @{ value = @() }
+        }
+
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        # Autopilot before Endpoint Security, Windows 365 after it, app buckets last
+        $categorySequence = @($script:capturedExport | ForEach-Object { $_.Category })
+        $categorySequence | Should -Be @('Device', 'Device Configuration', 'Settings Catalog Policy', 'Autopilot Deployment Profile',
+            'Endpoint Security - Antivirus', 'Windows 365 Cloud PC Provisioning Policy', 'Required Apps')
+    }
+}

--- a/Tests/Unit/GroupAssignment.Tests.ps1
+++ b/Tests/Unit/GroupAssignment.Tests.ps1
@@ -1,0 +1,257 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-Separator.ps1')
+    . (Join-Path $modulePrivate 'Get-PolicyPlatform.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Show-CategoryResultTable.ps1')
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $modulePrivate 'Get-GroupAssignmentReasons.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Add-CategoryExportData.ps1')
+    . (Join-Path $moduleRoot 'Public/Get-IntuneGroupAssignment.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:ScopeTagLookup = @{}
+    $script:AssignmentFilterLookup = @{}
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Get-GroupInfo {
+        param([string]$GroupId)
+        @{ Id = $GroupId; DisplayName = 'Test Group'; Success = $true }
+    }
+    function Get-TransitiveGroupMembership {
+        param([string]$GroupId)
+        @()
+    }
+    function Filter-ByScopeTag {
+        param($Items, $FilterTag, $ScopeTagLookup)
+        $Items
+    }
+    function Export-ResultsIfRequested {
+        param([System.Collections.ArrayList]$ExportData, [string]$DefaultFileName, [switch]$ForceExport, [string]$CustomExportPath, [switch]$ExportToCSV, [switch]$ParameterMode)
+    }
+}
+
+Describe 'Show-CategoryResultTable' {
+    BeforeEach {
+        $script:consoleLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { $script:consoleLines.Add("$ForegroundColor|$Object") }
+    }
+
+    It 'renders the section header block in Cyan' {
+        Show-CategoryResultTable -Title 'Device Configurations' -Items @()
+
+        $script:consoleLines[0] | Should -BeExactly "Cyan|`n$('-' * ('Device Configurations'.Length + 16))"
+        $script:consoleLines[1] | Should -BeExactly 'Cyan|------- Device Configurations -------'
+    }
+
+    It 'renders the default empty message in Gray when there are no items' {
+        Show-CategoryResultTable -Title 'Compliance Policies' -Items @()
+
+        $script:consoleLines | Should -Contain 'Gray|No Compliance Policies found.'
+    }
+
+    It 'renders a custom empty message when provided' {
+        Show-CategoryResultTable -Title 'Compliance Policies' -Items $null -EmptyMessage 'No Compliance Policies found for this group.'
+
+        $script:consoleLines | Should -Contain 'Gray|No Compliance Policies found for this group.'
+    }
+
+    It 'renders the column header in Yellow for non-empty sections' {
+        $items = @([PSCustomObject]@{ id = 'pol-1'; displayName = 'Policy One'; AssignmentReason = 'Direct Assignment' })
+        Show-CategoryResultTable -Title 'Policies' -Items $items
+
+        $expectedHeader = 'Yellow|' + ('{0,-40} {1,-15} {2,-20} {3,-30} {4,-35}' -f 'Policy Name', 'Platform', 'Scope Tags', 'ID', 'Assignment')
+        $script:consoleLines | Should -Contain $expectedHeader
+    }
+
+    It 'applies the legacy row coloring per assignment reason' {
+        $items = @(
+            [PSCustomObject]@{ id = 'p1'; displayName = 'Direct Policy'; AssignmentReason = 'Direct Assignment' }
+            [PSCustomObject]@{ id = 'p2'; displayName = 'Inherited Policy'; AssignmentReason = 'Inherited (via Parent)' }
+            [PSCustomObject]@{ id = 'p3'; displayName = 'Excluded Policy'; AssignmentReason = 'Direct Exclusion' }
+            [PSCustomObject]@{ id = 'p4'; displayName = 'Parent Excluded Policy'; AssignmentReason = 'Inherited Exclusion (via Parent)' }
+            [PSCustomObject]@{ id = 'p5'; displayName = 'Group Excluded App'; AssignmentReason = 'Group Exclusion' }
+        )
+        Show-CategoryResultTable -Title 'Policies' -Items $items
+
+        @($script:consoleLines | Where-Object { $_ -like 'White|Direct Policy*' }).Count | Should -Be 1
+        @($script:consoleLines | Where-Object { $_ -like 'DarkYellow|Inherited Policy*' }).Count | Should -Be 1
+        @($script:consoleLines | Where-Object { $_ -like 'Red|Excluded Policy*' }).Count | Should -Be 1
+        @($script:consoleLines | Where-Object { $_ -like 'Magenta|Parent Excluded Policy*' }).Count | Should -Be 1
+        # Legacy quirk: "Group Exclusion" (issue #126 app reason) stays White
+        @($script:consoleLines | Where-Object { $_ -like 'White|Group Excluded App*' }).Count | Should -Be 1
+    }
+
+    It 'falls back to displayName, then name, then Unnamed Profile by default' {
+        $items = @(
+            [PSCustomObject]@{ id = 'p1'; displayName = 'Display Name'; name = 'Name'; AssignmentReason = 'Direct Assignment' }
+            [PSCustomObject]@{ id = 'p2'; displayName = $null; name = 'Name Only'; AssignmentReason = 'Direct Assignment' }
+            [PSCustomObject]@{ id = 'p3'; displayName = $null; name = $null; AssignmentReason = 'Direct Assignment' }
+        )
+        Show-CategoryResultTable -Title 'Policies' -Items $items
+
+        @($script:consoleLines | Where-Object { $_ -like 'White|Display Name *' }).Count | Should -Be 1
+        @($script:consoleLines | Where-Object { $_ -like 'White|Name Only *' }).Count | Should -Be 1
+        @($script:consoleLines | Where-Object { $_ -like 'White|Unnamed Profile *' }).Count | Should -Be 1
+    }
+
+    It 'uses a caller-provided GetName scriptblock' {
+        $items = @([PSCustomObject]@{ id = 'p1'; displayName = 'Display'; name = 'Preferred'; AssignmentReason = 'Direct Assignment' })
+        Show-CategoryResultTable -Title 'Policies' -Items $items -GetName { param($item) $item.name }
+
+        @($script:consoleLines | Where-Object { $_ -like 'White|Preferred *' }).Count | Should -Be 1
+    }
+
+    It 'truncates long values exactly like the legacy table' {
+        $longName = 'A' * 50
+        $items = @([PSCustomObject]@{ id = 'p1'; displayName = $longName; AssignmentReason = 'Direct Assignment' })
+        Show-CategoryResultTable -Title 'Policies' -Items $items
+
+        $expectedName = ('A' * 34) + '...'
+        @($script:consoleLines | Where-Object { $_ -like "White|$expectedName *" }).Count | Should -Be 1
+    }
+}
+
+Describe 'Get-IntuneGroupAssignment' {
+    BeforeEach {
+        $script:groupGuid = '11111111-1111-1111-1111-111111111111'
+        $script:capturedExport = $null
+        Mock Write-Host {}
+        Mock Get-IntuneEntities { @() }
+        Mock Get-IntuneAssignments { @() }
+        Mock Add-IntentTemplateFamilyInfo {}
+        Mock Get-TransitiveGroupMembership { @() }
+        Mock Get-GroupInfo { @{ Id = $GroupId; DisplayName = 'Sales Team'; Success = $true } }
+        Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*mobileApps*isAssigned eq true*') {
+                return @{ value = @(
+                        [PSCustomObject]@{ id = 'app-inc'; displayName = 'Included App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-exc'; displayName = 'Excluded Only App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-both'; displayName = 'Included And Excluded App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-exc-uninstall'; displayName = 'Excluded Uninstall App'; isFeatured = $false; isBuiltIn = $false }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-inc')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupGuid } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-exc')/assignments*") {
+                # Issue #126 fixture: exclusion-only assignment for the checked group
+                return @{ value = @(
+                        @{ intent = 'available'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:groupGuid } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-both')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupGuid } }
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:groupGuid } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-exc-uninstall')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'uninstall'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:groupGuid } }
+                    )
+                }
+            }
+            return @{ value = @() }
+        }
+    }
+
+    It 'exports the corrected Group row first' {
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $script:capturedExport[0].Category | Should -BeExactly 'Group'
+        $script:capturedExport[0].Item | Should -BeExactly "Sales Team (ID: $($script:groupGuid))"
+        $script:capturedExport[0].AssignmentReason | Should -BeExactly 'N/A'
+    }
+
+    It 'keeps exclusion-only apps under the excluding assignment intent (issue #126)' {
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $availableRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Available Apps' })
+        $availableRows.Count | Should -Be 1
+        $availableRows[0].Item | Should -BeExactly 'Excluded Only App (ID: app-exc)'
+        $availableRows[0].AssignmentReason | Should -BeExactly 'Group Exclusion'
+
+        $uninstallRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Uninstall Apps' })
+        $uninstallRows.Count | Should -Be 1
+        $uninstallRows[0].Item | Should -BeExactly 'Excluded Uninstall App (ID: app-exc-uninstall)'
+        $uninstallRows[0].AssignmentReason | Should -BeExactly 'Group Exclusion'
+    }
+
+    It 'prefers the inclusion intent when the group is both included and excluded' {
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $requiredRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Required Apps' })
+        @($requiredRows | Where-Object { $_.Item -eq 'Included App (ID: app-inc)' -and $_.AssignmentReason -eq 'Direct Assignment' }).Count | Should -Be 1
+        @($requiredRows | Where-Object { $_.Item -eq 'Included And Excluded App (ID: app-both)' -and $_.AssignmentReason -eq 'Direct Assignment; Group Exclusion' }).Count | Should -Be 1
+    }
+
+    It 'resolves inherited assignment reasons through the parent group map' {
+        Mock Get-TransitiveGroupMembership { @([PSCustomObject]@{ id = 'parent-1'; displayName = 'All Staff' }) }
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceConfigurations') {
+                return @([PSCustomObject]@{ id = 'dc-1'; displayName = 'Config One' })
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityId -eq 'dc-1') {
+                return @([PSCustomObject]@{ Reason = 'Direct Exclusion'; GroupId = 'parent-1'; FilterId = $null; FilterType = $null })
+            }
+            @()
+        }
+
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $configRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Device Configuration' })
+        $configRows.Count | Should -Be 1
+        $configRows[0].AssignmentReason | Should -BeExactly 'Inherited Exclusion (via All Staff)'
+    }
+
+    It 'passes the direct and parent group ids to the category scan' {
+        Mock Get-TransitiveGroupMembership { @([PSCustomObject]@{ id = 'parent-1'; displayName = 'All Staff' }) }
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceConfigurations') {
+                return @([PSCustomObject]@{ id = 'dc-1'; displayName = 'Config One' })
+            }
+            @()
+        }
+
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        Should -Invoke Get-IntuneAssignments -ParameterFilter {
+            $EntityId -eq 'dc-1' -and $GroupIds.Count -eq 2 -and $GroupIds -contains $script:groupGuid -and $GroupIds -contains 'parent-1'
+        }
+    }
+}

--- a/Tests/Unit/TestGroupMembership.Tests.ps1
+++ b/Tests/Unit/TestGroupMembership.Tests.ps1
@@ -1,0 +1,335 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-Separator.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $modulePrivate 'Resolve-AssignmentReason.ps1')
+    . (Join-Path $modulePrivate 'Resolve-SimulatedAssignmentDelta.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $moduleRoot 'Public/Test-IntuneGroupMembership.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:ScopeTagLookup = @{}
+    $script:AssignmentFilterLookup = @{}
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-UserInfo {
+        param([string]$UserPrincipalName)
+        @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false }
+    }
+    function Get-DeviceInfo {
+        param([string]$DeviceName)
+        @{ Id = $null; DisplayName = $DeviceName; Success = $false; MultipleFound = $false; AllDevices = @() }
+    }
+    function Get-GroupMemberships {
+        param([string]$ObjectId, [string]$ObjectType)
+        @()
+    }
+    function Get-GroupInfo {
+        param([string]$GroupId)
+        @{ Id = $GroupId; DisplayName = 'Target Group'; Success = $true }
+    }
+    function Get-TransitiveGroupMembership {
+        param([string]$GroupId)
+        @()
+    }
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Filter-ByScopeTag {
+        param($Items, $FilterTag, $ScopeTagLookup)
+        $Items
+    }
+    function Export-ResultsIfRequested {
+        param([System.Collections.ArrayList]$ExportData, [string]$DefaultFileName, [switch]$ForceExport, [string]$CustomExportPath, [switch]$ExportToCSV, [switch]$ParameterMode)
+    }
+}
+
+Describe 'Test-IntuneGroupMembership' {
+    BeforeEach {
+        $script:capturedExport = $null
+        $script:hostLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { if ($null -ne $Object) { $script:hostLines.Add([string]$Object) } }
+        Mock Start-Sleep {}
+        Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
+        Mock Get-UserInfo {
+            if ($UserPrincipalName -eq 'user1@contoso.com') { @{ Id = 'u1'; UserPrincipalName = $UserPrincipalName; Success = $true } }
+            else { @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false } }
+        }
+        Mock Get-DeviceInfo {
+            if ($DeviceName -eq 'DEV1') { @{ Id = 'd1'; DisplayName = 'DEV1'; Success = $true; MultipleFound = $false; AllDevices = @() } }
+            else { @{ Id = $null; DisplayName = $DeviceName; Success = $false; MultipleFound = $false; AllDevices = @() } }
+        }
+        Mock Get-GroupMemberships {
+            switch ($ObjectType) {
+                'User' { @([PSCustomObject]@{ id = 'g-cur'; displayName = 'Current Group' }) }
+                'Device' { @([PSCustomObject]@{ id = 'g-dev'; displayName = 'Device Group' }) }
+                default { @() }
+            }
+        }
+        Mock Get-TransitiveGroupMembership { @() }
+        Mock Add-IntentTemplateFamilyInfo {
+            foreach ($intent in $IntentPolicies) {
+                if ($intent.id -eq 'av-intent') {
+                    $intent | Add-Member -NotePropertyName 'templateReference' -NotePropertyValue ([PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' }) -Force
+                }
+            }
+        }
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'deviceConfigurations' {
+                    @(
+                        [PSCustomObject]@{ id = 'dc-new'; displayName = 'New Config' }
+                        [PSCustomObject]@{ id = 'dc-cur'; displayName = 'Current Config' }
+                        [PSCustomObject]@{ id = 'dc-allusers'; displayName = 'All Users Config' }
+                        [PSCustomObject]@{ id = 'dc-alldev'; displayName = 'All Devices Config' }
+                        [PSCustomObject]@{ id = 'dc-conflict'; displayName = 'Conflict Config' }
+                        [PSCustomObject]@{ id = 'dc-devconflict'; displayName = 'Device Conflict Config' }
+                    )
+                }
+                'configurationPolicies' {
+                    @([PSCustomObject]@{ id = 'av-cfg'; name = 'AV Config Policy'; templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' } })
+                }
+                'deviceAppManagement/managedAppPolicies' {
+                    @(
+                        [PSCustomObject]@{ id = 'apppol-new'; displayName = 'AP New'; '@odata.type' = '#microsoft.graph.androidManagedAppProtection' }
+                        [PSCustomObject]@{ id = 'apppol-alldev'; displayName = 'AP AllDev'; '@odata.type' = '#microsoft.graph.androidManagedAppProtection' }
+                    )
+                }
+                'deviceManagement/intents' {
+                    @([PSCustomObject]@{ id = 'av-intent'; displayName = 'AV Intent Legacy' })
+                }
+                default { @() }
+            }
+        }
+        Mock Get-IntuneAssignments {
+            switch ($EntityId) {
+                'dc-new' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }) }
+                'dc-cur' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-cur'; FilterId = $null; FilterType = $null }) }
+                'dc-allusers' { @([PSCustomObject]@{ Reason = 'All Users'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+                'dc-alldev' { @([PSCustomObject]@{ Reason = 'All Devices'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+                'dc-conflict' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = 'g-cur'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'dc-devconflict' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = 'g-dev'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'av-cfg' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }) }
+                default { @() }
+            }
+        }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*v1.0/groups?*') {
+                return @{ value = @([PSCustomObject]@{ id = 'g-target'; displayName = 'Target Group' }) }
+            }
+            if ($Uri -like '*mobileApps?*isAssigned*') {
+                return @{ value = @(
+                        [PSCustomObject]@{ id = 'app-new'; displayName = 'New App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-conflict'; displayName = 'Conflict App'; isFeatured = $false; isBuiltIn = $false }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-new')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-target' } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-conflict')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = 'g-cur' } }
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-target' } }
+                    )
+                }
+            }
+            if ($Uri -like "*androidManagedAppProtections('apppol-new')/assignments*") {
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-target' } }
+                    )
+                }
+            }
+            if ($Uri -like "*androidManagedAppProtections('apppol-alldev')/assignments*") {
+                # Legacy App Protection walk never mapped All Devices targets
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget' } }
+                    )
+                }
+            }
+            if ($Uri -like '*deviceManagement/intents/av-intent/assignments*') {
+                # Filter fields present on the target, but the legacy intent rows carried
+                # Reason/GroupId only, so the delta reason must have no filter suffix
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-target'; deviceAndAppManagementAssignmentFilterId = 'f1'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                    )
+                }
+            }
+            return @{ value = @() }
+        }
+    }
+
+    It 'exports the Simulation Info row first with the legacy subject label' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $script:capturedExport[0].Category | Should -BeExactly 'Simulation Info'
+        $script:capturedExport[0].Item | Should -BeExactly "User 'user1@contoso.com' -> Group: Target Group (ID: g-target)"
+        $script:capturedExport[0].AssignmentReason | Should -BeExactly 'Impact Analysis'
+    }
+
+    It 'reports policies gained via the target group as NEW and drops already-received policies' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $configRows = @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: Device Configuration' })
+        @($configRows | Where-Object { $_.Item -eq 'New Config (ID: dc-new)' -and $_.AssignmentReason -eq 'Group Assignment' }).Count | Should -Be 1
+        # Already received via another group or All Users: not part of the delta
+        @($script:capturedExport | Where-Object { $_.Item -like '*dc-cur*' }).Count | Should -Be 0
+        @($script:capturedExport | Where-Object { $_.Item -like '*dc-allusers*' }).Count | Should -Be 0
+    }
+
+    It 'reports exclusion conflicts with the legacy category label and wording' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $conflictRows = @($script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Device Configuration' })
+        $conflictRows.Count | Should -Be 1
+        $conflictRows[0].Item | Should -BeExactly 'Conflict Config (ID: dc-conflict)'
+        $conflictRows[0].AssignmentReason | Should -BeExactly 'Currently excluded; target group includes it'
+    }
+
+    It 'runs device-only against device memberships and never treats All Devices targets as new' {
+        Test-IntuneGroupMembership -DeviceNames 'DEV1' -SimulateTargetGroup 'Target Group'
+
+        $script:capturedExport[0].Item | Should -BeExactly "Device 'DEV1' -> Group: Target Group (ID: g-target)"
+        # Assigned to the target group: new for the device too
+        @($script:capturedExport | Where-Object { $_.Item -eq 'New Config (ID: dc-new)' }).Count | Should -Be 1
+        # All Devices already applies; the device exclusion conflict surfaces instead of the user one
+        @($script:capturedExport | Where-Object { $_.Item -like '*dc-alldev*' }).Count | Should -Be 0
+        @($script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Device Configuration' -and $_.Item -like '*dc-devconflict*' }).Count | Should -Be 1
+        # App Protection assignments never match All Devices targets (legacy walk parity)
+        @($script:capturedExport | Where-Object { $_.Item -like '*apppol-alldev*' }).Count | Should -Be 0
+    }
+
+    It 'unions user and device memberships in a combined run' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -DeviceNames 'DEV1' -SimulateTargetGroup 'Target Group'
+
+        $script:capturedExport[0].Item | Should -BeExactly "User 'user1@contoso.com' + Device 'DEV1' -> Group: Target Group (ID: g-target)"
+        # Both exclusion conflicts surface because current membership is the union of user and device groups
+        $conflictItems = @($script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Device Configuration' } | ForEach-Object { $_.Item })
+        $conflictItems | Should -Contain 'Conflict Config (ID: dc-conflict)'
+        $conflictItems | Should -Contain 'Device Conflict Config (ID: dc-devconflict)'
+        # dc-devconflict is NOT new (it is a conflict), and already-had policies stay absent
+        @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: Device Configuration' -and $_.Item -like '*dc-devconflict*' }).Count | Should -Be 0
+        @($script:capturedExport | Where-Object { $_.Item -like '*dc-allusers*' -or $_.Item -like '*dc-alldev*' }).Count | Should -Be 0
+    }
+
+    It 'resolves Endpoint Security across both phases, keeping the legacy Settings Catalog double-count and no intent filter suffix' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        # av-cfg surfaces both as a Settings Catalog policy and as an ES Antivirus profile (legacy walk had no ES filter)
+        @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: Settings Catalog Policy' -and $_.Item -eq 'AV Config Policy (ID: av-cfg)' }).Count | Should -Be 1
+        $avRows = @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: Endpoint Security - Antivirus' })
+        $avRows.Count | Should -Be 2
+        @($avRows | Where-Object { $_.Item -eq 'AV Config Policy (ID: av-cfg)' -and $_.AssignmentReason -eq 'Group Assignment' }).Count | Should -Be 1
+        # The intent target carries filter fields, but the legacy reason has no suffix
+        @($avRows | Where-Object { $_.Item -eq 'AV Intent Legacy (ID: av-intent)' -and $_.AssignmentReason -eq 'Group Assignment' }).Count | Should -Be 1
+    }
+
+    It 'routes new apps by intent and reports app exclusion conflicts with the intent label' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $requiredRows = @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: Required App' })
+        $requiredRows.Count | Should -Be 1
+        $requiredRows[0].Item | Should -BeExactly 'New App (ID: app-new)'
+        $requiredRows[0].AssignmentReason | Should -BeExactly 'Group Assignment'
+        $appConflicts = @($script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Application (required)' })
+        $appConflicts.Count | Should -Be 1
+        $appConflicts[0].Item | Should -BeExactly 'Conflict App (ID: app-conflict)'
+    }
+
+    It 'reports new App Protection policies gained via the target group' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $apRows = @($script:capturedExport | Where-Object { $_.Category -eq 'NEW: App Protection Policy' })
+        $apRows.Count | Should -Be 1
+        $apRows[0].Item | Should -BeExactly 'AP New (ID: apppol-new)'
+        $apRows[0].AssignmentReason | Should -BeExactly 'Group Assignment'
+    }
+
+    It 'fetches each entity set from Graph only once even with user and device supplied' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -DeviceNames 'DEV1' -SimulateTargetGroup 'Target Group'
+
+        # The legacy walk fetched configurationPolicies 7 times and intents 6 times per run
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'configurationPolicies' }
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'deviceManagement/intents' }
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'deviceConfigurations' }
+        Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly -ParameterFilter { $Uri -like '*mobileApps?*isAssigned*' }
+    }
+
+    It 'emits the legacy 18-step progress lines' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
+
+        $script:hostLines | Should -Contain '[1/18] Fetching Device Configurations...'
+        $script:hostLines | Should -Contain '[6/18] Fetching Applications...'
+        $script:hostLines | Should -Contain '[9/18] Fetching Antivirus Policies...'
+        $script:hostLines | Should -Contain '[12/18] Fetching Endpoint Detection and Response Policies...'
+        $script:hostLines | Should -Contain '[15/18] Fetching Autopilot Deployment Profiles...'
+        $script:hostLines | Should -Contain '[16/18] Fetching Enrollment Status Page Profiles...'
+        $script:hostLines | Should -Contain '[18/18] Fetching Windows 365 Cloud PC User Settings...'
+    }
+
+    It 'escapes single quotes in the group name OData filter (F9)' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup "O'Brien Team"
+
+        Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly -ParameterFilter { $Uri -like "*displayName eq 'O''Brien Team'*" }
+    }
+
+    It 'emits export categories in the legacy CSV order' {
+        Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -DeviceNames 'DEV1' -SimulateTargetGroup 'Target Group'
+
+        $expectedOrder = @(
+            'Simulation Info',
+            'NEW: Device Configuration', 'NEW: Settings Catalog Policy', 'NEW: Compliance Policy',
+            'NEW: App Protection Policy', 'NEW: App Configuration Policy',
+            'NEW: Required App', 'NEW: Available App', 'NEW: Uninstall App',
+            'NEW: Platform Script', 'NEW: Proactive Remediation Script',
+            'NEW: Endpoint Security - Antivirus', 'NEW: Endpoint Security - Disk Encryption',
+            'NEW: Endpoint Security - Firewall', 'NEW: Endpoint Security - EDR',
+            'NEW: Endpoint Security - ASR', 'NEW: Endpoint Security - Account Protection',
+            'NEW: Autopilot Deployment Profile', 'NEW: Enrollment Status Page Profile',
+            'NEW: Cloud PC Provisioning Policy', 'NEW: Cloud PC User Setting',
+            'CONFLICT: Device Configuration', 'CONFLICT: Application (required)'
+        )
+        $actualOrder = @($script:capturedExport.Category | Select-Object -Unique)
+        # Empty buckets emit no rows; the observed sequence must be a subsequence of the legacy order
+        $cursor = 0
+        foreach ($category in $actualOrder) {
+            $position = $expectedOrder.IndexOf($category)
+            $position | Should -BeGreaterOrEqual $cursor -Because "category '$category' must not appear out of legacy order"
+            $cursor = $position
+        }
+    }
+}

--- a/Tests/Unit/TestGroupRemoval.Tests.ps1
+++ b/Tests/Unit/TestGroupRemoval.Tests.ps1
@@ -1,0 +1,327 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-Separator.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $modulePrivate 'Resolve-AssignmentReason.ps1')
+    . (Join-Path $modulePrivate 'Resolve-SimulatedAssignmentDelta.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $moduleRoot 'Public/Test-IntuneGroupRemoval.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:ScopeTagLookup = @{}
+    $script:AssignmentFilterLookup = @{ 'f1' = @{ Name = 'Filter One' } }
+
+    # Builds one raw Graph assignment object (apps, app protection, intents)
+    function Build-RawAssignment {
+        param([string]$Type, [string]$TargetGroupId, [string]$FilterId, [string]$FilterType, [string]$Intent)
+        [PSCustomObject]@{
+            intent = $Intent
+            target = [PSCustomObject]@{
+                '@odata.type'                              = $Type
+                groupId                                    = $TargetGroupId
+                deviceAndAppManagementAssignmentFilterId   = $FilterId
+                deviceAndAppManagementAssignmentFilterType = $FilterType
+            }
+        }
+    }
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-UserInfo {
+        param([string]$UserPrincipalName)
+        @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false }
+    }
+    function Get-DeviceInfo {
+        param([string]$DeviceName)
+        @{ Id = $null; DisplayName = $DeviceName; Success = $false; MultipleFound = $false; AllDevices = @() }
+    }
+    function Get-GroupMemberships {
+        param([string]$ObjectId, [string]$ObjectType)
+        @()
+    }
+    function Get-GroupInfo {
+        param([string]$GroupId)
+        @{ Id = $GroupId; DisplayName = 'Target Group'; Success = $true }
+    }
+    function Get-TransitiveGroupMembership {
+        param([string]$GroupId)
+        @()
+    }
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Filter-ByScopeTag {
+        param($Items, $FilterTag, $ScopeTagLookup)
+        $Items
+    }
+    function Export-ResultsIfRequested {
+        param([System.Collections.ArrayList]$ExportData, [string]$DefaultFileName, [switch]$ForceExport, [string]$CustomExportPath, [switch]$ExportToCSV, [switch]$ParameterMode)
+    }
+}
+
+Describe 'Test-IntuneGroupRemoval' {
+    BeforeEach {
+        $script:capturedExport = $null
+        $script:hostLines = [System.Collections.Generic.List[string]]::new()
+        $script:requestedUris = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { if ($null -ne $Object) { $script:hostLines.Add([string]$Object) } }
+        Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
+        Mock Get-UserInfo {
+            if ($UserPrincipalName -eq 'user1@contoso.com') { @{ Id = 'u1'; UserPrincipalName = $UserPrincipalName; Success = $true } }
+            else { @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false } }
+        }
+        Mock Get-DeviceInfo {
+            if ($DeviceName -eq 'DEV1') { @{ Id = 'd1'; DisplayName = 'DEV1'; Success = $true; MultipleFound = $false; AllDevices = @() } }
+            else { @{ Id = $null; DisplayName = $DeviceName; Success = $false; MultipleFound = $false; AllDevices = @() } }
+        }
+        # User is member of the target group plus one other; device of the target plus a device group
+        Mock Get-GroupMemberships {
+            switch ($ObjectType) {
+                'User' { @([PSCustomObject]@{ id = 'g-target' }, [PSCustomObject]@{ id = 'g-other' }) }
+                'Device' { @([PSCustomObject]@{ id = 'g-target' }, [PSCustomObject]@{ id = 'g-dev' }) }
+                default { @() }
+            }
+        }
+        Mock Get-TransitiveGroupMembership { @([PSCustomObject]@{ id = 'g-parent'; displayName = 'Parent Group' }) }
+        Mock Add-IntentTemplateFamilyInfo {
+            foreach ($intent in $IntentPolicies) {
+                if ($intent.id -in @('av-intent', 'av-cfg')) {
+                    $intent | Add-Member -NotePropertyName 'templateReference' -NotePropertyValue ([PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' }) -Force
+                }
+            }
+        }
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'deviceConfigurations' {
+                    @(
+                        [PSCustomObject]@{ id = 'dc-lost'; displayName = 'DC Lost' }
+                        [PSCustomObject]@{ id = 'dc-kept'; displayName = 'DC Kept' }
+                        [PSCustomObject]@{ id = 'dc-allusers'; displayName = 'DC AllUsers' }
+                        [PSCustomObject]@{ id = 'dc-conflict'; displayName = 'DC Conflict' }
+                        [PSCustomObject]@{ id = 'dc-lifted'; displayName = 'DC Lifted' }
+                    )
+                }
+                'configurationPolicies' {
+                    @([PSCustomObject]@{ id = 'av-cfg'; name = 'AV Cfg'; templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' } })
+                }
+                'deviceAppManagement/managedAppPolicies' {
+                    @([PSCustomObject]@{ id = 'ap-alldev'; displayName = 'AP AllDev'; '@odata.type' = '#microsoft.graph.iosManagedAppProtection' })
+                }
+                'deviceManagement/intents' {
+                    @(
+                        [PSCustomObject]@{ id = 'av-intent'; displayName = 'AV Intent' }
+                        [PSCustomObject]@{ id = 'av-cfg'; displayName = 'AV Cfg Duplicate' }
+                    )
+                }
+                'virtualEndpoint/provisioningPolicies' { throw 'Windows 365 not licensed' }
+                default { @() }
+            }
+        }
+        Mock Get-IntuneAssignments {
+            switch ($EntityId) {
+                'dc-lost' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = 'f1'; FilterType = 'include' }) }
+                'dc-kept' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-other'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'dc-allusers' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'All Users'; GroupId = $null; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'dc-conflict' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = 'g-other'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-parent'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'dc-lifted' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-other'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'av-cfg' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-target'; FilterId = $null; FilterType = $null }) }
+                default { @() }
+            }
+        }
+        Mock Invoke-MgGraphRequest {
+            $script:requestedUris.Add([string]$Uri)
+            switch -Wildcard ($Uri) {
+                '*/v1.0/groups[?]*' { return @{ value = @([PSCustomObject]@{ id = 'g-target'; displayName = 'Target Group' }) } }
+                '*mobileApps[?]*' {
+                    return @{
+                        value = @(
+                            [PSCustomObject]@{ id = 'app-builtin'; displayName = 'App BuiltIn'; isBuiltIn = $true; isFeatured = $false }
+                            [PSCustomObject]@{ id = 'app-lost'; displayName = 'App Lost'; isBuiltIn = $false; isFeatured = $false }
+                            [PSCustomObject]@{ id = 'app-conflict'; displayName = 'App Conflict'; isBuiltIn = $false; isFeatured = $false }
+                        )
+                    }
+                }
+                "*mobileApps('app-lost')/assignments" {
+                    return @{ value = @((Build-RawAssignment -Type '#microsoft.graph.groupAssignmentTarget' -TargetGroupId 'g-target' -FilterId 'f1' -FilterType 'include' -Intent 'required')) }
+                }
+                "*mobileApps('app-conflict')/assignments" {
+                    return @{ value = @(
+                            (Build-RawAssignment -Type '#microsoft.graph.exclusionGroupAssignmentTarget' -TargetGroupId 'g-other' -FilterType 'none' -Intent 'available')
+                            (Build-RawAssignment -Type '#microsoft.graph.groupAssignmentTarget' -TargetGroupId 'g-parent' -FilterType 'none' -Intent 'available')
+                        ) }
+                }
+                "*iosManagedAppProtections('ap-alldev')/assignments" {
+                    return @{ value = @(
+                            (Build-RawAssignment -Type '#microsoft.graph.allDevicesAssignmentTarget' -FilterType 'none')
+                            (Build-RawAssignment -Type '#microsoft.graph.groupAssignmentTarget' -TargetGroupId 'g-target' -FilterType 'none')
+                        ) }
+                }
+                '*deviceManagement/intents/av-intent/assignments*' {
+                    return @{ value = @((Build-RawAssignment -Type '#microsoft.graph.groupAssignmentTarget' -TargetGroupId 'g-target' -FilterId 'f1' -FilterType 'include')) }
+                }
+                default { return @{ value = @() } }
+            }
+        }
+    }
+
+    Context 'user perspective' {
+        BeforeEach {
+            Test-IntuneGroupRemoval -UserPrincipalNames 'user1@contoso.com' -GroupNames 'Target Group'
+        }
+
+        It 'reports a policy assigned only via the target group as lost with its filter suffix' {
+            $row = $script:capturedExport | Where-Object { $_.Category -eq 'LOST: Device Configuration' -and $_.Item -like 'DC Lost*' }
+            $row | Should -HaveCount 1
+            $row.AssignmentReason | Should -Be 'Group Assignment (Filter: Filter One [Include])'
+        }
+
+        It 'keeps a policy still reachable via another group out of the results' {
+            @($script:capturedExport | Where-Object { $_.Item -like 'DC Kept*' }) | Should -HaveCount 0
+        }
+
+        It 'keeps an All Users policy for a user perspective' {
+            @($script:capturedExport | Where-Object { $_.Item -like 'DC AllUsers*' }) | Should -HaveCount 0
+        }
+
+        It 'flags an exclusion that removal would expose as a conflict' {
+            $row = $script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Device Configuration' }
+            $row | Should -HaveCount 1
+            $row.Item | Should -Be 'DC Conflict (ID: dc-conflict)'
+            $row.AssignmentReason | Should -Be 'Currently included; removal would expose exclusion'
+        }
+
+        It 'stays silent about a policy gained through a lifted exclusion (legacy behavior)' {
+            @($script:capturedExport | Where-Object { $_.Item -like 'DC Lifted*' }) | Should -HaveCount 0
+        }
+
+        It 'reports the Endpoint Security policy lost through both scan phases' {
+            # av-cfg also surfaces in the unfiltered Settings Catalog walk, as before the migration
+            ($script:capturedExport | Where-Object { $_.Category -eq 'LOST: Settings Catalog Policy' }).Item | Should -Be 'AV Cfg (ID: av-cfg)'
+            $esRows = @($script:capturedExport | Where-Object { $_.Category -eq 'LOST: Endpoint Security - Antivirus' })
+            @($esRows | ForEach-Object { $_.Item }) | Should -Be @('AV Cfg (ID: av-cfg)', 'AV Intent (ID: av-intent)')
+        }
+
+        It 'resolves intent-phase reasons without a filter suffix and dedupes intent ids' {
+            $intentRow = $script:capturedExport | Where-Object { $_.Item -eq 'AV Intent (ID: av-intent)' }
+            $intentRow.AssignmentReason | Should -Be 'Group Assignment'
+            # The intent sharing the config policy id is skipped by the two-phase dedupe
+            @($script:requestedUris | Where-Object { $_ -like '*intents/av-cfg/assignments*' }) | Should -HaveCount 0
+        }
+
+        It 'buckets a lost app under its intent with the winning filter suffix' {
+            $row = $script:capturedExport | Where-Object { $_.Category -eq 'LOST: Required App' }
+            $row | Should -HaveCount 1
+            $row.Item | Should -Be 'App Lost (ID: app-lost)'
+            $row.AssignmentReason | Should -Be 'Group Assignment (Filter: Filter One [Include])'
+        }
+
+        It 'labels an app exclusion conflict with the excluding intent' {
+            $row = $script:capturedExport | Where-Object { $_.Category -eq 'CONFLICT: Application (available)' }
+            $row.Item | Should -Be 'App Conflict (ID: app-conflict)'
+        }
+
+        It 'ignores All Devices targets on App Protection policies (legacy quirk)' {
+            $row = $script:capturedExport | Where-Object { $_.Category -eq 'LOST: App Protection Policy' }
+            $row.Item | Should -Be 'AP AllDev (ID: ap-alldev)'
+        }
+
+        It 'walks the 18 categories in the legacy order' {
+            $headers = @($script:hostLines | Where-Object { $_ -match '^\[\d+/18\] Fetching ' })
+            $headers | Should -HaveCount 18
+            $headers[0] | Should -Be '[1/18] Fetching Device Configurations...'
+            $headers[5] | Should -Be '[6/18] Fetching Applications...'
+            $headers[8] | Should -Be '[9/18] Fetching Antivirus Policies...'
+            $headers[14] | Should -Be '[15/18] Fetching Autopilot Deployment Profiles...'
+            $headers[17] | Should -Be '[18/18] Fetching Windows 365 Cloud PC User Settings...'
+        }
+
+        It 'skips unlicensed Windows 365 categories without failing the run' {
+            $script:capturedExport[0].Category | Should -Be 'Simulation Info'
+            ($script:hostLines -join "`n") | Should -Match 'Impact:'
+        }
+    }
+
+    Context 'device perspective' {
+        BeforeEach {
+            Test-IntuneGroupRemoval -DeviceNames 'DEV1' -GroupNames 'Target Group'
+        }
+
+        It 'loses an All Users policy because only All Devices counts for a device' {
+            $row = $script:capturedExport | Where-Object { $_.Item -like 'DC AllUsers*' }
+            $row.Category | Should -Be 'LOST: Device Configuration'
+        }
+
+        It 'raises no conflict for exclusions the device does not hold' {
+            @($script:capturedExport | Where-Object { $_.Category -like 'CONFLICT:*' }) | Should -HaveCount 0
+        }
+    }
+
+    Context 'combined user and device perspective' {
+        BeforeEach {
+            Test-IntuneGroupRemoval -UserPrincipalNames 'user1@contoso.com' -DeviceNames 'DEV1' -GroupNames 'Target Group'
+        }
+
+        It 'labels the simulation info row with both subjects' {
+            $script:capturedExport[0].Item | Should -Be "User 'user1@contoso.com' + Device 'DEV1' -> Remove from Group: Target Group (ID: g-target)"
+        }
+
+        It 'keeps the All Users policy when the user perspective is present' {
+            @($script:capturedExport | Where-Object { $_.Item -like 'DC AllUsers*' }) | Should -HaveCount 0
+        }
+    }
+
+    Context 'input handling' {
+        It 'escapes single quotes in the group name OData filter' {
+            Test-IntuneGroupRemoval -UserPrincipalNames 'user1@contoso.com' -GroupNames "O'Brien Team" | Out-Null
+            $groupLookup = @($script:requestedUris | Where-Object { $_ -like '*/v1.0/groups*' })
+            $groupLookup[0] | Should -Match ([regex]::Escape("displayName eq 'O''Brien Team'"))
+        }
+
+        It 'stops when the subject is not a member of the target group' {
+            Mock Get-GroupMemberships { @([PSCustomObject]@{ id = 'g-other' }) }
+            Test-IntuneGroupRemoval -UserPrincipalNames 'user1@contoso.com' -GroupNames 'Target Group'
+            ($script:hostLines -join "`n") | Should -Match 'is NOT a member of'
+            $script:capturedExport | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Unit/UserAssignment.Tests.ps1
+++ b/Tests/Unit/UserAssignment.Tests.ps1
@@ -1,0 +1,288 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-Separator.ps1')
+    . (Join-Path $modulePrivate 'Get-PolicyPlatform.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
+    . (Join-Path $modulePrivate 'Format-AssignmentSummaryLine.ps1')
+    . (Join-Path $modulePrivate 'Resolve-AssignmentReason.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Add-CategoryExportData.ps1')
+    . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
+    . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
+    . (Join-Path $moduleRoot 'Public/Get-IntuneUserAssignment.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+    $script:ScopeTagLookup = @{}
+    $script:AssignmentFilterLookup = @{}
+
+    # Stub collaborators so Pester can mock them per test
+    function Get-UserInfo {
+        param([string]$UserPrincipalName)
+        @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false }
+    }
+    function Get-GroupMemberships {
+        param([string]$ObjectId, [string]$ObjectType)
+        @()
+    }
+    function Get-IntuneEntities {
+        param([string]$EntityType, [string]$Filter, [string]$Select, [string]$Expand)
+        @()
+    }
+    function Get-IntuneAssignments {
+        param([string]$EntityType, [string]$EntityId, [string]$GroupId, [string[]]$GroupIds = @())
+        @()
+    }
+    function Add-IntentTemplateFamilyInfo {
+        param($IntentPolicies)
+    }
+    function Invoke-MgGraphRequest {
+        param($Uri, $Method)
+        @{ value = @() }
+    }
+    function Get-GroupInfo {
+        param([string]$GroupId)
+        @{ Id = $GroupId; DisplayName = 'Test Group'; Success = $true }
+    }
+    function Filter-ByScopeTag {
+        param($Items, $FilterTag, $ScopeTagLookup)
+        $Items
+    }
+    function Export-ResultsIfRequested {
+        param([System.Collections.ArrayList]$ExportData, [string]$DefaultFileName, [switch]$ForceExport, [string]$CustomExportPath, [switch]$ExportToCSV, [switch]$ParameterMode)
+    }
+}
+
+Describe 'Get-IntuneUserAssignment' {
+    BeforeEach {
+        $script:capturedExport = $null
+        Mock Write-Host {}
+        Mock Add-IntentTemplateFamilyInfo {
+            foreach ($intent in $IntentPolicies) {
+                if ($intent.id -eq 'av-intent') {
+                    $intent | Add-Member -NotePropertyName 'templateReference' -NotePropertyValue ([PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' }) -Force
+                }
+            }
+        }
+        Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
+        Mock Get-UserInfo {
+            switch ($UserPrincipalName) {
+                'user1@contoso.com' { @{ Id = 'u1'; UserPrincipalName = $UserPrincipalName; Success = $true } }
+                'user2@contoso.com' { @{ Id = 'u2'; UserPrincipalName = $UserPrincipalName; Success = $true } }
+                default { @{ Id = $null; UserPrincipalName = $UserPrincipalName; Success = $false } }
+            }
+        }
+        Mock Get-GroupMemberships {
+            switch ($ObjectId) {
+                'u1' { @([PSCustomObject]@{ id = 'g-a'; displayName = 'Group A' }) }
+                'u2' { @([PSCustomObject]@{ id = 'g-b'; displayName = 'Group B' }) }
+                default { @() }
+            }
+        }
+        Mock Get-GroupInfo {
+            $names = @{ 'g-a' = 'Group A'; 'g-b' = 'Group B'; 'g-x' = 'Group X' }
+            @{ Id = $GroupId; DisplayName = $names[$GroupId]; Success = $true }
+        }
+        Mock Get-IntuneEntities {
+            switch ($EntityType) {
+                'deviceConfigurations' {
+                    @(
+                        [PSCustomObject]@{ id = 'dc-mine'; displayName = 'Config Mine' }
+                        [PSCustomObject]@{ id = 'dc-other'; displayName = 'Config Other' }
+                        [PSCustomObject]@{ id = 'dc-all'; displayName = 'Config All Users' }
+                        [PSCustomObject]@{ id = 'dc-excl'; displayName = 'Config Excluded' }
+                    )
+                }
+                'configurationPolicies' {
+                    @([PSCustomObject]@{ id = 'av-cfg'; name = 'AV Config Policy'; templateReference = [PSCustomObject]@{ templateFamily = 'endpointSecurityAntivirus' } })
+                }
+                'deviceAppManagement/managedAppPolicies' {
+                    @(
+                        [PSCustomObject]@{ id = 'apppol-in'; displayName = 'AP In'; '@odata.type' = '#microsoft.graph.androidManagedAppProtection' }
+                        [PSCustomObject]@{ id = 'apppol-out'; displayName = 'AP Out'; '@odata.type' = '#microsoft.graph.androidManagedAppProtection' }
+                    )
+                }
+                'deviceManagement/intents' {
+                    @([PSCustomObject]@{ id = 'av-intent'; displayName = 'AV Intent Legacy' })
+                }
+                default { @() }
+            }
+        }
+        Mock Get-IntuneAssignments {
+            switch ($EntityId) {
+                'dc-mine' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-a'; FilterId = 'f1'; FilterType = 'include' }) }
+                'dc-other' { @([PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'g-x'; FilterId = $null; FilterType = $null }) }
+                'dc-all' { @([PSCustomObject]@{ Reason = 'All Users'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+                'dc-excl' {
+                    @(
+                        [PSCustomObject]@{ Reason = 'All Users'; GroupId = $null; FilterId = $null; FilterType = $null }
+                        [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = 'g-a'; FilterId = $null; FilterType = $null }
+                    )
+                }
+                'av-cfg' { @([PSCustomObject]@{ Reason = 'All Users'; GroupId = $null; FilterId = $null; FilterType = $null }) }
+                default { @() }
+            }
+        }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*mobileApps?*isAssigned*') {
+                return @{ value = @(
+                        [PSCustomObject]@{ id = 'app-req-inc'; displayName = 'Required Included App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-avail-inc'; displayName = 'Available Included App'; isFeatured = $false; isBuiltIn = $false }
+                        [PSCustomObject]@{ id = 'app-excl'; displayName = 'Excluded App'; isFeatured = $false; isBuiltIn = $false }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-req-inc')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-a' } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-avail-inc')/assignments*") {
+                # F14 fixture: the winning assignment intent decides the bucket
+                return @{ value = @(
+                        @{ intent = 'available'; target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-excl')/assignments*") {
+                # Excluded-app fixture: exclusion for g-a wins over the All Users include
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = 'g-a'; deviceAndAppManagementAssignmentFilterId = 'f1'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                    )
+                }
+            }
+            if ($Uri -like "*androidManagedAppProtections('apppol-in')/assignments*") {
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' } }
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-a' } }
+                    )
+                }
+            }
+            if ($Uri -like "*androidManagedAppProtections('apppol-out')/assignments*") {
+                # F13 regression fixture: the user is not a member of g-x
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-x' } }
+                    )
+                }
+            }
+            if ($Uri -like '*deviceManagement/intents/av-intent/assignments*') {
+                # Intent-phase fixture: filter fields present on the target, but the legacy
+                # detail rows never carried them, so the reason must have no filter suffix
+                return @{ value = @(
+                        @{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'g-a'; deviceAndAppManagementAssignmentFilterId = 'f1'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                    )
+                }
+            }
+            return @{ value = @() }
+        }
+    }
+
+    It 'exports the User row first with the UPN and user id' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $script:capturedExport[0].Category | Should -BeExactly 'User'
+        $script:capturedExport[0].Item | Should -BeExactly 'user1@contoso.com (ID: u1)'
+        $script:capturedExport[0].AssignmentReason | Should -BeExactly 'N/A'
+    }
+
+    It 'includes All Users and member-group policies, drops other groups, and honors exclusion override' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $configRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Device Configuration' })
+        $configRows.Count | Should -Be 3
+        @($configRows | Where-Object { $_.Item -eq 'Config Mine (ID: dc-mine)' -and $_.AssignmentReason -eq 'Group Assignment (Filter: Unknown Filter (f1) [Include])' }).Count | Should -Be 1
+        @($configRows | Where-Object { $_.Item -eq 'Config All Users (ID: dc-all)' -and $_.AssignmentReason -eq 'All Users' }).Count | Should -Be 1
+        @($configRows | Where-Object { $_.Item -eq 'Config Excluded (ID: dc-excl)' -and $_.AssignmentReason -eq 'Excluded' }).Count | Should -Be 1
+        @($configRows | Where-Object { $_.Item -like '*dc-other*' }).Count | Should -Be 0
+    }
+
+    It 'keeps excluded apps visible in the excluding assignment intent bucket with filter suffix' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $requiredRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Required Apps' })
+        @($requiredRows | Where-Object { $_.Item -eq 'Excluded App (ID: app-excl)' -and $_.AssignmentReason -eq 'Excluded (Filter: Unknown Filter (f1) [Include])' }).Count | Should -Be 1
+        @($requiredRows | Where-Object { $_.Item -eq 'Required Included App (ID: app-req-inc)' -and $_.AssignmentReason -eq 'Included' }).Count | Should -Be 1
+    }
+
+    It 'routes included apps by the winning assignment intent (F14)' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $availableRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Available Apps' })
+        $availableRows.Count | Should -Be 1
+        $availableRows[0].Item | Should -BeExactly 'Available Included App (ID: app-avail-inc)'
+        $availableRows[0].AssignmentReason | Should -BeExactly 'Included'
+    }
+
+    It 'filters App Protection policies by actual group membership (F13)' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $apRows = @($script:capturedExport | Where-Object { $_.Category -eq 'App Protection Policy' })
+        $apRows.Count | Should -Be 1
+        $apRows[0].Item | Should -BeExactly 'AP In (ID: apppol-in)'
+        $apRows[0].AssignmentReason | Should -BeExactly 'All Users; Group Assignment - Group A'
+        @($script:capturedExport | Where-Object { $_.Item -like '*apppol-out*' }).Count | Should -Be 0
+    }
+
+    It 'resolves Endpoint Security policies across both phases, intent phase without filter suffix' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $avRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Endpoint Security - Antivirus' })
+        $avRows.Count | Should -Be 2
+        @($avRows | Where-Object { $_.Item -eq 'AV Config Policy (ID: av-cfg)' -and $_.AssignmentReason -eq 'All Users' }).Count | Should -Be 1
+        # The intent target carries filter fields, but the legacy reason has no suffix
+        @($avRows | Where-Object { $_.Item -eq 'AV Intent Legacy (ID: av-intent)' -and $_.AssignmentReason -eq 'Group Assignment' }).Count | Should -Be 1
+    }
+
+    It 'fetches each entity set from Graph only once for multiple UPNs (finding 10)' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com,user2@contoso.com'
+
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'configurationPolicies' }
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'deviceConfigurations' }
+        Should -Invoke Get-IntuneEntities -Times 1 -Exactly -ParameterFilter { $EntityType -eq 'deviceManagement/intents' }
+        Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly -ParameterFilter { $Uri -like '*mobileApps?*isAssigned*' }
+    }
+
+    It 'still resolves assignments per user when the entity cache is shared (second UPN)' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com,user2@contoso.com'
+
+        # user2 is only in g-b: no device configuration except All Users may appear in its block
+        $userRowIndexes = @(0..($script:capturedExport.Count - 1) | Where-Object { $script:capturedExport[$_].Category -eq 'User' })
+        $userRowIndexes.Count | Should -Be 2
+        $user2Rows = @($script:capturedExport | Select-Object -Skip $userRowIndexes[1])
+        $user2ConfigRows = @($user2Rows | Where-Object { $_.Category -eq 'Device Configuration' })
+        $user2ConfigRows.Count | Should -Be 2
+        @($user2ConfigRows | Where-Object { $_.Item -eq 'Config All Users (ID: dc-all)' -and $_.AssignmentReason -eq 'All Users' }).Count | Should -Be 1
+        # dc-excl excludes only g-a, so user2 keeps the All Users inclusion
+        @($user2ConfigRows | Where-Object { $_.Item -eq 'Config Excluded (ID: dc-excl)' -and $_.AssignmentReason -eq 'All Users' }).Count | Should -Be 1
+    }
+
+    It 'emits export categories in the legacy CSV order' {
+        Get-IntuneUserAssignment -UserPrincipalNames 'user1@contoso.com'
+
+        $expectedOrder = @(
+            'User', 'Device Configuration', 'Settings Catalog Policy', 'Compliance Policy', 'App Protection Policy',
+            'App Configuration Policy', 'Platform Scripts', 'Proactive Remediation Scripts',
+            'Autopilot Deployment Profile', 'Enrollment Status Page',
+            'Windows 365 Cloud PC Provisioning Policy', 'Windows 365 Cloud PC User Setting',
+            'Endpoint Security - Antivirus', 'Endpoint Security - Disk Encryption', 'Endpoint Security - Firewall',
+            'Endpoint Security - EDR', 'Endpoint Security - ASR', 'Endpoint Security - Account Protection',
+            'Required Apps', 'Available Apps', 'Uninstall Apps'
+        )
+        $actualOrder = @($script:capturedExport.Category | Select-Object -Unique)
+        # Empty buckets emit no rows; the observed sequence must be a subsequence of the legacy order
+        $cursor = 0
+        foreach ($category in $actualOrder) {
+            $position = $expectedOrder.IndexOf($category)
+            $position | Should -BeGreaterOrEqual $cursor -Because "category '$category' must not appear out of legacy order"
+            $cursor = $position
+        }
+    }
+}


### PR DESCRIPTION
Resolves #123, #124, #126. Addresses #125 (see the verification note below on why the intents fallback is retained).

## Summary

### #126 - Excluded apps now shown in group checks
Get-IntuneGroupAssignment collected exclusion reasons for apps but dropped the app when no inclusion assignment supplied an intent. The excluding assignment's intent is now used as a fallback, so exclusion-only apps appear in their intent bucket with reason "Group Exclusion" / "Inherited Exclusion (via X)". Compare-IntuneGroupAssignment marks excluded apps with the [EXCLUDED] suffix used by its other sections. Verified against live tenant data: a group excluded from a required app now appears under Required Apps.

### #123 - All 30 findings addressed, including the decomposition
- The ten near-identical category-walk cmdlets now run on a shared scan engine (Private/Invoke-IntuneCategoryScan.ps1 plus a per-audience category registry). Combined size of the ten cmdlets: 8409 lines down to 3172, with each file reduced to target resolution, a per-cmdlet predicate callback, display, and export.
- Cross-cutting fixes now live once in shared code: entity sets fetched once per run (configurationPolicies dropped from up to 14 fetches to 1 per run), per-category failures continue the run and populate the error stream, progress totals derive from the registry, the App Protection URI switch exists exactly once, pagination accumulates via List instead of array +=.
- Bug fixes: Switch-Tenant connected with empty permission scopes; group memberships, comparison categories, and assignment failures silently truncated past 100 items; App Protection policies shown for every user regardless of membership; app intent misclassification from a stale loop variable; multi-device input collapsed into a single bogus lookup; nested export calls produced junk CSV rows; Get-IntuneEmptyGroup never actually tested App Protection groups for emptiness and never populated its six endpoint security categories; EDR policies missing from HTML reports due to a template mapping typo; Set-Environment killed the host session; guest UPNs with # broke lookups.
- Security hardening: HTML-encoding for all Graph-derived report values, OData filter escaping for group names, -ClientSecretCredential (PSCredential) as the preferred client secret input (plain-string -ClientSecret retained for compatibility), register script no longer leaves a temporary client secret behind on failed certificate upload.

### #124 - Docs and register script aligned
README auth options (adds pre-fetched token and client secret credential), user-and/or-device wording for options 12/13, register script grants all nine validated permissions plus documented DeviceManagementServiceConfig.Read.All, and its next-steps output uses the module cmdlets. Permission GUIDs were verified against the Microsoft Graph service principal appRoles via live Graph calls; two GUIDs previously suggested in the issue comments (DeviceManagementScripts.Read.All, DeviceManagementRBAC.Read.All) were wrong and are corrected here.

### #125 - Intents fallback retained deliberately
Live verification before removal found an assigned macOS FileVault policy that exists only as a deviceManagement/intent, with no configurationPolicies counterpart: the MC955748 auto-migration covered Windows endpoint security policies only. Removing the fallback would silently drop live macOS legacy policies from every report. Instead, the fallback is centralized in the scan engine (intents and templates fetched once per run instead of six-plus times per cmdlet), which delivers the API-call reduction the issue aimed for without the regression. Removal can be revisited when Microsoft migrates the remaining macOS intents.

## Verification
- Pester: 157/157 (44 baseline plus 113 new engine/cmdlet tests)
- PSScriptAnalyzer: clean with repo settings (Error severity)
- Every migrated cmdlet verified against a stubbed old-vs-new harness with byte-identical console and CSV output (only accepted difference: numbered progress lines)
- The #126 fix verified with real captured tenant payloads before and after the engine migration
- Every distinct Graph URI family the module builds was executed against a live tenant (entity lists, per-entity assignments for configurationPolicies, managed app protections, and intents, transitive membership, and the Cloud PC 403 path that the engine treats as an optional-feature skip)