### PR TITLE
Release v4.3.2: expand assignment coverage and reporting

### DIFF
--- a/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psd1
+++ b/Module/IntuneAssignmentChecker/IntuneAssignmentChecker.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'IntuneAssignmentChecker.psm1'
-    ModuleVersion     = '4.3.1'
+    ModuleVersion     = '4.3.2'
     GUID              = 'c6e25ec6-5787-45ef-95af-8abeb8a17daf'
     Author            = 'Ugur Koc'
     CompanyName       = 'Community'
@@ -43,6 +43,14 @@
             ProjectUri   = 'https://github.com/ugurkocde/IntuneAssignmentChecker'
             IconUri      = ''
             ReleaseNotes = @'
+Version 4.3.2:
+- Recognize Microsoft 365 (Unified) groups as first-class Intune assignment targets and expose group type, membership mode, and mail address in group checks and exports (issue #128).
+- Restore Imported Administrative Template support across assignment views, simulations, search, CSV exports, and HTML reports; imported and mixed group policy configurations are included while built-in-only configurations remain excluded (issue #129).
+- Allow delegated sign-in with an explicit application (client) ID, with or without a tenant ID, while preserving app-only certificate authentication (issue #130).
+- Return every application scope tag by explicitly selecting roleScopeTagIds in Microsoft Graph mobile-app collection queries (issue #131).
+- Generate a flat, formula-safe CSV companion alongside every HTML report, with -CSVReportPath for centralized ingestion/Azure Workbooks and -NoCSVReport for HTML-only automation (issue #132).
+- Return assigned applications regardless of the unrelated isFeatured metadata flag so featured apps are no longer omitted from results (issue #134).
+
 Version 4.3.1:
 Security:
 - Replace the broad Group.Read.All permission with GroupMember.Read.All for group lookup, membership, and transitive membership operations. This preserves IntuneAssignmentChecker behavior without granting access to Microsoft 365 group content.

--- a/Module/IntuneAssignmentChecker/Private/Add-CategoryExportData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-CategoryExportData.ps1
@@ -16,7 +16,11 @@ function Add-CategoryExportData {
 
         # Passed through to Add-ExportData when provided (string or scriptblock).
         [Parameter(Mandatory = $false)]
-        [object]$AssignmentReason
+        [object]$AssignmentReason,
+
+        # Optional attribution columns added uniformly to every exported row.
+        [Parameter(Mandatory = $false)]
+        [System.Collections.IDictionary]$AdditionalProperties
     )
 
     # Categories may share a bucket (e.g. Compare's ShellScripts feed PlatformScripts);
@@ -46,6 +50,9 @@ function Add-CategoryExportData {
             }
             if ($PSBoundParameters.ContainsKey('AssignmentReason')) {
                 $addParams.AssignmentReason = $AssignmentReason
+            }
+            if ($PSBoundParameters.ContainsKey('AdditionalProperties')) {
+                $addParams.AdditionalProperties = $AdditionalProperties
             }
             Add-ExportData @addParams
         }

--- a/Module/IntuneAssignmentChecker/Private/Add-ExportData.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Add-ExportData.ps1
@@ -5,7 +5,9 @@ function Add-ExportData {
         [string]$Category,
         [object[]]$Items,
         [Parameter(Mandatory = $false)]
-        [object]$AssignmentReason = "N/A"
+        [object]$AssignmentReason = "N/A",
+        [Parameter(Mandatory = $false)]
+        [System.Collections.IDictionary]$AdditionalProperties
     )
 
     foreach ($item in $Items) {
@@ -32,13 +34,23 @@ function Add-ExportData {
             $filterType = $Matches['type']
         }
 
-        $null = $ExportData.Add([PSCustomObject]@{
-                Category         = $Category
-                Item             = "$itemName (ID: $($item.id))"
-                ScopeTags        = Get-ScopeTagNames -ScopeTagIds $item.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
-                AssignmentReason = $reason
-                FilterName       = $filterName
-                FilterType       = $filterType
-            })
+        $row = [ordered]@{
+            Category         = $Category
+            Item             = "$itemName (ID: $($item.id))"
+            ScopeTags        = Get-ScopeTagNames -ScopeTagIds $item.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
+            AssignmentReason = $reason
+            FilterName       = $filterName
+            FilterType       = $filterType
+        }
+        if ($AdditionalProperties) {
+            foreach ($propertyName in $AdditionalProperties.Keys) {
+                if ($row.Contains($propertyName)) {
+                    throw "Additional export property '$propertyName' conflicts with a reserved export column."
+                }
+                $row[$propertyName] = $AdditionalProperties[$propertyName]
+            }
+        }
+
+        $null = $ExportData.Add([PSCustomObject]$row)
     }
 }

--- a/Module/IntuneAssignmentChecker/Private/ConvertTo-IntuneGroupInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/ConvertTo-IntuneGroupInfo.ps1
@@ -1,0 +1,46 @@
+function ConvertTo-IntuneGroupInfo {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [object]$Group
+    )
+
+    process {
+        $groupTypes = @($Group.groupTypes)
+        $isMicrosoft365 = $groupTypes -contains 'Unified'
+        $isDynamic = $groupTypes -contains 'DynamicMembership'
+        $mailEnabled = $Group.mailEnabled -eq $true
+        $securityEnabled = $Group.securityEnabled -eq $true
+
+        # Microsoft Graph documents groupTypes, mailEnabled, and
+        # securityEnabled as the canonical group-type discriminators.
+        $groupType = if ($isMicrosoft365) {
+            'Microsoft 365'
+        }
+        elseif ($mailEnabled -and $securityEnabled) {
+            'Mail-enabled Security'
+        }
+        elseif ($securityEnabled) {
+            'Security'
+        }
+        elseif ($mailEnabled) {
+            'Distribution'
+        }
+        else {
+            'Unknown'
+        }
+
+        [PSCustomObject]@{
+            Id                = $Group.id
+            DisplayName       = $Group.displayName
+            GroupType         = $groupType
+            MembershipType    = if ($isDynamic) { 'Dynamic' } else { 'Assigned' }
+            IsMicrosoft365    = $isMicrosoft365
+            Mail              = $Group.mail
+            GroupTypes        = $groupTypes
+            MailEnabled       = $mailEnabled
+            SecurityEnabled   = $securityEnabled
+            Success           = -not [string]::IsNullOrWhiteSpace([string]$Group.id)
+        }
+    }
+}

--- a/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-GroupInfo.ps1
@@ -13,19 +13,40 @@ function Get-GroupInfo {
     }
 
     try {
-        $groupUri = "$script:GraphEndpoint/v1.0/groups/$GroupId"
+        $selectProperties = 'id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+        $groupUri = "$script:GraphEndpoint/v1.0/groups/$GroupId`?`$select=$selectProperties"
         $group = Invoke-MgGraphRequest -Uri $groupUri -Method Get
-        $result = @{
-            Id          = $group.id
-            DisplayName = $group.displayName
-            Success     = $true
+        $result = ConvertTo-IntuneGroupInfo -Group $group
+        if (-not $result.Success) {
+            throw "Microsoft Graph returned a group response without an Object ID."
         }
     }
     catch {
-        $result = @{
-            Id          = $GroupId
-            DisplayName = "Unknown Group"
-            Success     = $false
+        $errorMessage = $_.Exception.Message
+        $statusCode = if ($_.Exception.Response -and $null -ne $_.Exception.Response.StatusCode) {
+            [int]$_.Exception.Response.StatusCode
+        }
+        else {
+            $null
+        }
+        # Invoke-MgGraphRequest does not consistently expose Response.StatusCode,
+        # so also recognize the standard message-only not-found shapes.
+        $isNotFound = $statusCode -eq 404 -or
+            $errorMessage -match '(?i)\b404\b|Not\s*Found|Request_ResourceNotFound'
+        if (-not $isNotFound) {
+            Write-Warning "Group '$GroupId' lookup failed: $errorMessage"
+        }
+        $result = [PSCustomObject]@{
+            Id                = $GroupId
+            DisplayName       = "Unknown Group"
+            GroupType         = "Unknown"
+            MembershipType    = "Unknown"
+            IsMicrosoft365    = $false
+            Mail              = $null
+            GroupTypes        = @()
+            MailEnabled       = $false
+            SecurityEnabled   = $false
+            Success           = $false
         }
     }
 

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneAssignments.ps1
@@ -52,6 +52,10 @@ function Get-IntuneAssignments {
         # Example: virtualEndpoint/provisioningPolicies or virtualEndpoint/userSettings
         $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/$EntityType/$EntityId/assignments"
     }
+    elseif ($EntityType -eq "groupPolicyConfigurations") {
+        # Imported Administrative Templates use the documented resource-path form.
+        $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/groupPolicyConfigurations/$EntityId/assignments"
+    }
     else {
         # General device management entities
         $actualAssignmentsUri = "$script:GraphEndpoint/beta/deviceManagement/$EntityType('$EntityId')/assignments"

--- a/Module/IntuneAssignmentChecker/Private/Get-IntuneCategoryDefinition.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Get-IntuneCategoryDefinition.ps1
@@ -52,15 +52,19 @@ function Get-IntuneCategoryDefinition {
     }
 
     $espEntityFilter = { $_.'@odata.type' -match 'EnrollmentCompletionPageConfiguration' }
-    $mobileAppsEntityFilter = { -not ($_.isFeatured -or $_.isBuiltIn) }
+    # Imported Administrative Templates are group policy configurations whose settings
+    # were ingested by an administrator. A mixed configuration contains both imported
+    # and built-in definitions and must remain visible as an imported template policy.
+    $importedAdministrativeTemplateFilter = { Test-ImportedAdministrativeTemplate -Policy $_ }
 
     $baseCategories = @{
         DeviceConfigurations        = @{ Id = 'DeviceConfigurations'; EntityType = 'deviceConfigurations'; BucketKeys = @('DeviceConfigs'); DisplayName = 'Device Configurations'; ExportCategory = 'Device Configuration' }
+        ImportedAdministrativeTemplates = @{ Id = 'ImportedAdministrativeTemplates'; EntityType = 'groupPolicyConfigurations'; EntityFilter = $importedAdministrativeTemplateFilter; BucketKeys = @('ImportedAdministrativeTemplates'); DisplayName = 'Imported Administrative Templates'; ExportCategory = 'Imported Administrative Template' }
         SettingsCatalog             = @{ Id = 'SettingsCatalog'; EntityType = 'configurationPolicies'; BucketKeys = @('SettingsCatalog'); DisplayName = 'Settings Catalog Policies'; ExportCategory = 'Settings Catalog Policy' }
         CompliancePolicies          = @{ Id = 'CompliancePolicies'; EntityType = 'deviceCompliancePolicies'; BucketKeys = @('CompliancePolicies'); DisplayName = 'Compliance Policies'; ExportCategory = 'Compliance Policy' }
         AppProtectionPolicies       = @{ Id = 'AppProtectionPolicies'; Kind = 'AppProtection'; EntityType = 'deviceAppManagement/managedAppPolicies'; BucketKeys = @('AppProtectionPolicies'); DisplayName = 'App Protection Policies'; ExportCategory = 'App Protection Policy' }
         AppConfigurationPolicies    = @{ Id = 'AppConfigurationPolicies'; EntityType = 'deviceAppManagement/mobileAppConfigurations'; AssignmentEntityType = 'mobileAppConfigurations'; BucketKeys = @('AppConfigurationPolicies'); DisplayName = 'App Configuration Policies'; ExportCategory = 'App Configuration Policy' }
-        Applications                = @{ Id = 'Applications'; Kind = 'MobileApps'; EntityType = 'deviceAppManagement/mobileApps'; EntityFilter = $mobileAppsEntityFilter; BucketKeys = @('AppsRequired', 'AppsAvailable', 'AppsUninstall'); BucketExportCategories = @{ AppsRequired = 'Required Apps'; AppsAvailable = 'Available Apps'; AppsUninstall = 'Uninstall Apps' }; DisplayName = 'Applications' }
+        Applications                = @{ Id = 'Applications'; Kind = 'MobileApps'; EntityType = 'deviceAppManagement/mobileApps'; BucketKeys = @('AppsRequired', 'AppsAvailable', 'AppsUninstall'); BucketExportCategories = @{ AppsRequired = 'Required Apps'; AppsAvailable = 'Available Apps'; AppsUninstall = 'Uninstall Apps' }; DisplayName = 'Applications' }
         PlatformScripts             = @{ Id = 'PlatformScripts'; EntityType = 'deviceManagementScripts'; BucketKeys = @('PlatformScripts'); DisplayName = 'Platform Scripts'; ExportCategory = 'Platform Scripts' }
         HealthScripts               = @{ Id = 'HealthScripts'; EntityType = 'deviceHealthScripts'; BucketKeys = @('HealthScripts'); DisplayName = 'Proactive Remediation Scripts'; ExportCategory = 'Proactive Remediation Scripts' }
         DeploymentProfiles          = @{ Id = 'DeploymentProfiles'; EntityType = 'windowsAutopilotDeploymentProfiles'; BucketKeys = @('DeploymentProfiles'); DisplayName = 'Autopilot Deployment Profiles'; ExportCategory = 'Autopilot Deployment Profile' }
@@ -104,9 +108,10 @@ function Get-IntuneCategoryDefinition {
 
     switch ($Audience) {
         'UserContext' {
-            # Order and display names from Get-IntuneUserAssignment.ps1 (16 progress steps).
+            # Order and display names from Get-IntuneUserAssignment.ps1 (17 progress steps).
             $categories = @(
                 & $use 'DeviceConfigurations'
+                & $use 'ImportedAdministrativeTemplates'
                 # UserContext applies no ES exclusion to Settings Catalog (Get-IntuneUserAssignment.ps1:125-133)
                 & $use 'SettingsCatalog'
                 & $use 'CompliancePolicies'
@@ -128,11 +133,12 @@ function Get-IntuneCategoryDefinition {
             return $categories
         }
         'DeviceContext' {
-            # Order and display names from Get-IntuneDeviceAssignment.ps1 (16 fetch steps).
+            # Order and display names from Get-IntuneDeviceAssignment.ps1 (17 fetch steps).
             # Autopilot/ESP are Windows-only conditional fetches there; the migrated cmdlet
             # decides whether to flip BucketOnly off for Windows devices.
             $categories = @(
                 & $use 'DeviceConfigurations'
+                & $use 'ImportedAdministrativeTemplates'
                 # DeviceContext applies no ES exclusion to Settings Catalog (Get-IntuneDeviceAssignment.ps1:171-180)
                 & $use 'SettingsCatalog'
                 & $use 'CompliancePolicies'
@@ -152,9 +158,10 @@ function Get-IntuneCategoryDefinition {
             return $categories
         }
         'GroupContext' {
-            # Order and display names from Get-IntuneGroupAssignment.ps1 (18 fetch steps).
+            # Order and display names from Get-IntuneGroupAssignment.ps1 (19 fetch steps).
             $categories = @(
                 & $use 'DeviceConfigurations'
+                & $use 'ImportedAdministrativeTemplates'
                 & $use 'SettingsCatalog' @{ EntityFilter = $groupSettingsCatalogFilter }
                 & $use 'CompliancePolicies'
                 & $use 'AppProtectionPolicies'
@@ -173,9 +180,10 @@ function Get-IntuneCategoryDefinition {
             return $categories
         }
         'AllPolicies' {
-            # Order and display names from Get-IntuneAllPolicies.ps1 (17 categories, no Applications).
+            # Order and display names from Get-IntuneAllPolicies.ps1 (18 categories, no Applications).
             $categories = @(
                 & $use 'DeviceConfigurations'
+                & $use 'ImportedAdministrativeTemplates'
                 # AllPolicies applies no ES exclusion to Settings Catalog (Get-IntuneAllPolicies.ps1:83-92)
                 & $use 'SettingsCatalog'
                 & $use 'CompliancePolicies'
@@ -192,11 +200,12 @@ function Get-IntuneCategoryDefinition {
             return $categories
         }
         'Search' {
-            # Order, display names and export labels from Search-IntunePolicy.ps1 (18 categories).
+            # Order, display names and export labels from Search-IntunePolicy.ps1 (19 categories).
             # All Search categories feed one flat SearchResults bucket (grouped rows at display time).
             $searchBucket = @{ BucketKeys = @('SearchResults'); BucketExportCategories = $null }
             $categories = @(
                 & $use 'DeviceConfigurations' $searchBucket
+                & $use 'ImportedAdministrativeTemplates' $searchBucket
                 & $use 'SettingsCatalog' ($searchBucket + @{ EntityFilter = $searchSettingsCatalogFilter; ExportCategory = 'Settings Catalog' })
                 & $use 'CompliancePolicies' $searchBucket
                 & $use 'AppProtectionPolicies' $searchBucket
@@ -215,11 +224,12 @@ function Get-IntuneCategoryDefinition {
             return $categories
         }
         'Compare' {
-            # Categories Compare-IntuneGroupAssignment.ps1 currently walks (13 fetch categories).
+            # Categories Compare-IntuneGroupAssignment.ps1 currently walks (14 fetch categories).
             # Compare currently checks intents only for ES; the shared EndpointSecurity kind adds
             # the configurationPolicies phase when Compare is migrated onto the engine.
             $categories = @(
                 & $use 'DeviceConfigurations' @{ ExportCategory = 'Device Configurations' }
+                & $use 'ImportedAdministrativeTemplates' @{ ExportCategory = 'Imported Administrative Templates' }
                 # Compare applies no ES exclusion to Settings Catalog (Compare-IntuneGroupAssignment.ps1:214-252)
                 & $use 'SettingsCatalog' @{ ExportCategory = 'Settings Catalog' }
                 & $use 'CompliancePolicies' @{ ExportCategory = 'Compliance Policies' }

--- a/Module/IntuneAssignmentChecker/Private/Invoke-IntuneCategoryScan.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Invoke-IntuneCategoryScan.ps1
@@ -218,7 +218,9 @@ function Invoke-IntuneCategoryScan {
                 }
                 'MobileApps' {
                     if (-not $EntityCache.ContainsKey($category.EntityType)) {
-                        $EntityCache[$category.EntityType] = Get-PagedGraphValue -Uri "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
+                        # roleScopeTagIds is not reliably returned by the collection endpoint
+                        # unless it is requested explicitly.
+                        $EntityCache[$category.EntityType] = Get-PagedGraphValue -Uri "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true&`$select=id,displayName,roleScopeTagIds"
                     }
                     $allApps = @($EntityCache[$category.EntityType])
                     if ($category.EntityFilter) {

--- a/Module/IntuneAssignmentChecker/Private/Test-ImportedAdministrativeTemplate.ps1
+++ b/Module/IntuneAssignmentChecker/Private/Test-ImportedAdministrativeTemplate.ps1
@@ -1,0 +1,10 @@
+function Test-ImportedAdministrativeTemplate {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSObject]$Policy
+    )
+
+    return $Policy.policyConfigurationIngestionType -in @('custom', 'mixed')
+}

--- a/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Compare-IntuneGroupAssignment.ps1
@@ -132,15 +132,22 @@ function Compare-IntuneGroupAssignment {
         # Initialize variables
         $groupId = $null
         $groupName = $null
+        $resolvedGroupInfo = $null
+        $groupSelect = 'id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
 
         # Check if input is a GUID
         if ($groupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
             try {
                 # Get group info from Graph API
-                $groupUri = "$script:GraphEndpoint/v1.0/groups/$groupInput"
+                $groupUri = "$script:GraphEndpoint/v1.0/groups/$groupInput`?`$select=$groupSelect"
                 $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
-                $groupId = $groupResponse.id
-                $groupName = $groupResponse.displayName
+                $resolvedGroupInfo = ConvertTo-IntuneGroupInfo -Group $groupResponse
+                if (-not $resolvedGroupInfo.Success) {
+                    Write-Host "The group lookup for '$groupInput' returned an invalid response without an Object ID." -ForegroundColor Red
+                    continue
+                }
+                $groupId = $resolvedGroupInfo.Id
+                $groupName = $resolvedGroupInfo.DisplayName
                 $resolvedGroups[$groupId] = $groupName
                 Write-Host "Found group by ID: $groupName" -ForegroundColor Green
             }
@@ -152,7 +159,7 @@ function Compare-IntuneGroupAssignment {
         else {
             # Try to find group by display name (single quotes escaped for the OData filter)
             $escapedGroupName = $groupInput -replace "'", "''"
-            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
+            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'&`$select=$groupSelect"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
 
             if ($groupResponse.value.Count -eq 0) {
@@ -162,16 +169,24 @@ function Compare-IntuneGroupAssignment {
             elseif ($groupResponse.value.Count -gt 1) {
                 Write-Host "Multiple groups found with name: $groupInput. Please use the Object ID instead:" -ForegroundColor Red
                 foreach ($group in $groupResponse.value) {
-                    Write-Host "  - $($group.displayName) (ID: $($group.id))" -ForegroundColor Yellow
+                    $candidateInfo = ConvertTo-IntuneGroupInfo -Group $group
+                    Write-Host "  - $($candidateInfo.DisplayName) (ID: $($candidateInfo.Id); Type: $($candidateInfo.GroupType); Membership: $($candidateInfo.MembershipType))" -ForegroundColor Yellow
                 }
                 continue
             }
 
-            $groupId = $groupResponse.value[0].id
-            $groupName = $groupResponse.value[0].displayName
+            $resolvedGroupInfo = ConvertTo-IntuneGroupInfo -Group $groupResponse.value[0]
+            if (-not $resolvedGroupInfo.Success) {
+                Write-Host "The group lookup for '$groupInput' returned an invalid response without an Object ID." -ForegroundColor Red
+                continue
+            }
+            $groupId = $resolvedGroupInfo.Id
+            $groupName = $resolvedGroupInfo.DisplayName
             $resolvedGroups[$groupId] = $groupName
             Write-Host "Found group by name: $groupName (ID: $groupId)" -ForegroundColor Green
         }
+
+        Write-Host "Group details: Type: $($resolvedGroupInfo.GroupType); Membership: $($resolvedGroupInfo.MembershipType)$(if ($resolvedGroupInfo.Mail) { "; Mail: $($resolvedGroupInfo.Mail)" })" -ForegroundColor Green
 
         # Build effective group IDs for nested group support (direct + transitive parents)
         $allGroupIds = @($groupId)
@@ -222,6 +237,7 @@ function Compare-IntuneGroupAssignment {
     # Update categories to include "Proactive Remediation Scripts"
     $categories = [ordered]@{
         "Device Configurations"               = "DeviceConfigs"
+        "Imported Administrative Templates"   = "ImportedAdministrativeTemplates"
         "Settings Catalog"                    = "SettingsCatalog"
         "Compliance Policies"                 = "CompliancePolicies"
         "Required Apps"                       = "RequiredApps"

--- a/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Connect-IntuneAssignmentChecker.ps1
@@ -74,6 +74,7 @@ function Connect-IntuneAssignmentChecker {
     $hasClientSecret   = -not [string]::IsNullOrWhiteSpace($ClientSecret)
     $hasClientSecretCredential = $null -ne $ClientSecretCredential
     $hasCertThumbprint = -not [string]::IsNullOrWhiteSpace($CertificateThumbprint)
+    $hasAppOnlyCredential = $hasClientSecret -or $hasClientSecretCredential -or $hasCertThumbprint
     $hasAccessToken    = $null -ne $AccessToken -and $AccessToken.Length -gt 0
     $parameterMode     = $hasAppId -or $hasTenantId -or $hasClientSecret -or $hasClientSecretCredential -or $hasCertThumbprint -or $hasAccessToken
 
@@ -141,7 +142,15 @@ function Connect-IntuneAssignmentChecker {
             }
             else {
                 # Interactive authentication fallback
-                Write-Host "App ID, Tenant ID, or authentication credential (Certificate/Client Secret) is missing or not set correctly." -ForegroundColor Red
+                if ($hasAppOnlyCredential) {
+                    Write-Host "An app-only credential was supplied, but its required authentication parameters are incomplete. Falling back to interactive authentication." -ForegroundColor Red
+                }
+                elseif ($hasAppId) {
+                    Write-Host "No app-only credential supplied. The specified App ID will be used for interactive delegated authentication." -ForegroundColor Yellow
+                }
+                else {
+                    Write-Host "App ID, Tenant ID, or authentication credential (Certificate/Client Secret) is missing or not set correctly." -ForegroundColor Red
+                }
                 $manualConnection = Read-Host "Would you like to attempt a manual interactive connection? (y/n)"
                 if ($manualConnection -match '^[Yy]') {
                     Write-Host "Attempting manual interactive connection (you need privileges to consent permissions)..." -ForegroundColor Yellow
@@ -156,7 +165,19 @@ function Connect-IntuneAssignmentChecker {
                         Write-Host "Connection cancelled by user." -ForegroundColor Red
                         return
                     }
-                    $null = Connect-MgGraph -Scopes $permissionsList -Environment $script:GraphEnvironment -NoWelcome -ErrorAction Stop
+                    $connectParams = @{
+                        Scopes      = $permissionsList
+                        Environment = $script:GraphEnvironment
+                        NoWelcome   = $true
+                        ErrorAction = 'Stop'
+                    }
+                    if ($hasAppId) {
+                        $connectParams['ClientId'] = $AppId
+                    }
+                    if ($hasTenantId) {
+                        $connectParams['TenantId'] = $TenantId
+                    }
+                    $null = Connect-MgGraph @connectParams
                 }
                 else {
                     Write-Host "Connection cancelled by user." -ForegroundColor Red

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllDevicesAssignment.ps1
@@ -33,9 +33,9 @@ function Get-IntuneAllDevicesAssignment {
     foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoryById[$category.Id] = $category }
     foreach ($id in @('DeploymentProfiles', 'ESPProfiles')) { $categoryById[$id].BucketOnly = $false }
 
-    # Fetch order matches the pre-migration cmdlet (16 categories).
+    # Fetch order extends the pre-migration sequence with Imported Administrative Templates.
     $scanCategories = foreach ($id in @(
-            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
             'AppConfigurationPolicies', 'Applications', 'PlatformScripts', 'HealthScripts',
             'DeploymentProfiles', 'ESPProfiles',
             'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection')) {
@@ -102,6 +102,7 @@ function Get-IntuneAllDevicesAssignment {
 
     $displaySpecs = @(
         @{ Bucket = 'DeviceConfigs'; Header = 'Device Configurations'; Empty = 'Device Configurations'; Line = { param($item) "Device Configuration Name: $(Get-NamePreferringName $item), Platform: $(Get-PolicyPlatform -Policy $item), Configuration ID: $($item.id)" } }
+        @{ Bucket = 'ImportedAdministrativeTemplates'; Header = 'Imported Administrative Templates'; Empty = 'Imported Administrative Templates'; Line = { param($item) "Imported Administrative Template Name: $($item.displayName), Policy ID: $($item.id)" } }
         @{ Bucket = 'SettingsCatalog'; Header = 'Settings Catalog Policies'; Empty = 'Settings Catalog Policies'; Line = { param($item) "Settings Catalog Policy Name: $(Get-NamePreferringName $item), Policy ID: $($item.id)" } }
         @{ Bucket = 'CompliancePolicies'; Header = 'Compliance Policies'; Empty = 'Compliance Policies'; Line = { param($item) "Compliance Policy Name: $(Get-NamePreferringName $item), Platform: $(Get-PolicyPlatform -Policy $item), Policy ID: $($item.id)" } }
         @{ Bucket = 'AppProtectionPolicies'; Header = 'App Protection Policies'; Empty = 'App Protection Policies'; Line = {
@@ -145,7 +146,7 @@ function Get-IntuneAllDevicesAssignment {
 
     # Export rows in the pre-migration CSV order (apps after scripts, Autopilot/ESP last).
     $exportCategories = foreach ($id in @(
-            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
             'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'Applications',
             'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection',
             'DeploymentProfiles', 'ESPProfiles')) {

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllPolicies.ps1
@@ -119,6 +119,7 @@ function Get-IntuneAllPolicies {
 
     # Display all policies and their assignments
     Invoke-PolicyAssignments -Policies $allPolicies.DeviceConfigs -DisplayName "Device Configurations"
+    Invoke-PolicyAssignments -Policies $allPolicies.ImportedAdministrativeTemplates -DisplayName "Imported Administrative Templates"
     Invoke-PolicyAssignments -Policies $allPolicies.SettingsCatalog -DisplayName "Settings Catalog Policies"
     Invoke-PolicyAssignments -Policies $allPolicies.CompliancePolicies -DisplayName "Compliance Policies"
     Invoke-PolicyAssignments -Policies $allPolicies.AppProtectionPolicies -DisplayName "App Protection Policies"

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneAllUsersAssignment.ps1
@@ -96,6 +96,11 @@ function Get-IntuneAllUsersAssignment {
         "Device Configuration Name: $configName, Platform: $platform, Configuration ID: $($config.id)"
     }
 
+    Show-AllUsersSection -Header "Imported Administrative Templates" -EmptyLabel "Imported Administrative Templates" -Items $allUsersAssignments.ImportedAdministrativeTemplates -Line {
+        param($policy)
+        "Imported Administrative Template Name: $($policy.displayName), Policy ID: $($policy.id)"
+    }
+
     Show-AllUsersSection -Header "Settings Catalog Policies" -EmptyLabel "Settings Catalog Policies" -Items $allUsersAssignments.SettingsCatalog -Line {
         param($policy)
         $policyName = if ([string]::IsNullOrWhiteSpace($policy.name)) { $policy.displayName } else { $policy.name }
@@ -175,7 +180,7 @@ function Get-IntuneAllUsersAssignment {
     # where the app buckets came after the script categories, so export in that order
     # rather than fetch order.
     $exportOrderIds = @(
-        'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+        'DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
         'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'Applications',
         'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection', 'ESAttackSurface',
         'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles'

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneDeviceAssignment.ps1
@@ -39,7 +39,10 @@ function Get-IntuneDeviceAssignment {
 
     $categories = Get-IntuneCategoryDefinition -Audience 'DeviceContext'
     # Categories the legacy code fetched only for Windows (or unknown-OS) devices
-    $windowsOnlyCategoryIds = @('DeploymentProfiles', 'ESPProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
+    $windowsOnlyCategoryIds = @('ImportedAdministrativeTemplates', 'DeploymentProfiles', 'ESPProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
+    # These legacy categories retain their historical first-match assignment walk.
+    # Imported templates use standard exclusion precedence instead.
+    $firstMatchCategoryIds = @('DeploymentProfiles', 'ESPProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
     # Shared across devices so each entity set is fetched from Graph once per run
     $entityCache = @{}
 
@@ -293,7 +296,7 @@ function Get-IntuneDeviceAssignment {
                 return
             }
 
-            if ($ctx.Category.Id -in $windowsOnlyCategoryIds) {
+            if ($ctx.Category.Id -in $firstMatchCategoryIds) {
                 # First-match walk with no platform filtering: All Devices or a member group
                 # assignment includes; a member group exclusion shows as "Excluded".
                 foreach ($assignment in $ctx.Assignments) {
@@ -345,6 +348,7 @@ function Get-IntuneDeviceAssignment {
 
         $displaySections = @(
             @{ Title = 'Device Configurations'; Bucket = 'DeviceConfigs'; GetName = $nameFirst }
+            @{ Title = 'Imported Administrative Templates'; Bucket = 'ImportedAdministrativeTemplates'; GetName = $displayNameFirst }
             @{ Title = 'Settings Catalog Policies'; Bucket = 'SettingsCatalog'; GetName = $nameFirst }
             @{ Title = 'Compliance Policies'; Bucket = 'CompliancePolicies'; GetName = $nameFirst }
             @{ Title = 'App Protection Policies'; Bucket = 'AppProtectionPolicies'; GetName = $displayNameOnly }
@@ -377,7 +381,7 @@ function Get-IntuneDeviceAssignment {
 
         $reasonProperty = { param($item) $item.AssignmentReason }
         $exportBatches = @(
-            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            @{ Ids = @('DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
             # App Protection rows export the AssignmentSummary built above
             @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
             @{ Ids = @('AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'DeploymentProfiles', 'ESPProfiles',

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneEmptyGroup.ps1
@@ -32,6 +32,7 @@ function Get-IntuneEmptyGroup {
     # Initialize collections for policies with empty group assignments
     $emptyGroupAssignments = @{
         DeviceConfigs             = @()
+        ImportedAdministrativeTemplates = @()
         SettingsCatalog           = @()
         CompliancePolicies        = @()
         AppProtectionPolicies     = @()
@@ -57,6 +58,24 @@ function Get-IntuneEmptyGroup {
                 if ($groupInfo.Success -and (Test-EmptyGroup -GroupId $assignment.GroupId)) {
                     $config | Add-Member -NotePropertyName 'EmptyGroupInfo' -NotePropertyValue "Assigned to empty group: $($groupInfo.DisplayName)" -Force
                     $emptyGroupAssignments.DeviceConfigs += $config
+                    break
+                }
+            }
+        }
+    }
+
+    # Get Imported Administrative Templates
+    Write-Host "Fetching Imported Administrative Templates..." -ForegroundColor Yellow
+    $importedTemplates = Get-IntuneEntities -EntityType "groupPolicyConfigurations" |
+        Where-Object { Test-ImportedAdministrativeTemplate -Policy $_ }
+    foreach ($policy in $importedTemplates) {
+        $assignments = Get-IntuneAssignments -EntityType "groupPolicyConfigurations" -EntityId $policy.id
+        foreach ($assignment in $assignments) {
+            if ($assignment.Reason -eq "Group Assignment" -and $assignment.GroupId) {
+                $groupInfo = Get-GroupInfo -GroupId $assignment.GroupId
+                if ($groupInfo.Success -and (Test-EmptyGroup -GroupId $assignment.GroupId)) {
+                    $policy | Add-Member -NotePropertyName 'EmptyGroupInfo' -NotePropertyValue "Assigned to empty group: $($groupInfo.DisplayName)" -Force
+                    $emptyGroupAssignments.ImportedAdministrativeTemplates += $policy
                     break
                 }
             }
@@ -214,6 +233,21 @@ function Get-IntuneEmptyGroup {
             Write-Host "$($config.EmptyGroupInfo)" -ForegroundColor Yellow
             Write-Host ""
             Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items @($config) -AssignmentReason $config.EmptyGroupInfo
+        }
+    }
+
+    # Display Imported Administrative Templates
+    Write-Host "`n------- Imported Administrative Templates -------" -ForegroundColor Cyan
+    if ($emptyGroupAssignments.ImportedAdministrativeTemplates.Count -eq 0) {
+        Write-Host "No Imported Administrative Templates assigned to empty groups" -ForegroundColor Gray
+    }
+    else {
+        foreach ($policy in $emptyGroupAssignments.ImportedAdministrativeTemplates) {
+            Write-Host "Imported Administrative Template Name: $($policy.displayName)" -ForegroundColor White
+            Write-Host "Policy ID: $($policy.id)" -ForegroundColor Gray
+            Write-Host "$($policy.EmptyGroupInfo)" -ForegroundColor Yellow
+            Write-Host ""
+            Add-ExportData -ExportData $exportData -Category "Imported Administrative Template" -Items @($policy) -AssignmentReason $policy.EmptyGroupInfo
         }
     }
 

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneGroupAssignment.ps1
@@ -60,6 +60,7 @@ function Get-IntuneGroupAssignment {
         # Initialize variables
         $groupId = $null
         $groupName = $null
+        $resolvedGroupInfo = $null
 
         # Check if input is a GUID
         if ($groupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
@@ -70,11 +71,13 @@ function Get-IntuneGroupAssignment {
             }
             $groupId = $groupInfo.Id
             $groupName = $groupInfo.DisplayName
+            $resolvedGroupInfo = $groupInfo
         }
         else {
             # Try to find group by display name (single quotes escaped for the OData filter)
             $escapedGroupName = $groupInput -replace "'", "''"
-            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'"
+            $groupSelect = 'id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+            $groupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedGroupName'&`$select=$groupSelect"
             $groupResponse = Invoke-MgGraphRequest -Uri $groupUri -Method Get
 
             if ($groupResponse.value.Count -eq 0) {
@@ -84,16 +87,27 @@ function Get-IntuneGroupAssignment {
             elseif ($groupResponse.value.Count -gt 1) {
                 Write-Host "Multiple groups found with name: $groupInput. Please use the Object ID instead:" -ForegroundColor Red
                 foreach ($group in $groupResponse.value) {
-                    Write-Host "  - $($group.displayName) (ID: $($group.id))" -ForegroundColor Yellow
+                    $candidateInfo = ConvertTo-IntuneGroupInfo -Group $group
+                    $candidateDetails = "ID: $($candidateInfo.Id); Type: $($candidateInfo.GroupType); Membership: $($candidateInfo.MembershipType)"
+                    if ($candidateInfo.Mail) { $candidateDetails += "; Mail: $($candidateInfo.Mail)" }
+                    Write-Host "  - $($candidateInfo.DisplayName) ($candidateDetails)" -ForegroundColor Yellow
                 }
                 continue
             }
 
-            $groupId = $groupResponse.value[0].id
-            $groupName = $groupResponse.value[0].displayName
+            $resolvedGroupInfo = ConvertTo-IntuneGroupInfo -Group $groupResponse.value[0]
+            if (-not $resolvedGroupInfo.Success) {
+                Write-Host "The group lookup for '$groupInput' returned an invalid response without an Object ID." -ForegroundColor Red
+                continue
+            }
+            $groupId = $resolvedGroupInfo.Id
+            $groupName = $resolvedGroupInfo.DisplayName
         }
 
         Write-Host "Found group: $groupName (ID: $groupId)" -ForegroundColor Green
+        $groupDetails = "Type: $($resolvedGroupInfo.GroupType); Membership: $($resolvedGroupInfo.MembershipType)"
+        if ($resolvedGroupInfo.Mail) { $groupDetails += "; Mail: $($resolvedGroupInfo.Mail)" }
+        Write-Host "Group details: $groupDetails" -ForegroundColor Green
 
         # Build effective group IDs list (direct + parent groups if nested checking enabled)
         $allGroupIds = @($groupId)
@@ -198,6 +212,7 @@ function Get-IntuneGroupAssignment {
 
         $displaySections = @(
             @{ Title = 'Device Configurations'; Bucket = 'DeviceConfigs'; GetName = $nameFirst }
+            @{ Title = 'Imported Administrative Templates'; Bucket = 'ImportedAdministrativeTemplates'; GetName = $displayNameFirst }
             @{ Title = 'Settings Catalog Policies'; Bucket = 'SettingsCatalog'; GetName = $nameFirst }
             @{ Title = 'Compliance Policies'; Bucket = 'CompliancePolicies'; GetName = $nameFirst }
             @{ Title = 'App Protection Policies'; Bucket = 'AppProtectionPolicies'; GetName = $displayNameOnly }
@@ -230,15 +245,22 @@ function Get-IntuneGroupAssignment {
 
         # Add to export data: the Group row first, then categories in the legacy CSV order
         # (Endpoint Security after the Windows 365 categories, the app buckets last).
+        $groupExportProperties = [ordered]@{
+            GroupId        = $groupId
+            GroupName      = $groupName
+            GroupType      = $resolvedGroupInfo.GroupType
+            MembershipType = $resolvedGroupInfo.MembershipType
+            GroupMail      = $resolvedGroupInfo.Mail
+        }
         Add-ExportData -ExportData $exportData -Category "Group" -Items @([PSCustomObject]@{
                 displayName      = $groupName
                 id               = $groupId
                 AssignmentReason = "N/A"
-            })
+            }) -AdditionalProperties $groupExportProperties
 
         $reasonProperty = { param($item) $item.AssignmentReason }
         $exportBatches = @(
-            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            @{ Ids = @('DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
             # Historical quirk preserved: App Protection rows export AssignmentSummary,
             # a property this cmdlet never sets, so their AssignmentReason column stays empty.
             @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
@@ -248,7 +270,7 @@ function Get-IntuneGroupAssignment {
         )
         foreach ($batch in $exportBatches) {
             $batchCategories = foreach ($id in $batch.Ids) { $categories | Where-Object { $_.Id -eq $id } }
-            Add-CategoryExportData -ExportData $exportData -Categories $batchCategories -Buckets $relevantPolicies -AssignmentReason $batch.Reason
+            Add-CategoryExportData -ExportData $exportData -Categories $batchCategories -Buckets $relevantPolicies -AssignmentReason $batch.Reason -AdditionalProperties $groupExportProperties
         }
     }
 

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUnassignedPolicy.ps1
@@ -17,6 +17,7 @@ function Get-IntuneUnassignedPolicy {
     # Initialize collections for policies without assignments
     $unassignedPolicies = @{
         DeviceConfigs            = @()
+        ImportedAdministrativeTemplates = @()
         SettingsCatalog          = @()
         CompliancePolicies       = @()
         AppProtectionPolicies    = @()
@@ -33,6 +34,18 @@ function Get-IntuneUnassignedPolicy {
         $assignments = Get-IntuneAssignments -EntityType "deviceConfigurations" -EntityId $config.id
         if ($assignments.Count -eq 0) {
             $unassignedPolicies.DeviceConfigs += $config
+        }
+    }
+
+    # Get Imported Administrative Templates. Built-in-only group policy
+    # configurations are intentionally excluded from this imported category.
+    Write-Host "Fetching Imported Administrative Templates..." -ForegroundColor Yellow
+    $importedTemplates = Get-IntuneEntities -EntityType "groupPolicyConfigurations" |
+        Where-Object { Test-ImportedAdministrativeTemplate -Policy $_ }
+    foreach ($policy in $importedTemplates) {
+        $assignments = Get-IntuneAssignments -EntityType "groupPolicyConfigurations" -EntityId $policy.id
+        if ($assignments.Count -eq 0) {
+            $unassignedPolicies.ImportedAdministrativeTemplates += $policy
         }
     }
 
@@ -227,7 +240,7 @@ function Get-IntuneUnassignedPolicy {
 
     # Get Unassigned Apps
     Write-Host "Fetching Unassigned Apps..." -ForegroundColor Yellow
-    $unassignedAppUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq false"
+    $unassignedAppUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq false&`$select=id,displayName,roleScopeTagIds"
     $unassignedApps = [System.Collections.Generic.List[object]]::new()
     try {
         $unassignedAppResponse = Invoke-MgGraphRequest -Uri $unassignedAppUri -Method Get
@@ -241,7 +254,6 @@ function Get-IntuneUnassignedPolicy {
         Write-Host "Error fetching unassigned applications: $($_.Exception.Message)" -ForegroundColor Red
         Write-Error -Message "Unassigned applications fetch failed: $($_.Exception.Message)"
     }
-    $unassignedApps = $unassignedApps | Where-Object { -not $_.isFeatured -and -not $_.isBuiltIn }
     $unassignedPolicies.Apps = $unassignedApps
 
     # Apply scope tag filter if specified
@@ -265,6 +277,18 @@ function Get-IntuneUnassignedPolicy {
             $platform = Get-PolicyPlatform -Policy $config
             Write-Host "Device Configuration Name: $configName, Platform: $platform, Configuration ID: $($config.id)" -ForegroundColor White
             Add-ExportData -ExportData $exportData -Category "Device Configuration" -Items @($config) -AssignmentReason "No Assignment"
+        }
+    }
+
+    # Display Imported Administrative Templates
+    Write-Host "`n------- Imported Administrative Templates -------" -ForegroundColor Cyan
+    if ($unassignedPolicies.ImportedAdministrativeTemplates.Count -eq 0) {
+        Write-Host "No unassigned Imported Administrative Templates found" -ForegroundColor Gray
+    }
+    else {
+        foreach ($policy in $unassignedPolicies.ImportedAdministrativeTemplates) {
+            Write-Host "Imported Administrative Template Name: $($policy.displayName), Policy ID: $($policy.id)" -ForegroundColor White
+            Add-ExportData -ExportData $exportData -Category "Imported Administrative Template" -Items @($policy) -AssignmentReason "No Assignment"
         }
     }
 

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserAssignment.ps1
@@ -114,7 +114,7 @@ function Get-IntuneUserAssignment {
                 if ($null -eq $appProgress.Total) {
                     $allCachedApps = @($entityCache[$ctx.Category.EntityType])
                     $appProgress.Total = $allCachedApps.Count
-                    $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
+                    $appProgress.FilteredTotal = @($allCachedApps).Count
                 }
                 $appProgress.Current++
                 Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
@@ -254,7 +254,7 @@ function Get-IntuneUserAssignment {
         Write-Host "`nAssignments for User: $upn" -ForegroundColor Green
 
         # Calculate category summary
-        $categoryNames = @('DeviceConfigs', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies', 'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'AppsRequired', 'AppsAvailable', 'AppsUninstall', 'AntivirusProfiles', 'DiskEncryptionProfiles', 'FirewallProfiles', 'EndpointDetectionProfiles', 'AttackSurfaceProfiles', 'AccountProtectionProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
+        $categoryNames = @('DeviceConfigs', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies', 'AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'AppsRequired', 'AppsAvailable', 'AppsUninstall', 'AntivirusProfiles', 'DiskEncryptionProfiles', 'FirewallProfiles', 'EndpointDetectionProfiles', 'AttackSurfaceProfiles', 'AccountProtectionProfiles', 'CloudPCProvisioningPolicies', 'CloudPCUserSettings')
         $nonEmptyCount = ($categoryNames | Where-Object { $relevantPolicies[$_].Count -gt 0 }).Count
         $totalDisplayCategories = $categoryNames.Count
         Write-Host "`nFound assignments in $nonEmptyCount of $totalDisplayCategories categories." -ForegroundColor Cyan
@@ -287,6 +287,7 @@ function Get-IntuneUserAssignment {
             Write-Host $separator
         }
 
+        Show-UserSectionTable -Title 'Imported Administrative Templates' -Items @($relevantPolicies.ImportedAdministrativeTemplates) -NameLabel 'Policy Name' -IdLabel 'Policy ID' -GetName $displayNameOnly
         Show-UserSectionTable -Title 'Settings Catalog Policies' -Items @($relevantPolicies.SettingsCatalog) -NameLabel 'Policy Name' -IdLabel 'Policy ID' -GetName $nameFirst
         Show-UserSectionTable -Title 'Compliance Policies' -Items @($relevantPolicies.CompliancePolicies) -NameLabel 'Policy Name' -IdLabel 'Policy ID' -GetName $nameFirst
 
@@ -363,7 +364,7 @@ function Get-IntuneUserAssignment {
 
         $reasonProperty = { param($item) $item.AssignmentReason }
         $exportBatches = @(
-            @{ Ids = @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
+            @{ Ids = @('DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies'); Reason = $reasonProperty }
             # App Protection rows export the AssignmentSummary built during the scan
             @{ Ids = @('AppProtectionPolicies'); Reason = { param($item) $item.AssignmentSummary } }
             @{ Ids = @('AppConfigurationPolicies', 'PlatformScripts', 'HealthScripts', 'DeploymentProfiles', 'ESPProfiles',

--- a/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Get-IntuneUserDeviceAssignment.ps1
@@ -146,6 +146,7 @@ function Get-IntuneUserDeviceAssignment {
 
     $relevantPolicies = @{
         DeviceConfigs               = [System.Collections.ArrayList]::new()
+        ImportedAdministrativeTemplates = [System.Collections.ArrayList]::new()
         SettingsCatalog             = [System.Collections.ArrayList]::new()
         CompliancePolicies          = [System.Collections.ArrayList]::new()
         AppProtectionPolicies       = [System.Collections.ArrayList]::new()
@@ -240,6 +241,21 @@ function Get-IntuneUserDeviceAssignment {
     # ── Generic categories ───────────────────────────────────────────────────
     Write-Host "  Device Configurations..." -ForegroundColor Yellow
     & $processGeneric "deviceConfigurations" "DeviceConfigs"
+
+    if (-not $deviceOS -or $deviceOS -eq 'Windows') {
+        Write-Host "  Imported Administrative Templates..." -ForegroundColor Yellow
+        $importedTemplates = Get-IntuneEntities -EntityType "groupPolicyConfigurations" |
+            Where-Object { Test-ImportedAdministrativeTemplate -Policy $_ }
+        foreach ($policy in $importedTemplates) {
+            $assignments = Get-IntuneAssignments -EntityType "groupPolicyConfigurations" -EntityId $policy.id
+            $reason = Resolve-AssignmentReason -Assignments $assignments -GroupMembershipIds $combinedGroupIds -IncludeReasons $includeReasons
+            if (-not $reason) { continue }
+            $info = & $classify $assignments $reason
+            $policy | Add-Member -NotePropertyName 'AssignmentReason' -NotePropertyValue $info.Reason -Force
+            $policy | Add-Member -NotePropertyName 'Source' -NotePropertyValue $info.Source -Force
+            [void]$relevantPolicies.ImportedAdministrativeTemplates.Add($policy)
+        }
+    }
 
     Write-Host "  Settings Catalog Policies..." -ForegroundColor Yellow
     $allConfigPolicies = Get-IntuneEntities -EntityType "configurationPolicies"
@@ -356,7 +372,7 @@ function Get-IntuneUserDeviceAssignment {
 
     # ── Applications ─────────────────────────────────────────────────────────
     Write-Host "  Applications..." -ForegroundColor Yellow
-    $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
+    $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true&`$select=id,displayName,roleScopeTagIds"
     $allApps = [System.Collections.Generic.List[object]]::new()
     try {
         $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
@@ -372,7 +388,6 @@ function Get-IntuneUserDeviceAssignment {
     }
 
     foreach ($app in $allApps) {
-        if ($app.isFeatured -or $app.isBuiltIn) { continue }
         if (-not (Test-AppPlatformCompatibility -DeviceOS $deviceOS -App $app)) { continue }
 
         try {
@@ -482,6 +497,7 @@ function Get-IntuneUserDeviceAssignment {
 
     $categoryDisplay = [ordered]@{
         DeviceConfigs               = "Device Configurations"
+        ImportedAdministrativeTemplates = "Imported Administrative Templates"
         SettingsCatalog             = "Settings Catalog Policies"
         CompliancePolicies          = "Compliance Policies"
         AppProtectionPolicies       = "App Protection Policies"
@@ -553,6 +569,7 @@ function Get-IntuneUserDeviceAssignment {
     })
 
     Add-ExportData -ExportData $exportData -Category "Device Configuration"                  -Items $relevantPolicies.DeviceConfigs               -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
+    Add-ExportData -ExportData $exportData -Category "Imported Administrative Template"      -Items $relevantPolicies.ImportedAdministrativeTemplates -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
     Add-ExportData -ExportData $exportData -Category "Settings Catalog Policy"               -Items $relevantPolicies.SettingsCatalog             -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
     Add-ExportData -ExportData $exportData -Category "Compliance Policy"                     -Items $relevantPolicies.CompliancePolicies          -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }
     Add-ExportData -ExportData $exportData -Category "App Protection Policy"                 -Items $relevantPolicies.AppProtectionPolicies       -AssignmentReason { param($i) "$($i.Source) | $($i.AssignmentReason)" }

--- a/Module/IntuneAssignmentChecker/Public/Invoke-IntuneAssignmentChecker.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Invoke-IntuneAssignmentChecker.ps1
@@ -58,6 +58,12 @@ function Invoke-IntuneAssignmentChecker {
         [Parameter(Mandatory = $false, HelpMessage = "Path for the exported HTML report file")]
         [string]$HTMLReportPath,
 
+        [Parameter(Mandatory = $false, HelpMessage = "Path for the CSV companion to the HTML report")]
+        [string]$CSVReportPath,
+
+        [Parameter(Mandatory = $false, HelpMessage = "Generate only the HTML report without its CSV companion")]
+        [switch]$NoCSVReport,
+
         [Parameter(Mandatory = $false, HelpMessage = "Show policies and apps without assignments")]
         [switch]$ShowPoliciesWithoutAssignments,
 
@@ -114,6 +120,12 @@ function Invoke-IntuneAssignmentChecker {
         [string]$ScopeTagFilter
     )
 
+    # Reject contradictory report output options before authentication or any
+    # other work. New-IntuneHTMLReport enforces the same rule via parameter sets.
+    if ($NoCSVReport -and $CSVReportPath) {
+        throw "-NoCSVReport cannot be combined with -CSVReportPath."
+    }
+
     # ── Determine parameter mode ──────────────────────────────────────────
     $parameterMode  = $false
     $selectedOption = $null
@@ -135,8 +147,8 @@ function Invoke-IntuneAssignmentChecker {
     elseif ($SearchSetting)            { $parameterMode = $true; $selectedOption = '15' }
     elseif ($CheckUserAndDevice)       { $parameterMode = $true; $selectedOption = '16' }
 
-    # HTMLReportPath implies GenerateHTMLReport
-    if (-not $parameterMode -and $HTMLReportPath) {
+    # Any report output option implies GenerateHTMLReport.
+    if (-not $parameterMode -and ($HTMLReportPath -or $CSVReportPath -or $NoCSVReport)) {
         $parameterMode  = $true
         $selectedOption = '7'
     }
@@ -211,8 +223,11 @@ function Invoke-IntuneAssignmentChecker {
                     -ScopeTagFilter $ScopeTagFilter
             }
             '7' {
-                New-IntuneHTMLReport `
-                    -HTMLReportPath $HTMLReportPath
+                $reportParams = @{}
+                if ($HTMLReportPath) { $reportParams['HTMLReportPath'] = $HTMLReportPath }
+                if ($CSVReportPath)  { $reportParams['CSVReportPath'] = $CSVReportPath }
+                if ($NoCSVReport)    { $reportParams['NoCSVReport'] = $true }
+                New-IntuneHTMLReport @reportParams
             }
             '8' {
                 Get-IntuneUnassignedPolicy `

--- a/Module/IntuneAssignmentChecker/Public/New-IntuneHTMLReport.ps1
+++ b/Module/IntuneAssignmentChecker/Public/New-IntuneHTMLReport.ps1
@@ -1,14 +1,20 @@
 function New-IntuneHTMLReport {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'CsvCompanion')]
     param (
         [Parameter()]
-        [string]$HTMLReportPath
+        [string]$HTMLReportPath,
+
+        [Parameter(ParameterSetName = 'CsvCompanion')]
+        [string]$CSVReportPath,
+
+        [Parameter(Mandatory, ParameterSetName = 'HtmlOnly')]
+        [switch]$NoCSVReport
     )
 
     Write-Host "Generating HTML Report..." -ForegroundColor Green
 
     # Dot-source html-export.ps1 shipped with the module
-    $htmlExportScript = Join-Path $PSScriptRoot '..' 'html-export.ps1'
+    $htmlExportScript = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..') -ChildPath 'html-export.ps1'
 
     try {
         . $htmlExportScript
@@ -16,8 +22,9 @@ function New-IntuneHTMLReport {
         $defaultFileName = "IntuneAssignmentReport.html"
 
         if ($HTMLReportPath) {
-            # Resolve to absolute path to avoid writing to CWD (e.g. System32 on Windows)
-            $HTMLReportPath = [System.IO.Path]::GetFullPath($HTMLReportPath)
+            # Resolve relative paths against PowerShell's current provider
+            # location. The .NET process directory does not follow Set-Location.
+            $HTMLReportPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($HTMLReportPath)
 
             if (Test-Path $HTMLReportPath -PathType Container) {
                 # Existing directory - append default filename
@@ -54,8 +61,17 @@ function New-IntuneHTMLReport {
             $filePath = Join-Path $defaultReportPath $defaultFileName
         }
 
-        Write-Host "Report will be saved to: $filePath" -ForegroundColor Cyan
-        Export-HTMLReport -FilePath $filePath
+        Write-Host "HTML report will be saved to: $filePath" -ForegroundColor Cyan
+        if ($NoCSVReport) {
+            Write-Host "CSV companion report disabled." -ForegroundColor Gray
+        }
+        elseif ($CSVReportPath) {
+            Write-Host "CSV report requested at: $CSVReportPath" -ForegroundColor Cyan
+        }
+        else {
+            Write-Host "CSV report will use the HTML report base path." -ForegroundColor Cyan
+        }
+        Export-HTMLReport -FilePath $filePath -CSVReportPath $CSVReportPath -SkipCSVReport:$NoCSVReport
     }
     catch {
         Write-Host "Error: Failed to generate the HTML report. $($_.Exception.Message)" -ForegroundColor Red

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupMembership.ps1
@@ -94,6 +94,7 @@ function Test-IntuneGroupMembership {
 
     # Resolve target group
     Write-Host "Looking up group: $simGroupInput" -ForegroundColor Yellow
+    $simResolvedGroupInfo = $null
     if ($simGroupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
         $simGroupInfo = Get-GroupInfo -GroupId $simGroupInput
         if (-not $simGroupInfo.Success) {
@@ -102,11 +103,13 @@ function Test-IntuneGroupMembership {
         }
         $simTargetGroupId = $simGroupInfo.Id
         $simTargetGroupName = $simGroupInfo.DisplayName
+        $simResolvedGroupInfo = $simGroupInfo
     }
     else {
         # Single quotes escaped for the OData filter (F9)
         $escapedSimGroupName = $simGroupInput -replace "'", "''"
-        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
+        $simGroupSelect = 'id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'&`$select=$simGroupSelect"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {
@@ -116,16 +119,23 @@ function Test-IntuneGroupMembership {
         elseif ($simGroupResponse.value.Count -gt 1) {
             Write-Host "Multiple groups found with name: $simGroupInput. Please use the Object ID instead:" -ForegroundColor Red
             foreach ($g in $simGroupResponse.value) {
-                Write-Host "  - $($g.displayName) (ID: $($g.id))" -ForegroundColor Yellow
+                $candidateInfo = ConvertTo-IntuneGroupInfo -Group $g
+                Write-Host "  - $($candidateInfo.DisplayName) (ID: $($candidateInfo.Id); Type: $($candidateInfo.GroupType); Membership: $($candidateInfo.MembershipType))" -ForegroundColor Yellow
             }
             return
         }
 
-        $simTargetGroupId = $simGroupResponse.value[0].id
-        $simTargetGroupName = $simGroupResponse.value[0].displayName
+        $simResolvedGroupInfo = ConvertTo-IntuneGroupInfo -Group $simGroupResponse.value[0]
+        if (-not $simResolvedGroupInfo.Success) {
+            Write-Host "The group lookup for '$simGroupInput' returned an invalid response without an Object ID." -ForegroundColor Red
+            return
+        }
+        $simTargetGroupId = $simResolvedGroupInfo.Id
+        $simTargetGroupName = $simResolvedGroupInfo.DisplayName
     }
 
     Write-Host "Target group: $simTargetGroupName (ID: $simTargetGroupId)" -ForegroundColor Green
+    Write-Host "Group details: Type: $($simResolvedGroupInfo.GroupType); Membership: $($simResolvedGroupInfo.MembershipType)$(if ($simResolvedGroupInfo.Mail) { "; Mail: $($simResolvedGroupInfo.Mail)" })" -ForegroundColor Green
 
     # Get current group memberships (union of user and device, depending on what was supplied)
     $simCurrentGroupIds = @()
@@ -159,14 +169,14 @@ function Test-IntuneGroupMembership {
 
     Write-Host "Analyzing impact..." -ForegroundColor Yellow
 
-    # The legacy 18-step walk matches the UserContext registry entries (same display names, no
-    # Settings Catalog ES filter): reorder to the legacy sequence and make Autopilot/ESP fetchable.
+    # The legacy walk matches the UserContext registry entries (same display names, no
+    # Settings Catalog ES filter); Imported Administrative Templates add one step.
     $categoriesById = @{}
     foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoriesById[$category.Id] = $category }
     $categoriesById['DeploymentProfiles'].BucketOnly = $false
     $categoriesById['ESPProfiles'].BucketOnly = $false
     $categories = @(
-        @('DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies', 'AppConfigurationPolicies',
+        @('DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies', 'AppConfigurationPolicies',
             'Applications', 'PlatformScripts', 'HealthScripts', 'ESAntivirus', 'ESDiskEncryption', 'ESFirewall',
             'ESEndpointDetection', 'ESAttackSurface', 'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles',
             'CloudPCProvisioningPolicies', 'CloudPCUserSettings') | ForEach-Object { $categoriesById[$_] })
@@ -195,7 +205,7 @@ function Test-IntuneGroupMembership {
                 # Legacy progress counted against the unfiltered app list
                 $allCachedApps = @($entityCache[$ctx.Category.EntityType])
                 $appProgress.Total = $allCachedApps.Count
-                $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
+                $appProgress.FilteredTotal = @($allCachedApps).Count
             }
             $appProgress.Current++
             Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
@@ -319,7 +329,8 @@ function Test-IntuneGroupMembership {
 
     # Category display mapping (legacy section order and labels)
     $categoryDisplay = [ordered]@{
-        DeviceConfigs = "Device Configurations"; SettingsCatalog = "Settings Catalog Policies"
+        DeviceConfigs = "Device Configurations"; ImportedAdministrativeTemplates = "Imported Administrative Templates"
+        SettingsCatalog = "Settings Catalog Policies"
         CompliancePolicies = "Compliance Policies"; AppProtectionPolicies = "App Protection Policies"
         AppConfigurationPolicies = "App Configuration Policies"; AppsRequired = "Required Apps"
         AppsAvailable = "Available Apps"; AppsUninstall = "Uninstall Apps"
@@ -421,7 +432,8 @@ function Test-IntuneGroupMembership {
 
     # Legacy CSV order and labels for the NEW-policy rows
     $exportSections = [ordered]@{
-        'NEW: Device Configuration' = 'DeviceConfigs'; 'NEW: Settings Catalog Policy' = 'SettingsCatalog'
+        'NEW: Device Configuration' = 'DeviceConfigs'; 'NEW: Imported Administrative Template' = 'ImportedAdministrativeTemplates'
+        'NEW: Settings Catalog Policy' = 'SettingsCatalog'
         'NEW: Compliance Policy' = 'CompliancePolicies'; 'NEW: App Protection Policy' = 'AppProtectionPolicies'
         'NEW: App Configuration Policy' = 'AppConfigurationPolicies'; 'NEW: Required App' = 'AppsRequired'
         'NEW: Available App' = 'AppsAvailable'; 'NEW: Uninstall App' = 'AppsUninstall'

--- a/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
+++ b/Module/IntuneAssignmentChecker/Public/Test-IntuneGroupRemoval.ps1
@@ -116,6 +116,7 @@ function Test-IntuneGroupRemoval {
     Write-Host "Looking up group: $simGroupInput" -ForegroundColor Yellow
     $simTargetGroupId = $null
     $simTargetGroupName = $null
+    $simResolvedGroupInfo = $null
 
     if ($simGroupInput -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$') {
         $simGroupInfo = Get-GroupInfo -GroupId $simGroupInput
@@ -125,10 +126,12 @@ function Test-IntuneGroupRemoval {
         }
         $simTargetGroupId = $simGroupInfo.Id
         $simTargetGroupName = $simGroupInfo.DisplayName
+        $simResolvedGroupInfo = $simGroupInfo
     }
     else {
         $escapedSimGroupName = $simGroupInput -replace "'", "''"
-        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'"
+        $simGroupSelect = 'id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+        $simGroupUri = "$script:GraphEndpoint/v1.0/groups?`$filter=displayName eq '$escapedSimGroupName'&`$select=$simGroupSelect"
         $simGroupResponse = Invoke-MgGraphRequest -Uri $simGroupUri -Method Get
 
         if ($simGroupResponse.value.Count -eq 0) {
@@ -138,16 +141,23 @@ function Test-IntuneGroupRemoval {
         elseif ($simGroupResponse.value.Count -gt 1) {
             Write-Host "Multiple groups found with name: $simGroupInput. Please use the Object ID instead:" -ForegroundColor Red
             foreach ($g in $simGroupResponse.value) {
-                Write-Host "  - $($g.displayName) (ID: $($g.id))" -ForegroundColor Yellow
+                $candidateInfo = ConvertTo-IntuneGroupInfo -Group $g
+                Write-Host "  - $($candidateInfo.DisplayName) (ID: $($candidateInfo.Id); Type: $($candidateInfo.GroupType); Membership: $($candidateInfo.MembershipType))" -ForegroundColor Yellow
             }
             return
         }
 
-        $simTargetGroupId = $simGroupResponse.value[0].id
-        $simTargetGroupName = $simGroupResponse.value[0].displayName
+        $simResolvedGroupInfo = ConvertTo-IntuneGroupInfo -Group $simGroupResponse.value[0]
+        if (-not $simResolvedGroupInfo.Success) {
+            Write-Host "The group lookup for '$simGroupInput' returned an invalid response without an Object ID." -ForegroundColor Red
+            return
+        }
+        $simTargetGroupId = $simResolvedGroupInfo.Id
+        $simTargetGroupName = $simResolvedGroupInfo.DisplayName
     }
 
     Write-Host "Target group: $simTargetGroupName (ID: $simTargetGroupId)" -ForegroundColor Green
+    Write-Host "Group details: Type: $($simResolvedGroupInfo.GroupType); Membership: $($simResolvedGroupInfo.MembershipType)$(if ($simResolvedGroupInfo.Mail) { "; Mail: $($simResolvedGroupInfo.Mail)" })" -ForegroundColor Green
 
     # Get current group memberships (union of user and device, depending on what was supplied)
     $simCurrentGroupIds = @()
@@ -196,12 +206,12 @@ function Test-IntuneGroupRemoval {
     Write-Host "Analyzing removal impact..." -ForegroundColor Yellow
 
     # UserContext supplies this cmdlet's legacy display names and the unfiltered Settings
-    # Catalog fetch; reorder to the legacy 18-step walk and fetch the Autopilot/ESP
-    # categories that UserContext keeps bucket-only.
+    # Catalog fetch; extend the legacy walk with Imported Administrative Templates and
+    # fetch the Autopilot/ESP categories that UserContext keeps bucket-only.
     $categoryIndex = @{}
     foreach ($category in (Get-IntuneCategoryDefinition -Audience 'UserContext')) { $categoryIndex[$category.Id] = $category }
     $categories = foreach ($id in @(
-            'DeviceConfigurations', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
+            'DeviceConfigurations', 'ImportedAdministrativeTemplates', 'SettingsCatalog', 'CompliancePolicies', 'AppProtectionPolicies',
             'AppConfigurationPolicies', 'Applications', 'PlatformScripts', 'HealthScripts',
             'ESAntivirus', 'ESDiskEncryption', 'ESFirewall', 'ESEndpointDetection',
             'ESAttackSurface', 'ESAccountProtection', 'DeploymentProfiles', 'ESPProfiles',
@@ -235,7 +245,7 @@ function Test-IntuneGroupRemoval {
             if ($null -eq $appProgress.Total) {
                 $allCachedApps = @($entityCache[$ctx.Category.EntityType])
                 $appProgress.Total = $allCachedApps.Count
-                $appProgress.FilteredTotal = @($allCachedApps | Where-Object { -not ($_.isFeatured -or $_.isBuiltIn) }).Count
+                $appProgress.FilteredTotal = @($allCachedApps).Count
             }
             $appProgress.Current++
             Write-Host "`rFetching Application $($appProgress.Current) of $($appProgress.Total)" -NoNewline
@@ -364,6 +374,7 @@ function Test-IntuneGroupRemoval {
     # Per-bucket display and export labels in the legacy order
     $categoryTable = @(
         @{ Key = 'DeviceConfigs'; Display = 'Device Configurations'; Export = 'Device Configuration' }
+        @{ Key = 'ImportedAdministrativeTemplates'; Display = 'Imported Administrative Templates'; Export = 'Imported Administrative Template' }
         @{ Key = 'SettingsCatalog'; Display = 'Settings Catalog Policies'; Export = 'Settings Catalog Policy' }
         @{ Key = 'CompliancePolicies'; Display = 'Compliance Policies'; Export = 'Compliance Policy' }
         @{ Key = 'AppProtectionPolicies'; Display = 'App Protection Policies'; Export = 'App Protection Policy' }

--- a/Module/IntuneAssignmentChecker/html-export.ps1
+++ b/Module/IntuneAssignmentChecker/html-export.ps1
@@ -11,8 +11,11 @@ function Get-HtmlAssignmentInfo {
 
     if ($null -eq $Assignments -or $Assignments.Count -eq 0) {
         return @{
-            Type   = "None"
-            Target = "Not Assigned"
+            Type       = "None"
+            Target     = "Not Assigned"
+            FilterName = "None"
+            FilterType = "None"
+            Filter     = "None"
         }
     }
 
@@ -20,6 +23,7 @@ function Get-HtmlAssignmentInfo {
     $targets = @()
     $filterNames = @()
     $filterTypes = @()
+    $filterDisplays = @()
 
     foreach ($assignment in $Assignments) {
         $type = "None"
@@ -58,9 +62,10 @@ function Get-HtmlAssignmentInfo {
         # Handle standard format (with Reason and GroupId)
         else {
             $type = switch ($assignment.Reason) {
-                "All Users" { "All Users"; break }
-                "All Devices" { "All Devices"; break }
+                "All Users" { $target = "All Users"; "All Users"; break }
+                "All Devices" { $target = "All Devices"; "All Devices"; break }
                 "Group Assignment" { "Group"; break }
+                "Group Exclusion" { "Exclude"; break }
                 "Exclude" { "Exclude"; break }
                 default { "None" }
             }
@@ -92,11 +97,18 @@ function Get-HtmlAssignmentInfo {
                 default   { $filterType }
             }
         }
+        else {
+            $filterName = 'None'
+            $filterTypeLabel = 'None'
+        }
+
+        # Keep filter entries positionally aligned with the assignment targets.
+        $filterNames += $filterName
+        $filterTypes += $filterTypeLabel
+        $filterDisplays += if ($filterId) { "$filterName [$filterTypeLabel]" } else { 'None' }
 
         $types += $type
         $targets += $target
-        $filterNames += $filterName
-        $filterTypes += $filterTypeLabel
     }
 
     # Determine the primary type (prioritize All Users/Devices over Group)
@@ -116,17 +128,12 @@ function Get-HtmlAssignmentInfo {
         "None"
     }
 
-    $filterDisplay = ($filterNames | Where-Object { $_ } | ForEach-Object -Begin { $i = 0 } -Process {
-        $lbl = $filterTypes[$i]; $i++
-        "$_ [$lbl]"
-    }) -join "; "
-
     return @{
         Type       = $primaryType
         Target     = ($targets -join "; ")
-        FilterName = ($filterNames -join "; ").TrimEnd(';', ' ')
-        FilterType = ($filterTypes -join "; ").TrimEnd(';', ' ')
-        Filter     = $filterDisplay
+        FilterName = $filterNames -join "; "
+        FilterType = $filterTypes -join "; "
+        Filter     = $filterDisplays -join "; "
     }
 }
 
@@ -134,10 +141,32 @@ function Get-HtmlAssignmentInfo {
 # Get-IntentTemplateFamilyLookup, Add-IntentTemplateFamilyInfo) comes from the
 # module scope, since this file is dot-sourced inside the module.
 
+function ConvertTo-IntuneCsvSafeValue {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Value
+    )
+
+    $text = if ($null -eq $Value) { '' } else { [string]$Value }
+    # Quoting alone does not stop spreadsheet formula injection. Prefix tenant-
+    # controlled values that spreadsheet applications can interpret as formulas.
+    if ($text -match '^[=+\-@\t\r]') { return "'$text" }
+    return $text
+}
+
 function Export-HTMLReport {
     param (
         [Parameter(Mandatory = $true)]
-        [string]$FilePath
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$CSVReportPath,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipCSVReport
     )
 
     # HTML template with placeholders for $tabHeaders, $tabContent, summary stats, and chart
@@ -585,10 +614,10 @@ function Export-HTMLReport {
     # Initialize collections
     $policies = @{
         DeviceConfigs             = @()
+        ImportedAdministrativeTemplates = @()
         SettingsCatalog           = @()
         CompliancePolicies        = @()
         AppProtectionPolicies     = @()
-        AppConfigurationPolicies  = @()
         PlatformScripts           = @()
         HealthScripts             = @()
         RequiredApps              = @()
@@ -618,6 +647,24 @@ function Export-HTMLReport {
             Type           = "Device Configuration"
             Platform       = Get-PolicyPlatform -Policy $config
             ScopeTags      = Get-ScopeTagNames -ScopeTagIds $config.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
+            AssignmentType = $assignmentInfo.Type
+            AssignedTo     = $assignmentInfo.Target
+            Filter         = $assignmentInfo.Filter
+        }
+    }
+
+    Write-Host "Fetching Imported Administrative Templates..." -ForegroundColor Yellow
+    $importedTemplates = Get-IntuneEntities -EntityType "groupPolicyConfigurations" |
+        Where-Object { Test-ImportedAdministrativeTemplate -Policy $_ }
+    foreach ($policy in $importedTemplates) {
+        $assignments = Get-IntuneAssignments -EntityType "groupPolicyConfigurations" -EntityId $policy.id
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
+        $policies.ImportedAdministrativeTemplates += @{
+            Name           = $policy.displayName
+            ID             = $policy.id
+            Type           = "Imported Administrative Template"
+            Platform       = "Windows"
+            ScopeTags      = Get-ScopeTagNames -ScopeTagIds $policy.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
             AssignmentType = $assignmentInfo.Type
             AssignedTo     = $assignmentInfo.Target
             Filter         = $assignmentInfo.Filter
@@ -674,7 +721,7 @@ function Export-HTMLReport {
             try {
                 $assignmentResponse = Invoke-MgGraphRequest -Uri $assignmentsUri -Method Get
                 # Pass the raw .value to Get-HtmlAssignmentInfo as it expects an array of assignment objects
-                $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignmentResponse.value 
+                $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignmentResponse.value
 
                 $policies.AppProtectionPolicies += @{
                     Name           = $policy.displayName
@@ -732,15 +779,15 @@ function Export-HTMLReport {
     # Get Autopilot Deployment Profiles
     Write-Host "Fetching Autopilot Deployment Profiles..." -ForegroundColor Yellow
     $autoProfiles = Get-IntuneEntities -EntityType "windowsAutopilotDeploymentProfiles"
-    foreach ($profile in $autoProfiles) {
-        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $profile.id
+    foreach ($autoProfile in $autoProfiles) {
+        $assignments = Get-IntuneAssignments -EntityType "windowsAutopilotDeploymentProfiles" -EntityId $autoProfile.id
         $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $assignments
         $policies.DeploymentProfiles += @{
-            Name           = $profile.displayName
-            ID             = $profile.id
+            Name           = $autoProfile.displayName
+            ID             = $autoProfile.id
             Type           = "Autopilot Deployment Profile"
             Platform       = "Windows"
-            ScopeTags      = Get-ScopeTagNames -ScopeTagIds $profile.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
+            ScopeTags      = Get-ScopeTagNames -ScopeTagIds $autoProfile.roleScopeTagIds -ScopeTagLookup $script:ScopeTagLookup
             AssignmentType = $assignmentInfo.Type
             AssignedTo     = $assignmentInfo.Target
             Filter         = $assignmentInfo.Filter
@@ -868,18 +915,18 @@ function Export-HTMLReport {
                             AssignedTo     = $assignmentInfo.Target
                             Filter         = $assignmentInfo.Filter
                         }
-                    } 
+                    }
                     catch {
                         Write-Host "Error fetching assignments for $($esCategory.Name) intent $($policy.displayName): $($_.Exception.Message)" -ForegroundColor Red
                     }
-                } 
-            } 
-        } 
+                }
+            }
+        }
     }
 
     # Get Apps
     Write-Host "Fetching Applications..." -ForegroundColor Yellow
-    $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true"
+    $appUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true&`$select=id,displayName,roleScopeTagIds"
     $allApps = [System.Collections.Generic.List[object]]::new()
     try {
         $appResponse = Invoke-MgGraphRequest -Uri $appUri -Method Get
@@ -895,11 +942,6 @@ function Export-HTMLReport {
     }
 
     foreach ($app in $allApps) {
-        # Skip built-in and Microsoft apps
-        if ($app.isFeatured -or $app.isBuiltIn) {
-            continue
-        }
-
         $appId = $app.id
         $assignmentsUri = "$script:GraphEndpoint/beta/deviceAppManagement/mobileApps('$appId')/assignments"
         try {
@@ -917,7 +959,7 @@ function Export-HTMLReport {
             # We need to wrap it in an array for Get-HtmlAssignmentInfo.
             $currentAssignmentArray = @($assignment) # Ensure it's an array
             $assignmentInfo = Get-HtmlAssignmentInfo -Assignments $currentAssignmentArray
-            
+
             $appInfo = @{
                 Name           = $app.displayName
                 ID             = $app.id
@@ -979,8 +1021,9 @@ function Export-HTMLReport {
     }
 
     $categories = @(
-        @{ Key = 'all'; Name = 'All Policies & Apps' }, 
+        @{ Key = 'all'; Name = 'All Policies & Apps' },
         @{ Key = 'DeviceConfigs'; Name = 'Device Configurations' },
+        @{ Key = 'ImportedAdministrativeTemplates'; Name = 'Imported Administrative Templates' },
         @{ Key = 'SettingsCatalog'; Name = 'Settings Catalog' },
         @{ Key = 'CompliancePolicies'; Name = 'Compliance Policies' },
         @{ Key = 'AppProtectionPolicies'; Name = 'App Protection Policies' },
@@ -1005,7 +1048,7 @@ function Export-HTMLReport {
     foreach ($category in $categories | Where-Object { $_.Key -ne 'all' }) {
         if ($policies.ContainsKey($category.Key)) {
             $items = $policies[$category.Key]
-            if ($null -ne $items) { 
+            if ($null -ne $items) {
                 $summaryStats.TotalPolicies += $items.Count
                 $summaryStats.AllUsers += ($items | Where-Object { $_.AssignmentType -eq "All Users" }).Count
                 $summaryStats.AllDevices += ($items | Where-Object { $_.AssignmentType -eq "All Devices" }).Count
@@ -1014,7 +1057,7 @@ function Export-HTMLReport {
             }
         }
     }
-    
+
     # Build dynamic tab headers and tab content
     $tabHeaders = ""
     $tabContent = ""
@@ -1244,11 +1287,12 @@ function Export-HTMLReport {
     var policyTypesChart = new Chart(ctx2, {
         type: 'bar',
         data: {
-            labels: ['Device Configs', 'Settings Catalog', 'Compliance', 'App Protection', 'Autopilot Profiles', 'ESP Profiles', 'Windows 365 Provisioning', 'Windows 365 User Settings', 'Scripts', 'Antivirus', 'Disk Encryption', 'Firewall', 'EDR', 'ASR', 'Account Protection'],
+            labels: ['Device Configs', 'Imported Admin Templates', 'Settings Catalog', 'Compliance', 'App Protection', 'Autopilot Profiles', 'ESP Profiles', 'Windows 365 Provisioning', 'Windows 365 User Settings', 'Scripts', 'Antivirus', 'Disk Encryption', 'Firewall', 'EDR', 'ASR', 'Account Protection'],
             datasets: [{
                 label: 'Number of Policies',
                 data: [
                     $($policies.DeviceConfigs.Count),
+                    $($policies.ImportedAdministrativeTemplates.Count),
                     $($policies.SettingsCatalog.Count),
                     $($policies.CompliancePolicies.Count),
                     $($policies.AppProtectionPolicies.Count),
@@ -1309,5 +1353,77 @@ function Export-HTMLReport {
     # Output file
     $htmlContent | Out-File -FilePath $FilePath -Encoding UTF8
     Write-Host "HTML report exported to: $FilePath" -ForegroundColor Green
-}
 
+    if ($SkipCSVReport) { return }
+
+    # Export the same report data as a flat CSV for Log Analytics, workbooks,
+    # and other centralized processing. The aggregate "all" tab is skipped so
+    # every policy/app appears exactly once under its source category.
+    $resolvedCsvPath = $CSVReportPath
+    try {
+        if ([string]::IsNullOrWhiteSpace($CSVReportPath)) {
+            $resolvedCsvPath = [System.IO.Path]::ChangeExtension($FilePath, '.csv')
+        }
+        else {
+            # Resolve relative paths against PowerShell's current provider
+            # location. The .NET process directory does not follow Set-Location.
+            $requestedCsvPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CSVReportPath)
+            $csvFileName = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetFileName($FilePath), '.csv')
+            if (Test-Path -Path $requestedCsvPath -PathType Container) {
+                $resolvedCsvPath = Join-Path $requestedCsvPath $csvFileName
+            }
+            elseif ($requestedCsvPath -match '\.csv$') {
+                $resolvedCsvPath = $requestedCsvPath
+            }
+            else {
+                if (Test-Path -Path $requestedCsvPath -PathType Leaf) {
+                    throw "CSV report path '$requestedCsvPath' is an existing file without a .csv extension."
+                }
+                if ([System.IO.Path]::GetExtension($requestedCsvPath)) {
+                    throw "CSV report path '$requestedCsvPath' must be a .csv file or an existing/new directory without a file extension."
+                }
+                New-Item -ItemType Directory -Path $requestedCsvPath -Force -ErrorAction Stop | Out-Null
+                $resolvedCsvPath = Join-Path $requestedCsvPath $csvFileName
+            }
+        }
+
+        $csvParent = Split-Path -Path $resolvedCsvPath -Parent
+        if ($csvParent -and -not (Test-Path -Path $csvParent -PathType Container)) {
+            New-Item -ItemType Directory -Path $csvParent -Force -ErrorAction Stop | Out-Null
+        }
+        if (Test-Path -Path $resolvedCsvPath -PathType Leaf) {
+            Write-Host "Replacing existing CSV report: $resolvedCsvPath" -ForegroundColor Yellow
+        }
+
+        $csvRows = [System.Collections.Generic.List[object]]::new()
+        foreach ($category in $categories | Where-Object { $_.Key -ne 'all' }) {
+            if (-not $policies.ContainsKey($category.Key)) { continue }
+            foreach ($policy in @($policies[$category.Key])) {
+                $csvRows.Add([PSCustomObject][ordered]@{
+                        Category       = ConvertTo-IntuneCsvSafeValue $category.Name
+                        Name           = ConvertTo-IntuneCsvSafeValue $policy.Name
+                        ID             = ConvertTo-IntuneCsvSafeValue $policy.ID
+                        Type           = ConvertTo-IntuneCsvSafeValue $policy.Type
+                        Platform       = ConvertTo-IntuneCsvSafeValue $policy.Platform
+                        ScopeTags      = ConvertTo-IntuneCsvSafeValue $policy.ScopeTags
+                        AssignmentType = ConvertTo-IntuneCsvSafeValue $policy.AssignmentType
+                        AssignedTo     = ConvertTo-IntuneCsvSafeValue $policy.AssignedTo
+                        Filter         = ConvertTo-IntuneCsvSafeValue $policy.Filter
+                    })
+            }
+        }
+
+        if ($csvRows.Count -gt 0) {
+            $csvRows | Export-Csv -Path $resolvedCsvPath -NoTypeInformation -Encoding UTF8 -ErrorAction Stop
+        }
+        else {
+            # Keep a stable header even when the tenant returns no supported policies.
+            '"Category","Name","ID","Type","Platform","ScopeTags","AssignmentType","AssignedTo","Filter"' |
+                Set-Content -Path $resolvedCsvPath -Encoding UTF8 -ErrorAction Stop
+        }
+        Write-Host "CSV report exported to: $resolvedCsvPath" -ForegroundColor Green
+    }
+    catch {
+        Write-Warning "Failed to export CSV report to '$resolvedCsvPath': $($_.Exception.Message)"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ IntuneAssignmentChecker
 - 🔐 Support for certificate-based and client secret authentication
 - 🔄 Version check on connect with an update notice when a newer PSGallery release is available
 - 📊 Detailed reporting of Configuration Profiles, Compliance Policies, and Applications
+- 🧩 Imported Administrative Template coverage across assignment checks, search, CSV exports, and HTML reports
+- 👥 First-class Microsoft 365 group recognition with group type, membership mode, and mail address in group assignment checks and exports
 - 📈 Interactive HTML reports with charts and filterable tables
 
 ## 🎥 Demo
@@ -129,7 +131,7 @@ For interactive authentication, IntuneAssignmentChecker automatically requests t
 
 For certificate, client secret, managed identity, or pre-fetched token authentication, configure the listed application permissions on the app registration and grant administrator consent. App-only authentication cannot add or consent permissions automatically.
 
-`GroupMember.Read.All` provides the group and membership data used by IntuneAssignmentChecker without granting access to Microsoft 365 group content.
+`GroupMember.Read.All` provides the basic group properties and membership data used by IntuneAssignmentChecker without granting access to Microsoft 365 group conversations, files, calendars, or other group content.
 
 > **Existing app registrations**: Add `GroupMember.Read.All` and grant administrator consent before removing `Group.Read.All`. After confirming the updated module works, remove `Group.Read.All` from the configured API permissions and revoke its application consent. Updating the app registration manifest alone might not remove an existing service principal consent grant.
 
@@ -238,6 +240,12 @@ If you prefer not to set up an app registration, you can use interactive authent
 # Opens a browser sign-in prompt using delegated permissions
 Connect-IntuneAssignmentChecker
 
+# Use your own public-client application ID for delegated sign-in
+Connect-IntuneAssignmentChecker -AppId '<application-client-id>'
+
+# Optionally constrain that delegated sign-in to a specific tenant
+Connect-IntuneAssignmentChecker -AppId '<application-client-id>' -TenantId '<tenant-id>'
+
 # Or just launch the menu and pick interactive auth when prompted
 IntuneAssignmentChecker
 ```
@@ -336,14 +344,23 @@ Get-IntuneUserAssignment -UserPrincipalNames "user1@contoso.com,user2@contoso.co
 # Check assignments for a specific group
 Get-IntuneGroupAssignment -GroupNames "Marketing Team"
 
+# Microsoft 365 (Unified) groups are resolved by name or Object ID like any other group
+Get-IntuneGroupAssignment -GroupNames "Messaging Team" -ExportToCSV -ExportPath "C:\Temp\MessagingTeamAssignments.csv"
+
 # Check assignments for a specific device
 Get-IntuneDeviceAssignment -DeviceNames "Laptop123"
 
 # Show all policies with 'All Users' assignments
 Get-IntuneAllUsersAssignment -ExportToCSV
 
-# Generate HTML report
+# Generate HTML report and a companion CSV at the same base path
 New-IntuneHTMLReport -HTMLReportPath "C:\Temp\IntuneAssignmentReport.html"
+
+# Store the CSV companion in a separate central location
+New-IntuneHTMLReport -HTMLReportPath "C:\Temp\IntuneAssignmentReport.html" -CSVReportPath "C:\CentralReports\IntuneAssignments.csv"
+
+# Preserve the previous HTML-only behavior when no CSV is wanted
+New-IntuneHTMLReport -HTMLReportPath "C:\Temp\IntuneAssignmentReport.html" -NoCSVReport
 
 # Simulate what policies a user would receive if added to a group
 Test-IntuneGroupMembership -UserPrincipalNames "user@contoso.com" -SimulateTargetGroup "Marketing Team"
@@ -364,6 +381,21 @@ Search-IntunePolicy -PolicySearchTerm "BitLocker"
 Search-IntuneSetting -SearchTerm "BitLocker"
 ```
 
+`Get-IntuneGroupAssignment` CSV/Excel exports include `GroupId`, `GroupName`,
+`GroupType`, `MembershipType`, and `GroupMail` on every group and policy/app
+row. This keeps multi-group exports attributable and lets workbooks distinguish
+Microsoft 365 groups from security, mail-enabled security, and distribution
+groups without parsing display names.
+
+HTML reports include a flat CSV companion by default. The CSV uses a stable
+`Category`, `Name`, `ID`, `Type`, `Platform`, `ScopeTags`, `AssignmentType`,
+`AssignedTo`, and `Filter` schema for Azure Log Analytics, workbooks, and other
+automation. `-CSVReportPath` accepts either a `.csv` file or a directory; when a
+directory is supplied, the HTML report's base name is reused. Missing values are
+exported as empty fields, while the absence of an assignment filter is represented
+consistently as `None`. Values beginning with spreadsheet formula prefixes are
+escaped with a leading apostrophe. Use `-NoCSVReport` for HTML-only output.
+
 Available cmdlets:
 
 | Cmdlet                             | Description                                                           |
@@ -375,7 +407,7 @@ Available cmdlets:
 | `Get-IntuneAllPolicies`            | Show all policies and their assignments                               |
 | `Get-IntuneAllUsersAssignment`     | Show all 'All Users' assignments                                      |
 | `Get-IntuneAllDevicesAssignment`   | Show all 'All Devices' assignments                                    |
-| `New-IntuneHTMLReport`             | Generate interactive HTML report                                      |
+| `New-IntuneHTMLReport`             | Generate interactive HTML and flat CSV companion reports              |
 | `Get-IntuneUnassignedPolicy`       | Show policies without assignments                                     |
 | `Get-IntuneEmptyGroup`             | Check for empty groups used in assignments                            |
 | `Get-IntuneFailedAssignment`       | Show all failed policy assignments                                    |
@@ -424,6 +456,9 @@ Running `IntuneAssignmentChecker` opens a menu-driven interface with the followi
    - View all policies and apps assigned to specific groups
    - Supports checking multiple groups
    - Shows assignment types (Include/Exclude)
+   - Recognizes Microsoft 365, security, mail-enabled security, and distribution groups
+   - Shows group type, assigned/dynamic membership, and mail address in the console and CSV export
+   - Covers Intune policy and app assignments only; Exchange, Teams, SharePoint, and other Microsoft 365 service policies/content are outside this module's scope
 
 3. **Check Device(s) Assignments**
    - View all policies and apps assigned to specific devices

--- a/Tests/Unit/CategoryScan.Tests.ps1
+++ b/Tests/Unit/CategoryScan.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     $modulePrivate = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker/Private'
 
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
@@ -285,7 +286,7 @@ Describe 'Invoke-IntuneCategoryScan' {
     }
 
     Context 'mobile apps' {
-        It 'skips isFeatured/isBuiltIn apps and passes RawAssignments to the callback' {
+        It 'keeps every assigned app regardless of featured metadata and passes RawAssignments to the callback' {
             Mock Invoke-MgGraphRequest {
                 if ($Uri.Contains('mobileApps?$filter=isAssigned')) {
                     return @{ value = @(
@@ -311,11 +312,13 @@ Describe 'Invoke-IntuneCategoryScan' {
                 $script:appContexts.Add($ctx)
             }
 
-            $script:appContexts.Count | Should -Be 1
+            $script:appContexts.Count | Should -Be 3
             $script:appContexts[0].Entity.id | Should -Be 'app-1'
             @($script:appContexts[0].RawAssignments).Count | Should -Be 1
             $script:appContexts[0].RawAssignments[0].intent | Should -Be 'required'
             $script:appContexts[0].Assignments[0].Reason | Should -BeExactly 'All Users'
+            @($script:appContexts.Entity.id) | Should -Contain 'app-2'
+            @($script:appContexts.Entity.id) | Should -Contain 'app-3'
         }
     }
 
@@ -468,9 +471,40 @@ Describe 'Add-CategoryExportData' {
         $script:exportData[1].AssignmentReason | Should -BeExactly ''
     }
 
+    It 'adds caller-provided attribution columns uniformly to category rows' {
+        $categories = @(
+            New-TestCategory @{ Id = 'DeviceConfigurations'; BucketKeys = @('DeviceConfigs'); ExportCategory = 'Device Configuration' }
+        )
+        $buckets = @{
+            DeviceConfigs = @(
+                [PSCustomObject]@{ id = 'cfg-1'; displayName = 'Config 1' }
+                [PSCustomObject]@{ id = 'cfg-2'; displayName = 'Config 2' }
+            )
+        }
+        $attribution = [ordered]@{ GroupId = 'group-1'; GroupType = 'Microsoft 365' }
+
+        Add-CategoryExportData -ExportData $script:exportData -Categories $categories -Buckets $buckets -AdditionalProperties $attribution
+
+        $script:exportData | Should -HaveCount 2
+        @($script:exportData.GroupId | Select-Object -Unique) | Should -Be @('group-1')
+        @($script:exportData.GroupType | Select-Object -Unique) | Should -Be @('Microsoft 365')
+    }
+
+    It 'rejects additional properties that collide with reserved export columns' {
+        $item = [PSCustomObject]@{ id = 'cfg-1'; displayName = 'Config 1' }
+
+        {
+            Add-ExportData -ExportData $script:exportData -Category 'Device Configuration' -Items @($item) `
+                -AdditionalProperties ([ordered]@{ Category = 'Overwritten' })
+        } | Should -Throw '*conflicts with a reserved export column*'
+
+        $script:exportData | Should -HaveCount 0
+    }
+
     It 'covers every AllPolicies export label in registry order matching the pre-migration sequence' {
         $expectedLabels = @(
             'Device Configuration'
+            'Imported Administrative Template'
             'Settings Catalog Policy'
             'Compliance Policy'
             'App Protection Policy'
@@ -504,44 +538,58 @@ Describe 'Add-CategoryExportData' {
 }
 
 Describe 'Get-IntuneCategoryDefinition' {
-    It 'returns 16 fetchable categories plus Autopilot/ESP bucket placeholders for UserContext' {
+    It 'returns 17 fetchable categories plus Autopilot/ESP bucket placeholders for UserContext' {
         $categories = Get-IntuneCategoryDefinition -Audience UserContext
-        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 16
+        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 17
         @($categories | Where-Object { $_.BucketOnly }).Id | Should -Be @('DeploymentProfiles', 'ESPProfiles')
     }
 
-    It 'returns 16 fetchable categories plus Autopilot/ESP bucket placeholders for DeviceContext' {
+    It 'returns 17 fetchable categories plus Autopilot/ESP bucket placeholders for DeviceContext' {
         $categories = Get-IntuneCategoryDefinition -Audience DeviceContext
-        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 16
+        @($categories | Where-Object { -not $_.BucketOnly }).Count | Should -Be 17
         @($categories | Where-Object { $_.BucketOnly }).Id | Should -Be @('DeploymentProfiles', 'ESPProfiles')
     }
 
-    It 'returns 18 categories including Autopilot and ESP for GroupContext' {
+    It 'returns 19 categories including Imported Administrative Templates, Autopilot and ESP for GroupContext' {
         $categories = Get-IntuneCategoryDefinition -Audience GroupContext
-        @($categories).Count | Should -Be 18
+        @($categories).Count | Should -Be 19
         @($categories | Where-Object { $_.BucketOnly }).Count | Should -Be 0
         $categories.Id | Should -Contain 'DeploymentProfiles'
         $categories.Id | Should -Contain 'ESPProfiles'
     }
 
-    It 'returns 17 categories without Applications for AllPolicies' {
+    It 'returns 18 categories without Applications for AllPolicies' {
         $categories = Get-IntuneCategoryDefinition -Audience AllPolicies
-        @($categories).Count | Should -Be 17
+        @($categories).Count | Should -Be 18
         $categories.Id | Should -Not -Contain 'Applications'
     }
 
-    It 'returns 18 categories with a shared SearchResults bucket for Search' {
+    It 'returns 19 categories with a shared SearchResults bucket for Search' {
         $categories = Get-IntuneCategoryDefinition -Audience Search
-        @($categories).Count | Should -Be 18
+        @($categories).Count | Should -Be 19
         foreach ($category in $categories) {
             $category.BucketKeys | Should -Be @('SearchResults')
         }
     }
 
-    It 'returns 13 categories for Compare' {
+    It 'returns 14 categories for Compare' {
         $categories = Get-IntuneCategoryDefinition -Audience Compare
-        @($categories).Count | Should -Be 13
+        @($categories).Count | Should -Be 14
         $categories.Id | Should -Contain 'ShellScripts'
+    }
+
+    It 'includes custom and mixed imported templates but excludes built-in-only configurations' {
+        $category = @(Get-IntuneCategoryDefinition -Audience GroupContext | Where-Object { $_.Id -eq 'ImportedAdministrativeTemplates' })[0]
+        $policies = @(
+            [PSCustomObject]@{ id = 'custom'; policyConfigurationIngestionType = 'custom' }
+            [PSCustomObject]@{ id = 'mixed'; policyConfigurationIngestionType = 'mixed' }
+            [PSCustomObject]@{ id = 'built-in'; policyConfigurationIngestionType = 'builtIn' }
+            [PSCustomObject]@{ id = 'unknown'; policyConfigurationIngestionType = 'unknown' }
+        )
+
+        @($policies | Where-Object $category.EntityFilter).id | Should -Be @('custom', 'mixed')
+        $category.EntityType | Should -BeExactly 'groupPolicyConfigurations'
+        $category.ExportCategory | Should -BeExactly 'Imported Administrative Template'
     }
 
     Context 'audience-specific SettingsCatalog filters' {

--- a/Tests/Unit/CompareGroupAssignment.Tests.ps1
+++ b/Tests/Unit/CompareGroupAssignment.Tests.ps1
@@ -5,6 +5,8 @@ BeforeAll {
     $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
     $modulePrivate = Join-Path $moduleRoot 'Private'
 
+    . (Join-Path $modulePrivate 'ConvertTo-IntuneGroupInfo.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
@@ -119,13 +121,17 @@ Describe 'Compare-IntuneGroupAssignment' {
                 }
                 return @{ value = @() }
             }
-            if ($Uri -like "*/v1.0/groups/$($script:groupA)") { return @{ id = $script:groupA; displayName = 'Group A' } }
-            if ($Uri -like "*/v1.0/groups/$($script:groupB)") { return @{ id = $script:groupB; displayName = 'Group B' } }
+            if ($Uri -like "*/v1.0/groups/$($script:groupA)*") {
+                return @{ id = $script:groupA; displayName = 'Group A'; groupTypes = @(); mailEnabled = $false; securityEnabled = $true }
+            }
+            if ($Uri -like "*/v1.0/groups/$($script:groupB)*") {
+                return @{ id = $script:groupB; displayName = 'Group B'; groupTypes = @('Unified'); mailEnabled = $true; securityEnabled = $false; mail = 'groupb@contoso.com' }
+            }
             if ($Uri -like '*mobileApps*isAssigned eq true*') {
                 return @{ value = @(
                         [PSCustomObject]@{ id = 'app-shared'; displayName = 'Shared App'; isFeatured = $false; isBuiltIn = $false }
                         [PSCustomObject]@{ id = 'app-excluded'; displayName = 'Excluded App'; isFeatured = $false; isBuiltIn = $false }
-                        [PSCustomObject]@{ id = 'app-builtin'; displayName = 'Builtin App'; isFeatured = $false; isBuiltIn = $true }
+                        [PSCustomObject]@{ id = 'app-featured'; displayName = 'Featured App'; isFeatured = $true }
                     )
                 }
             }
@@ -140,6 +146,12 @@ Describe 'Compare-IntuneGroupAssignment' {
                 # Exclusion-only app assignment (issue #126 shape): stays visible, tagged [EXCLUDED]
                 return @{ value = @(
                         @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'; groupId = $script:groupA } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-featured')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'available'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupA } }
                     )
                 }
             }
@@ -171,6 +183,21 @@ Describe 'Compare-IntuneGroupAssignment' {
             Compare-IntuneGroupAssignment -CompareGroupNames "O'Brien Team, $($script:groupA)" -ExportToCSV -ExportPath $script:csvPath
 
             Should -Invoke Invoke-MgGraphRequest -ParameterFilter { $Uri -like "*displayName eq 'O''Brien Team'*" }
+        }
+
+        It 'skips a GUID lookup response that omits the group Object ID' {
+            Mock Invoke-MgGraphRequest {
+                @{ displayName = 'Incomplete Group'; groupTypes = @('Unified'); mailEnabled = $true }
+            } -ParameterFilter { $Uri -like "*/v1.0/groups/$($script:groupA)*" }
+
+            Compare-IntuneGroupAssignment -CompareGroupNames "$($script:groupA), $($script:groupB)" -ExportToCSV -ExportPath $script:csvPath
+
+            Should -Invoke Write-Host -Exactly 1 -ParameterFilter {
+                $Object -eq "The group lookup for '$($script:groupA)' returned an invalid response without an Object ID."
+            }
+            Should -Invoke Get-IntuneAssignments -Exactly 0 -ParameterFilter {
+                $null -eq $GroupIds -or $GroupIds -contains $null
+            }
         }
     }
 
@@ -211,12 +238,14 @@ Describe 'Compare-IntuneGroupAssignment' {
             $row.'Group B' | Should -BeExactly ''
         }
 
-        It 'buckets apps by assignment intent and skips built-in apps' {
+        It 'buckets every assigned app by intent, including featured apps' {
             $row = $script:rows | Where-Object { $_.PolicyName -eq 'Shared App' }
             $row.Category | Should -BeExactly 'Required Apps'
             $row.'Group A' | Should -BeExactly 'Included'
             $row.'Group B' | Should -BeExactly 'Included'
-            @($script:rows | Where-Object { $_.PolicyName -like 'Builtin App*' }).Count | Should -Be 0
+            $featuredRow = $script:rows | Where-Object { $_.PolicyName -eq 'Featured App' }
+            $featuredRow.Category | Should -BeExactly 'Available Apps'
+            $featuredRow.'Group A' | Should -BeExactly 'Included'
         }
 
         It 'labels platform and shell scripts with their type marker' {

--- a/Tests/Unit/Connection.Tests.ps1
+++ b/Tests/Unit/Connection.Tests.ps1
@@ -1,0 +1,116 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $modulePublic = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker/Public'
+
+    function Connect-MgGraph {
+        [CmdletBinding()]
+        param(
+            [string[]]$Scopes,
+            [string]$TenantId,
+            [string]$ClientId,
+            [string]$CertificateThumbprint,
+            [PSCredential]$ClientSecretCredential,
+            [SecureString]$AccessToken,
+            [string]$Environment,
+            [switch]$NoWelcome
+        )
+    }
+
+    function Get-MgContext { }
+    function Invoke-MgGraphRequest { }
+    function Set-Environment { }
+    function Get-ScopeTagLookup { }
+    function Get-AssignmentFilterLookup { }
+
+    . (Join-Path $modulePublic 'Connect-IntuneAssignmentChecker.ps1')
+}
+
+Describe 'Connect-IntuneAssignmentChecker interactive authentication' {
+    BeforeEach {
+        $script:RequiredPermissions = @(
+            @{ Permission = 'User.Read.All'; Reason = 'Test permission' }
+            @{ Permission = 'GroupMember.Read.All'; Reason = 'Second test permission' }
+        )
+        $script:GraphEnvironment = 'Global'
+        $script:GraphEndpoint = 'https://graph.microsoft.com'
+        $script:contextCallCount = 0
+
+        Mock Write-Host
+        Mock Find-Module { throw 'Offline during unit test' }
+        Mock Get-Module {
+            [PSCustomObject]@{ Version = [version]'4.3.1' }
+        } -ParameterFilter { $Name -eq 'IntuneAssignmentChecker' }
+        Mock Read-Host { 'y' }
+        Mock Set-Environment {
+            $script:GraphEnvironment = 'Global'
+            'https://graph.microsoft.com'
+        }
+        Mock Get-MgContext {
+            $script:contextCallCount++
+            if ($script:contextCallCount -eq 1) {
+                return $null
+            }
+
+            [PSCustomObject]@{
+                Environment = 'Global'
+                Scopes      = @('User.Read.All', 'GroupMember.Read.All')
+                TenantId    = 'tenant-from-context'
+                Account     = 'user@contoso.com'
+            }
+        }
+        Mock Connect-MgGraph
+        Mock Invoke-MgGraphRequest {
+            @{ value = @([PSCustomObject]@{ displayName = 'Contoso' }) }
+        }
+        Mock Get-ScopeTagLookup { @{} }
+        Mock Get-AssignmentFilterLookup { @{} }
+    }
+
+    It 'uses an AppId supplied by itself for delegated interactive sign-in' {
+        Connect-IntuneAssignmentChecker -AppId 'custom-client-id'
+
+        Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+            $ClientId -eq 'custom-client-id' -and
+            [string]::IsNullOrEmpty($TenantId) -and
+            $Scopes.Count -eq 1 -and
+            $Scopes[0] -eq 'User.Read.All, GroupMember.Read.All' -and
+            $Environment -eq 'Global' -and
+            $NoWelcome
+        }
+    }
+
+    It 'also forwards TenantId when AppId-only delegated sign-in is tenant-scoped' {
+        Connect-IntuneAssignmentChecker -AppId 'custom-client-id' -TenantId 'custom-tenant-id'
+
+        Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+            $ClientId -eq 'custom-client-id' -and
+            $TenantId -eq 'custom-tenant-id' -and
+            $Scopes.Count -eq 1 -and
+            $Scopes[0] -eq 'User.Read.All, GroupMember.Read.All'
+        }
+    }
+
+    It 'keeps the default Graph PowerShell interactive app when no AppId is supplied' {
+        Connect-IntuneAssignmentChecker
+
+        Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+            [string]::IsNullOrEmpty($ClientId) -and
+            [string]::IsNullOrEmpty($TenantId) -and
+            $Scopes.Count -eq 1 -and
+            $Scopes[0] -eq 'User.Read.All, GroupMember.Read.All'
+        }
+    }
+
+    It 'preserves certificate-based app-only authentication' {
+        Connect-IntuneAssignmentChecker -AppId 'certificate-client-id' -TenantId 'certificate-tenant-id' -CertificateThumbprint 'ABC123'
+
+        Should -Invoke Connect-MgGraph -Exactly 1 -ParameterFilter {
+            $ClientId -eq 'certificate-client-id' -and
+            $TenantId -eq 'certificate-tenant-id' -and
+            $CertificateThumbprint -eq 'ABC123' -and
+            $null -eq $Scopes
+        }
+    }
+}

--- a/Tests/Unit/DeviceAssignment.Tests.ps1
+++ b/Tests/Unit/DeviceAssignment.Tests.ps1
@@ -14,6 +14,7 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Test-PlatformCompatibility.ps1')
     . (Join-Path $modulePrivate 'Test-AppPlatformCompatibility.ps1')
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $modulePrivate 'Add-ExportData.ps1')
@@ -88,12 +89,12 @@ Describe 'Get-IntuneDeviceAssignment' {
         $script:capturedExport[0].AssignmentReason | Should -BeExactly 'N/A'
     }
 
-    It 'renders the legacy display sections in order with device-specific empty messages' {
+    It 'renders all display sections in order with device-specific empty messages' {
         Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
 
         $sectionTitles = @($script:consoleLines | Where-Object { $_ -match '^------- (.+) -------$' } | ForEach-Object { $Matches[1] })
         $sectionTitles | Should -Be @(
-            'Device Configurations', 'Settings Catalog Policies', 'Compliance Policies', 'App Protection Policies',
+            'Device Configurations', 'Imported Administrative Templates', 'Settings Catalog Policies', 'Compliance Policies', 'App Protection Policies',
             'App Configuration Policies', 'Platform Scripts', 'Proactive Remediation Scripts',
             'Autopilot Deployment Profiles', 'Enrollment Status Page Profiles',
             'Required Apps', 'Available Apps', 'Uninstall Apps',
@@ -132,6 +133,34 @@ Describe 'Get-IntuneDeviceAssignment' {
         $rows[1].AssignmentReason | Should -BeExactly 'Excluded'
         # The iOS-only policy must be dropped for a Windows device
         @($rows | Where-Object { $_.Item -like '*cfg-ios*' }).Count | Should -Be 0
+    }
+
+    It 'gives an imported template group exclusion precedence over an earlier inclusion' {
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'groupPolicyConfigurations') {
+                return @([PSCustomObject]@{
+                        id = 'iat-conflict'
+                        displayName = 'Imported Conflict Policy'
+                        policyConfigurationIngestionType = 'custom'
+                    })
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityId -eq 'iat-conflict') {
+                return @(
+                    [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = $script:memberGroupId; FilterId = $null; FilterType = $null }
+                    [PSCustomObject]@{ Reason = 'Group Exclusion'; GroupId = $script:memberGroupId; FilterId = $null; FilterType = $null }
+                )
+            }
+            @()
+        }
+
+        Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
+
+        $row = @($script:capturedExport | Where-Object { $_.Category -eq 'Imported Administrative Template' })
+        $row | Should -HaveCount 1
+        $row[0].AssignmentReason | Should -BeExactly 'Excluded'
     }
 
     Context 'applications' {
@@ -261,18 +290,18 @@ Describe 'Get-IntuneDeviceAssignment' {
     }
 
     Context 'Windows-conditional categories' {
-        It 'fetches Autopilot, ESP and Windows 365 categories for a Windows device' {
+        It 'fetches Imported Administrative Templates, Autopilot, ESP and Windows 365 categories for a Windows device' {
             Get-IntuneDeviceAssignment -DeviceNames 'PC-1'
 
-            foreach ($windowsEntityType in @('windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
+            foreach ($windowsEntityType in @('groupPolicyConfigurations', 'windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
                 Should -Invoke Get-IntuneEntities -Exactly -Times 1 -ParameterFilter { $EntityType -eq $windowsEntityType }
             }
         }
 
-        It 'never fetches Autopilot, ESP or Windows 365 categories for a macOS device' {
+        It 'never fetches Imported Administrative Templates, Autopilot, ESP or Windows 365 categories for a macOS device' {
             Get-IntuneDeviceAssignment -DeviceNames 'MAC-1'
 
-            foreach ($windowsEntityType in @('windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
+            foreach ($windowsEntityType in @('groupPolicyConfigurations', 'windowsAutopilotDeploymentProfiles', 'deviceEnrollmentConfigurations', 'virtualEndpoint/provisioningPolicies', 'virtualEndpoint/userSettings')) {
                 Should -Invoke Get-IntuneEntities -Times 0 -ParameterFilter { $EntityType -eq $windowsEntityType }
             }
         }

--- a/Tests/Unit/GroupAssignment.Tests.ps1
+++ b/Tests/Unit/GroupAssignment.Tests.ps1
@@ -8,8 +8,10 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Get-Separator.ps1')
     . (Join-Path $modulePrivate 'Get-PolicyPlatform.ps1')
     . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'ConvertTo-IntuneGroupInfo.ps1')
     . (Join-Path $modulePrivate 'Show-CategoryResultTable.ps1')
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $modulePrivate 'Get-GroupAssignmentReasons.ps1')
@@ -140,20 +142,35 @@ Describe 'Get-IntuneGroupAssignment' {
     BeforeEach {
         $script:groupGuid = '11111111-1111-1111-1111-111111111111'
         $script:capturedExport = $null
+        $script:ScopeTagLookup = @{}
         Mock Write-Host {}
         Mock Get-IntuneEntities { @() }
         Mock Get-IntuneAssignments { @() }
         Mock Add-IntentTemplateFamilyInfo {}
         Mock Get-TransitiveGroupMembership { @() }
-        Mock Get-GroupInfo { @{ Id = $GroupId; DisplayName = 'Sales Team'; Success = $true } }
+        Mock Get-GroupInfo {
+            [PSCustomObject]@{
+                Id = $GroupId; DisplayName = 'Sales Team'; GroupType = 'Security'; MembershipType = 'Assigned'
+                IsMicrosoft365 = $false; Mail = $null; Success = $true
+            }
+        }
         Mock Export-ResultsIfRequested { $script:capturedExport = @($ExportData) }
         Mock Invoke-MgGraphRequest {
             if ($Uri -like '*mobileApps*isAssigned eq true*') {
-                return @{ value = @(
-                        [PSCustomObject]@{ id = 'app-inc'; displayName = 'Included App'; isFeatured = $false; isBuiltIn = $false }
+                return @{
+                    value = @(
+                        [PSCustomObject]@{ id = 'app-inc'; displayName = 'Included App'; isFeatured = $false; isBuiltIn = $false; roleScopeTagIds = @('0', 'tag-finance') }
                         [PSCustomObject]@{ id = 'app-exc'; displayName = 'Excluded Only App'; isFeatured = $false; isBuiltIn = $false }
                         [PSCustomObject]@{ id = 'app-both'; displayName = 'Included And Excluded App'; isFeatured = $false; isBuiltIn = $false }
                         [PSCustomObject]@{ id = 'app-exc-uninstall'; displayName = 'Excluded Uninstall App'; isFeatured = $false; isBuiltIn = $false }
+                    )
+                    '@odata.nextLink' = 'https://graph.test/next-mobile-app-page'
+                }
+            }
+            if ($Uri -eq 'https://graph.test/next-mobile-app-page') {
+                return @{ value = @(
+                        [PSCustomObject]@{ id = 'app-featured-required'; displayName = 'Featured Required App'; isFeatured = $true; roleScopeTagIds = @('0') }
+                        [PSCustomObject]@{ id = 'app-featured-available'; displayName = 'Featured Available App'; isFeatured = $true; roleScopeTagIds = @('0') }
                     )
                 }
             }
@@ -183,6 +200,18 @@ Describe 'Get-IntuneGroupAssignment' {
                     )
                 }
             }
+            if ($Uri -like "*mobileApps('app-featured-required')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'required'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupGuid; deviceAndAppManagementAssignmentFilterId = 'shared-filter'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                    )
+                }
+            }
+            if ($Uri -like "*mobileApps('app-featured-available')/assignments*") {
+                return @{ value = @(
+                        @{ intent = 'available'; target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $script:groupGuid; deviceAndAppManagementAssignmentFilterId = 'shared-filter'; deviceAndAppManagementAssignmentFilterType = 'include' } }
+                    )
+                }
+            }
             return @{ value = @() }
         }
     }
@@ -193,20 +222,149 @@ Describe 'Get-IntuneGroupAssignment' {
         $script:capturedExport[0].Category | Should -BeExactly 'Group'
         $script:capturedExport[0].Item | Should -BeExactly "Sales Team (ID: $($script:groupGuid))"
         $script:capturedExport[0].AssignmentReason | Should -BeExactly 'N/A'
+        $script:capturedExport[0].GroupId | Should -BeExactly $script:groupGuid
+        $script:capturedExport[0].GroupName | Should -BeExactly 'Sales Team'
+        $script:capturedExport[0].GroupType | Should -BeExactly 'Security'
+        $script:capturedExport[0].MembershipType | Should -BeExactly 'Assigned'
+    }
+
+    It 'recognizes a Microsoft 365 group by object ID and exports its metadata' {
+        Mock Get-GroupInfo {
+            [PSCustomObject]@{
+                Id = $GroupId; DisplayName = 'Messaging Team'; GroupType = 'Microsoft 365'; MembershipType = 'Dynamic'
+                IsMicrosoft365 = $true; Mail = 'messaging@contoso.com'; Success = $true
+            }
+        }
+
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $groupRow = $script:capturedExport[0]
+        $groupRow.Item | Should -BeExactly "Messaging Team (ID: $($script:groupGuid))"
+        $groupRow.GroupType | Should -BeExactly 'Microsoft 365'
+        $groupRow.MembershipType | Should -BeExactly 'Dynamic'
+        $groupRow.GroupMail | Should -BeExactly 'messaging@contoso.com'
+        Should -Invoke Write-Host -ParameterFilter {
+            $Object -eq 'Group details: Type: Microsoft 365; Membership: Dynamic; Mail: messaging@contoso.com'
+        }
+
+        $csvPath = Join-Path $TestDrive 'm365-group.csv'
+        $script:capturedExport | Export-Csv -Path $csvPath -NoTypeInformation
+        $csvGroupRow = Import-Csv -Path $csvPath | Where-Object Category -eq 'Group'
+        $csvGroupRow.GroupType | Should -BeExactly 'Microsoft 365'
+        $csvGroupRow.GroupMail | Should -BeExactly 'messaging@contoso.com'
+        $csvPolicyRow = Import-Csv -Path $csvPath | Where-Object Category -ne 'Group' | Select-Object -First 1
+        $csvPolicyRow.GroupId | Should -BeExactly $script:groupGuid
+        $csvPolicyRow.GroupName | Should -BeExactly 'Messaging Team'
+        $csvPolicyRow.GroupType | Should -BeExactly 'Microsoft 365'
+        $csvPolicyRow.MembershipType | Should -BeExactly 'Dynamic'
+        $csvPolicyRow.GroupMail | Should -BeExactly 'messaging@contoso.com'
+    }
+
+    It 'recognizes a Microsoft 365 group by display name without filtering it out' {
+        Mock Invoke-MgGraphRequest {
+            @{
+                value = @([PSCustomObject]@{
+                        id = 'm365-by-name'; displayName = 'Messaging Team'; groupTypes = @('Unified')
+                        mailEnabled = $true; securityEnabled = $false; mail = 'messaging@contoso.com'
+                    })
+            }
+        } -ParameterFilter { $Uri -like '*/v1.0/groups?*displayName eq*' }
+
+        Get-IntuneGroupAssignment -GroupNames 'Messaging Team' -IncludeNestedGroups
+
+        $groupRow = $script:capturedExport[0]
+        $groupRow.Item | Should -BeExactly 'Messaging Team (ID: m365-by-name)'
+        $groupRow.GroupType | Should -BeExactly 'Microsoft 365'
+        $groupRow.GroupMail | Should -BeExactly 'messaging@contoso.com'
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+            $Uri -like '*/v1.0/groups?*' -and
+            $Uri -match '\$select=id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+        }
+    }
+
+    It 'attributes every policy row in a multi-group export to its source group' {
+        $secondGroupGuid = '22222222-2222-2222-2222-222222222222'
+        Mock Get-GroupInfo {
+            if ($GroupId -eq $script:groupGuid) {
+                return [PSCustomObject]@{
+                    Id = $GroupId; DisplayName = 'Messaging Team'; GroupType = 'Microsoft 365'; MembershipType = 'Assigned'
+                    IsMicrosoft365 = $true; Mail = 'messaging@contoso.com'; Success = $true
+                }
+            }
+            [PSCustomObject]@{
+                Id = $GroupId; DisplayName = 'Security Team'; GroupType = 'Security'; MembershipType = 'Dynamic'
+                IsMicrosoft365 = $false; Mail = $null; Success = $true
+            }
+        }
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceConfigurations') {
+                return @([PSCustomObject]@{ id = 'cfg-shared'; displayName = 'Shared Configuration' })
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityId -eq 'cfg-shared') {
+                $targetGroupId = @($GroupIds)[0]
+                return @([PSCustomObject]@{
+                        Reason = 'Direct Assignment'; GroupId = $targetGroupId; FilterId = $null; FilterType = $null
+                    })
+            }
+            @()
+        }
+
+        Get-IntuneGroupAssignment -GroupNames "$($script:groupGuid),$secondGroupGuid" -IncludeNestedGroups
+
+        $policyRows = @($script:capturedExport | Where-Object { $_.Item -eq 'Shared Configuration (ID: cfg-shared)' })
+        $policyRows | Should -HaveCount 2
+        ($policyRows | Where-Object GroupId -eq $script:groupGuid).GroupName | Should -BeExactly 'Messaging Team'
+        ($policyRows | Where-Object GroupId -eq $script:groupGuid).GroupType | Should -BeExactly 'Microsoft 365'
+        ($policyRows | Where-Object GroupId -eq $secondGroupGuid).GroupName | Should -BeExactly 'Security Team'
+        ($policyRows | Where-Object GroupId -eq $secondGroupGuid).GroupType | Should -BeExactly 'Security'
+        @($script:capturedExport | Where-Object {
+                -not $_.PSObject.Properties['GroupId'] -or -not $_.PSObject.Properties['GroupName'] -or
+                -not $_.PSObject.Properties['GroupType'] -or -not $_.PSObject.Properties['MembershipType'] -or
+                -not $_.PSObject.Properties['GroupMail']
+            }) | Should -HaveCount 0
     }
 
     It 'keeps exclusion-only apps under the excluding assignment intent (issue #126)' {
         Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
 
         $availableRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Available Apps' })
-        $availableRows.Count | Should -Be 1
-        $availableRows[0].Item | Should -BeExactly 'Excluded Only App (ID: app-exc)'
-        $availableRows[0].AssignmentReason | Should -BeExactly 'Group Exclusion'
+        $excludedAvailableRow = $availableRows | Where-Object { $_.Item -eq 'Excluded Only App (ID: app-exc)' }
+        @($excludedAvailableRow).Count | Should -Be 1
+        $excludedAvailableRow.AssignmentReason | Should -BeExactly 'Group Exclusion'
 
         $uninstallRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Uninstall Apps' })
         $uninstallRows.Count | Should -Be 1
         $uninstallRows[0].Item | Should -BeExactly 'Excluded Uninstall App (ID: app-exc-uninstall)'
         $uninstallRows[0].AssignmentReason | Should -BeExactly 'Group Exclusion'
+    }
+
+    It 'requests and exports every application scope tag (issue #131)' {
+        $script:ScopeTagLookup = @{ '0' = 'Default'; 'tag-finance' = 'Finance' }
+
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $appRow = $script:capturedExport | Where-Object { $_.Item -eq 'Included App (ID: app-inc)' }
+        $appRow.ScopeTags | Should -BeExactly 'Default, Finance'
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+            $Uri -like '*deviceAppManagement/mobileApps?*' -and
+            $Uri -match '\$select=[^&]*roleScopeTagIds'
+        }
+    }
+
+    It 'returns paged featured required and available apps assigned through the same group and filter (issue #134)' {
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $requiredRow = $script:capturedExport | Where-Object { $_.Item -eq 'Featured Required App (ID: app-featured-required)' }
+        $availableRow = $script:capturedExport | Where-Object { $_.Item -eq 'Featured Available App (ID: app-featured-available)' }
+
+        $requiredRow.Category | Should -BeExactly 'Required Apps'
+        $availableRow.Category | Should -BeExactly 'Available Apps'
+        $requiredRow.AssignmentReason | Should -BeExactly 'Direct Assignment (Filter: Unknown Filter (shared-filter) [Include])'
+        $availableRow.AssignmentReason | Should -BeExactly 'Direct Assignment (Filter: Unknown Filter (shared-filter) [Include])'
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter { $Uri -eq 'https://graph.test/next-mobile-app-page' }
     }
 
     It 'prefers the inclusion intent when the group is both included and excluded' {
@@ -237,6 +395,34 @@ Describe 'Get-IntuneGroupAssignment' {
         $configRows = @($script:capturedExport | Where-Object { $_.Category -eq 'Device Configuration' })
         $configRows.Count | Should -Be 1
         $configRows[0].AssignmentReason | Should -BeExactly 'Inherited Exclusion (via All Staff)'
+    }
+
+    It 'returns custom and mixed Imported Administrative Templates but excludes built-in-only configurations' {
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'groupPolicyConfigurations') {
+                return @(
+                    [PSCustomObject]@{ id = 'iat-custom'; displayName = 'Imported Chrome ADMX'; policyConfigurationIngestionType = 'custom'; roleScopeTagIds = @('0') }
+                    [PSCustomObject]@{ id = 'iat-mixed'; displayName = 'Mixed Office ADMX'; policyConfigurationIngestionType = 'mixed'; roleScopeTagIds = @('0') }
+                    [PSCustomObject]@{ id = 'iat-built-in'; displayName = 'Built-in Policy'; policyConfigurationIngestionType = 'builtIn'; roleScopeTagIds = @('0') }
+                )
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityType -eq 'groupPolicyConfigurations' -and $EntityId -in @('iat-custom', 'iat-mixed')) {
+                return @([PSCustomObject]@{ Reason = 'Direct Assignment'; GroupId = $script:groupGuid; FilterId = $null; FilterType = $null })
+            }
+            @()
+        }
+
+        Get-IntuneGroupAssignment -GroupNames $script:groupGuid -IncludeNestedGroups
+
+        $rows = @($script:capturedExport | Where-Object { $_.Category -eq 'Imported Administrative Template' })
+        @($rows | ForEach-Object { $_.Item }) | Should -Be @('Imported Chrome ADMX (ID: iat-custom)', 'Mixed Office ADMX (ID: iat-mixed)')
+        @($rows.AssignmentReason | Select-Object -Unique) | Should -Be @('Direct Assignment')
+        Should -Invoke Get-IntuneAssignments -Exactly 0 -ParameterFilter {
+            $EntityType -eq 'groupPolicyConfigurations' -and $EntityId -eq 'iat-built-in'
+        }
     }
 
     It 'passes the direct and parent group ids to the category scan' {

--- a/Tests/Unit/GroupInfo.Tests.ps1
+++ b/Tests/Unit/GroupInfo.Tests.ps1
@@ -1,0 +1,126 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $modulePrivate = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker/Private'
+
+    function Invoke-MgGraphRequest {
+        param([string]$Uri, [string]$Method)
+        $null = $Uri
+        $null = $Method
+    }
+
+    . (Join-Path $modulePrivate 'ConvertTo-IntuneGroupInfo.ps1')
+    . (Join-Path $modulePrivate 'Get-GroupInfo.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+}
+
+Describe 'ConvertTo-IntuneGroupInfo' {
+    It 'classifies assigned and dynamic Microsoft 365 groups from the Unified group type' {
+        $assigned = ConvertTo-IntuneGroupInfo -Group ([PSCustomObject]@{
+                id = 'm365-assigned'; displayName = 'Messaging'; groupTypes = @('Unified')
+                mailEnabled = $true; securityEnabled = $false; mail = 'messaging@contoso.com'
+            })
+        $dynamic = ConvertTo-IntuneGroupInfo -Group ([PSCustomObject]@{
+                id = 'm365-dynamic'; displayName = 'Dynamic Messaging'; groupTypes = @('Unified', 'DynamicMembership')
+                mailEnabled = $true; securityEnabled = $true; mail = 'dynamic@contoso.com'
+            })
+
+        $assigned.GroupType | Should -BeExactly 'Microsoft 365'
+        $assigned.MembershipType | Should -BeExactly 'Assigned'
+        $assigned.IsMicrosoft365 | Should -BeTrue
+        $assigned.Mail | Should -BeExactly 'messaging@contoso.com'
+        $dynamic.GroupType | Should -BeExactly 'Microsoft 365'
+        $dynamic.MembershipType | Should -BeExactly 'Dynamic'
+        $dynamic.IsMicrosoft365 | Should -BeTrue
+    }
+
+    It 'distinguishes the other Microsoft Graph group types' -ForEach @(
+        @{ Expected = 'Security'; MailEnabled = $false; SecurityEnabled = $true }
+        @{ Expected = 'Mail-enabled Security'; MailEnabled = $true; SecurityEnabled = $true }
+        @{ Expected = 'Distribution'; MailEnabled = $true; SecurityEnabled = $false }
+        @{ Expected = 'Unknown'; MailEnabled = $false; SecurityEnabled = $false }
+    ) {
+        $result = ConvertTo-IntuneGroupInfo -Group ([PSCustomObject]@{
+                id = 'group-1'; displayName = 'Group'; groupTypes = @()
+                mailEnabled = $MailEnabled; securityEnabled = $SecurityEnabled
+            })
+
+        $result.GroupType | Should -BeExactly $Expected
+        $result.IsMicrosoft365 | Should -BeFalse
+    }
+
+    It 'marks a partial Graph payload without an Object ID as unsuccessful' {
+        $result = ConvertTo-IntuneGroupInfo -Group ([PSCustomObject]@{
+                displayName = 'Incomplete Group'; groupTypes = @('Unified')
+                mailEnabled = $true; securityEnabled = $false
+            })
+
+        $result.Success | Should -BeFalse
+    }
+}
+
+Describe 'Get-GroupInfo' {
+    BeforeEach {
+        $script:GroupInfoCache = $null
+        Mock Write-Warning {}
+        Mock Invoke-MgGraphRequest {
+            [PSCustomObject]@{
+                id = 'm365-1'; displayName = 'Messaging Team'; groupTypes = @('Unified')
+                mailEnabled = $true; securityEnabled = $false; mail = 'messaging@contoso.com'
+            }
+        }
+    }
+
+    It 'requests the Microsoft 365 classification fields and caches the enriched result' {
+        $first = Get-GroupInfo -GroupId 'm365-1'
+        $second = Get-GroupInfo -GroupId 'm365-1'
+
+        $first.GroupType | Should -BeExactly 'Microsoft 365'
+        $first.Mail | Should -BeExactly 'messaging@contoso.com'
+        $second | Should -Be $first
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+            $Method -eq 'Get' -and
+            $Uri -eq 'https://graph.test/v1.0/groups/m365-1?$select=id,displayName,groupTypes,mailEnabled,securityEnabled,mail'
+        }
+    }
+
+    It 'returns a complete unknown result when Graph lookup fails' {
+        Mock Invoke-MgGraphRequest { throw 'service unavailable' }
+
+        $result = Get-GroupInfo -GroupId 'missing-group'
+
+        $result.Success | Should -BeFalse
+        $result.GroupType | Should -BeExactly 'Unknown'
+        $result.MembershipType | Should -BeExactly 'Unknown'
+        $result.IsMicrosoft365 | Should -BeFalse
+        Should -Invoke Write-Warning -Exactly 1 -ParameterFilter {
+            $Message -like "Group 'missing-group' lookup failed:*service unavailable*"
+        }
+    }
+
+    It 'does not warn when Graph reports a message-only 404 for a stale group assignment' {
+        Mock Invoke-MgGraphRequest { throw '404 Request_ResourceNotFound: Group was not found' }
+
+        $result = Get-GroupInfo -GroupId 'deleted-group'
+
+        $result.Success | Should -BeFalse
+        $result.DisplayName | Should -BeExactly 'Unknown Group'
+        Should -Invoke Write-Warning -Exactly 0
+    }
+
+    It 'rejects and diagnoses a successful response that omits the group Object ID' {
+        Mock Invoke-MgGraphRequest {
+            [PSCustomObject]@{ displayName = 'Incomplete'; groupTypes = @('Unified'); mailEnabled = $true }
+        }
+
+        $result = Get-GroupInfo -GroupId 'incomplete-group'
+
+        $result.Success | Should -BeFalse
+        $result.DisplayName | Should -BeExactly 'Unknown Group'
+        Should -Invoke Write-Warning -Exactly 1 -ParameterFilter {
+            $Message -like "Group 'incomplete-group' lookup failed:*without an Object ID*"
+        }
+    }
+}

--- a/Tests/Unit/HtmlReportCsv.Tests.ps1
+++ b/Tests/Unit/HtmlReportCsv.Tests.ps1
@@ -1,0 +1,323 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-PolicyPlatform.ps1')
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $moduleRoot 'html-export.ps1')
+    . (Join-Path $moduleRoot 'Public/New-IntuneHTMLReport.ps1')
+    . (Join-Path $moduleRoot 'Public/Invoke-IntuneAssignmentChecker.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+
+    function Get-IntuneEntities { param([string]$EntityType) @() }
+    function Get-IntuneAssignments { param([string]$EntityType, [string]$EntityId) @() }
+    function Get-AppProtectionAssignmentUri { param($Policy) $null }
+    function Add-IntentTemplateFamilyInfo { param($IntentPolicies) }
+    function Invoke-MgGraphRequest { param([string]$Uri, [string]$Method) @{ value = @() } }
+    function Get-GroupInfo { param([string]$GroupId) @{ DisplayName = "Group $GroupId"; Success = $true } }
+    function Connect-IntuneAssignmentChecker {}
+    function Get-MgContext { @{ Account = 'test@contoso.com' } }
+}
+
+Describe 'HTML report CSV companion' {
+    BeforeEach {
+        $script:ScopeTagLookup = @{ '0' = 'Default'; 'tag-ops' = 'Operations' }
+        Mock Write-Host {}
+        Mock Write-Warning {}
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'deviceConfigurations') {
+                return @([PSCustomObject]@{
+                        id = 'cfg-1'
+                        displayName = 'Déploiement Baseline'
+                        roleScopeTagIds = @('0', 'tag-ops')
+                        '@odata.type' = '#microsoft.graph.windows10GeneralConfiguration'
+                    })
+            }
+            @()
+        }
+        Mock Get-IntuneAssignments {
+            if ($EntityId -eq 'cfg-1') {
+                return @([PSCustomObject]@{
+                        Reason = 'All Users'
+                        GroupId = $null
+                        FilterId = $null
+                        FilterType = $null
+                    })
+            }
+            @()
+        }
+        Mock Get-AppProtectionAssignmentUri { $null }
+        Mock Add-IntentTemplateFamilyInfo {}
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+    }
+
+    It 'exports the requested stable CSV schema with the same report data' {
+        $htmlPath = Join-Path $TestDrive 'reports/report.html'
+        $csvPath = Join-Path $TestDrive 'central/intune.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+
+        Export-HTMLReport -FilePath $htmlPath -CSVReportPath $csvPath
+
+        $htmlPath | Should -Exist
+        $csvPath | Should -Exist
+        $rows = @(Import-Csv -Path $csvPath)
+        $rows | Should -HaveCount 1
+        @($rows[0].PSObject.Properties.Name) | Should -Be @(
+            'Category', 'Name', 'ID', 'Type', 'Platform', 'ScopeTags', 'AssignmentType', 'AssignedTo', 'Filter'
+        )
+        $rows[0].Category | Should -BeExactly 'Device Configurations'
+        $rows[0].Name | Should -BeExactly 'Déploiement Baseline'
+        $rows[0].ID | Should -BeExactly 'cfg-1'
+        $rows[0].Type | Should -BeExactly 'Device Configuration'
+        $rows[0].Platform | Should -BeExactly 'Windows'
+        $rows[0].ScopeTags | Should -BeExactly 'Default, Operations'
+        $rows[0].AssignmentType | Should -BeExactly 'All Users'
+        $rows[0].AssignedTo | Should -BeExactly 'All Users'
+        $rows[0].Filter | Should -BeExactly 'None'
+    }
+
+    It 'uses the HTML base path for the CSV companion by default' {
+        $htmlPath = Join-Path $TestDrive 'default/report.html'
+        $expectedCsvPath = Join-Path $TestDrive 'default/report.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+
+        Export-HTMLReport -FilePath $htmlPath
+
+        $htmlPath | Should -Exist
+        $expectedCsvPath | Should -Exist
+    }
+
+    It 'writes the stable header when the report contains no rows' {
+        Mock Get-IntuneEntities { @() }
+        $htmlPath = Join-Path $TestDrive 'empty/report.html'
+        $csvPath = Join-Path $TestDrive 'empty/report.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+
+        Export-HTMLReport -FilePath $htmlPath -CSVReportPath $csvPath
+
+        (Get-Content -Path $csvPath -Raw).Trim() | Should -BeExactly '"Category","Name","ID","Type","Platform","ScopeTags","AssignmentType","AssignedTo","Filter"'
+    }
+
+    It 'keeps a completed HTML report when the CSV path cannot be created' {
+        $htmlPath = Join-Path $TestDrive 'partial/report.html'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+        Mock Export-Csv { throw 'simulated CSV write failure' }
+
+        { Export-HTMLReport -FilePath $htmlPath } | Should -Not -Throw
+
+        $htmlPath | Should -Exist
+        Should -Invoke Write-Warning -Exactly 1 -ParameterFilter { $Message -like "Failed to export CSV report*" }
+    }
+
+    It 'isolates an unusable CSV path when called through the public cmdlet' {
+        $htmlPath = Join-Path $TestDrive 'public/report.html'
+        $invalidCsvPath = Join-Path $TestDrive 'existing-file-without-csv-extension'
+        Set-Content -Path $invalidCsvPath -Value 'file'
+
+        { New-IntuneHTMLReport -HTMLReportPath $htmlPath -CSVReportPath $invalidCsvPath } | Should -Not -Throw
+
+        $htmlPath | Should -Exist
+        Should -Invoke Write-Warning -Exactly 1 -ParameterFilter { $Message -like "Failed to export CSV report*existing file without a .csv extension*" }
+    }
+
+    It 'supports a central directory path and derives the CSV name from the HTML report' {
+        $htmlPath = Join-Path $TestDrive 'named/custom-report.html'
+        $csvDirectory = Join-Path $TestDrive 'central-directory'
+
+        New-IntuneHTMLReport -HTMLReportPath $htmlPath -CSVReportPath $csvDirectory
+
+        $htmlPath | Should -Exist
+        (Join-Path $csvDirectory 'custom-report.csv') | Should -Exist
+    }
+
+    It 'resolves relative report paths against the PowerShell location' {
+        $workingDirectory = Join-Path $TestDrive 'relative-location'
+        New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+
+        Push-Location $workingDirectory
+        try {
+            New-IntuneHTMLReport -HTMLReportPath 'relative-report.html' -CSVReportPath 'relative-report.csv'
+        }
+        finally {
+            Pop-Location
+        }
+
+        (Join-Path $workingDirectory 'relative-report.html') | Should -Exist
+        (Join-Path $workingDirectory 'relative-report.csv') | Should -Exist
+    }
+
+    It 'rejects a mistyped CSV file extension without blocking HTML output' {
+        $htmlPath = Join-Path $TestDrive 'mistyped/report.html'
+        $mistypedCsvPath = Join-Path $TestDrive 'mistyped/intune.cvs'
+
+        New-IntuneHTMLReport -HTMLReportPath $htmlPath -CSVReportPath $mistypedCsvPath
+
+        $htmlPath | Should -Exist
+        $mistypedCsvPath | Should -Not -Exist
+        Should -Invoke Write-Warning -Exactly 1 -ParameterFilter { $Message -like 'Failed to export CSV report*must be a .csv file*' }
+    }
+
+    It 'supports explicit HTML-only report generation' {
+        $htmlPath = Join-Path $TestDrive 'html-only/report.html'
+        $csvPath = Join-Path $TestDrive 'html-only/report.csv'
+
+        New-IntuneHTMLReport -HTMLReportPath $htmlPath -NoCSVReport
+
+        $htmlPath | Should -Exist
+        $csvPath | Should -Not -Exist
+    }
+
+    It 'rejects conflicting CSV options at parameter binding before report generation starts' {
+        $htmlPath = Join-Path $TestDrive 'conflict/report.html'
+        $csvPath = Join-Path $TestDrive 'conflict/report.csv'
+
+        { New-IntuneHTMLReport -HTMLReportPath $htmlPath -CSVReportPath $csvPath -NoCSVReport } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+
+        $htmlPath | Should -Not -Exist
+        $csvPath | Should -Not -Exist
+        Should -Invoke Write-Host -Exactly 0 -ParameterFilter { $Object -eq 'Generating HTML Report...' }
+    }
+
+    It 'notifies before replacing an existing CSV companion without using the warning stream' {
+        $htmlPath = Join-Path $TestDrive 'overwrite/report.html'
+        $csvPath = Join-Path $TestDrive 'overwrite/report.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+        Set-Content -Path $csvPath -Value 'old data'
+
+        Export-HTMLReport -FilePath $htmlPath
+
+        Should -Invoke Write-Host -Exactly 1 -ParameterFilter { $Object -like 'Replacing existing CSV report*' }
+        Should -Invoke Write-Warning -Exactly 0
+        @(Import-Csv -Path $csvPath) | Should -HaveCount 1
+    }
+
+    It 'neutralizes spreadsheet formula prefixes in tenant-controlled CSV values' {
+        foreach ($value in @('=1+1', '+SUM(A1:A2)', '-2+3', '@cmd', "`tformula", "`rformula")) {
+            (ConvertTo-IntuneCsvSafeValue $value) | Should -BeExactly "'$value"
+        }
+        ConvertTo-IntuneCsvSafeValue 'Normal value' | Should -BeExactly 'Normal value'
+    }
+
+    It 'keeps filters positionally aligned with their assignment targets' {
+        $script:AssignmentFilterLookup = @{ 'filter-corp' = @{ Name = 'Corporate Devices' } }
+        $assignmentInfo = Get-HtmlAssignmentInfo -Assignments @(
+            [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'group-a'; FilterId = $null; FilterType = $null }
+            [PSCustomObject]@{ Reason = 'Group Assignment'; GroupId = 'group-b'; FilterId = 'filter-corp'; FilterType = 'include' }
+        )
+
+        $assignmentInfo.Target | Should -BeExactly 'Group group-a; Group group-b'
+        $assignmentInfo.Filter | Should -BeExactly 'None; Corporate Devices [Include]'
+    }
+
+    It 'uses an empty platform and a consistent None sentinel when no assignment filter exists' {
+        Mock Get-PolicyPlatform { '' }
+        Mock Get-IntuneAssignments { @() }
+        $htmlPath = Join-Path $TestDrive 'empty-values/report.html'
+        $csvPath = Join-Path $TestDrive 'empty-values/report.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+
+        Export-HTMLReport -FilePath $htmlPath -CSVReportPath $csvPath
+
+        $row = @(Import-Csv -Path $csvPath)[0]
+        $row.Platform | Should -BeExactly ''
+        $row.Filter | Should -BeExactly 'None'
+    }
+
+    It 'retains mobile-app type metadata for platform classification in report rows' {
+        Mock Get-IntuneEntities { @() }
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*deviceAppManagement/mobileApps?*isAssigned*') {
+                return @{ value = @([PSCustomObject]@{
+                            id = 'app-ios'
+                            displayName = 'iOS Store App'
+                            roleScopeTagIds = @('tag-ops')
+                            '@odata.type' = '#microsoft.graph.iosStoreApp'
+                        }) }
+            }
+            if ($Uri -like "*mobileApps('app-ios')/assignments*") {
+                return @{ value = @([PSCustomObject]@{
+                            intent = 'required'
+                            target = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' }
+                        }) }
+            }
+            @{ value = @() }
+        }
+        $htmlPath = Join-Path $TestDrive 'app-platform/report.html'
+        $csvPath = Join-Path $TestDrive 'app-platform/report.csv'
+        New-Item -ItemType Directory -Path (Split-Path $htmlPath -Parent) -Force | Out-Null
+
+        Export-HTMLReport -FilePath $htmlPath -CSVReportPath $csvPath
+
+        $row = @(Import-Csv -Path $csvPath | Where-Object ID -EQ 'app-ios')
+        $row | Should -HaveCount 1
+        $row[0].Category | Should -BeExactly 'Required Applications'
+        $row[0].Platform | Should -BeExactly 'iOS/iPadOS'
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+            $Uri -like '*deviceAppManagement/mobileApps?*' -and $Uri -like '*$select=id,displayName,roleScopeTagIds*'
+        }
+    }
+
+    It 'exposes CSVReportPath through both public entry points' {
+        (Get-Command New-IntuneHTMLReport).Parameters.Keys | Should -Contain 'CSVReportPath'
+        (Get-Command New-IntuneHTMLReport).Parameters.Keys | Should -Contain 'NoCSVReport'
+        (Get-Command Invoke-IntuneAssignmentChecker).Parameters.Keys | Should -Contain 'CSVReportPath'
+        (Get-Command Invoke-IntuneAssignmentChecker).Parameters.Keys | Should -Contain 'NoCSVReport'
+    }
+
+    Context 'Invoke-IntuneAssignmentChecker report dispatch' {
+        BeforeEach {
+            Mock Connect-IntuneAssignmentChecker {}
+            Mock Get-MgContext { @{ Account = 'test@contoso.com' } }
+            Mock New-IntuneHTMLReport {}
+        }
+
+        It 'dispatches default companion report generation without inactive parameters' {
+            Invoke-IntuneAssignmentChecker -GenerateHTMLReport
+
+            Should -Invoke New-IntuneHTMLReport -Exactly 1 -ParameterFilter {
+                -not $HTMLReportPath -and -not $CSVReportPath -and -not $NoCSVReport
+            }
+        }
+
+        It 'dispatches an explicit CSV destination to the report cmdlet' {
+            $csvPath = Join-Path $TestDrive 'dispatch/central.csv'
+
+            Invoke-IntuneAssignmentChecker -CSVReportPath $csvPath
+
+            Should -Invoke New-IntuneHTMLReport -Exactly 1 -ParameterFilter {
+                $CSVReportPath -eq $csvPath -and -not $NoCSVReport
+            }
+        }
+
+        It 'dispatches HTML-only generation without supplying a CSV path' {
+            Invoke-IntuneAssignmentChecker -GenerateHTMLReport -NoCSVReport
+
+            Should -Invoke New-IntuneHTMLReport -Exactly 1 -ParameterFilter {
+                $NoCSVReport -and -not $CSVReportPath
+            }
+        }
+
+        It 'treats NoCSVReport by itself as an HTML-only report request' {
+            Invoke-IntuneAssignmentChecker -NoCSVReport
+
+            Should -Invoke New-IntuneHTMLReport -Exactly 1 -ParameterFilter {
+                $NoCSVReport -and -not $CSVReportPath
+            }
+        }
+
+        It 'rejects contradictory report options before attempting authentication' {
+            $csvPath = Join-Path $TestDrive 'dispatch/conflict.csv'
+
+            { Invoke-IntuneAssignmentChecker -GenerateHTMLReport -CSVReportPath $csvPath -NoCSVReport } |
+                Should -Throw '*-NoCSVReport cannot be combined with -CSVReportPath*'
+
+            Should -Invoke Connect-IntuneAssignmentChecker -Exactly 0
+            Should -Invoke New-IntuneHTMLReport -Exactly 0
+        }
+    }
+}

--- a/Tests/Unit/ImportedAdministrativeTemplates.Tests.ps1
+++ b/Tests/Unit/ImportedAdministrativeTemplates.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+    . (Join-Path $modulePrivate 'Get-IntuneAssignments.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
+
+    $script:GraphEndpoint = 'https://graph.test'
+
+    function Invoke-MgGraphRequest {
+        param([string]$Uri, [string]$Method)
+        @{ value = @() }
+    }
+}
+
+Describe 'Test-ImportedAdministrativeTemplate' {
+    It 'recognizes custom and mixed configurations only' {
+        Test-ImportedAdministrativeTemplate -Policy ([PSCustomObject]@{ policyConfigurationIngestionType = 'custom' }) | Should -BeTrue
+        Test-ImportedAdministrativeTemplate -Policy ([PSCustomObject]@{ policyConfigurationIngestionType = 'mixed' }) | Should -BeTrue
+        Test-ImportedAdministrativeTemplate -Policy ([PSCustomObject]@{ policyConfigurationIngestionType = 'builtIn' }) | Should -BeFalse
+        Test-ImportedAdministrativeTemplate -Policy ([PSCustomObject]@{ policyConfigurationIngestionType = 'unknownFutureValue' }) | Should -BeFalse
+    }
+
+    It 'keeps every hand-wired reporting surface on the shared classification helper' {
+        $relativePaths = @(
+            'Public/Get-IntuneUserDeviceAssignment.ps1'
+            'Public/Get-IntuneUnassignedPolicy.ps1'
+            'Public/Get-IntuneEmptyGroup.ps1'
+            'html-export.ps1'
+        )
+
+        foreach ($relativePath in $relativePaths) {
+            $source = Get-Content -Path (Join-Path $moduleRoot $relativePath) -Raw
+            $source | Should -Match 'Get-IntuneEntities -EntityType "groupPolicyConfigurations"'
+            $source | Should -Match 'Where-Object \{ Test-ImportedAdministrativeTemplate -Policy \$_ \}'
+        }
+    }
+
+    It 'keeps manual buckets, exports, Windows gating, and HTML output wired to the imported category' {
+        $userDeviceSource = Get-Content -Path (Join-Path $moduleRoot 'Public/Get-IntuneUserDeviceAssignment.ps1') -Raw
+        $userDeviceSource | Should -Match '(?s)if \(-not \$deviceOS -or \$deviceOS -eq ''Windows''\) \{\s+Write-Host "  Imported Administrative Templates\.\.\.".*?relevantPolicies\.ImportedAdministrativeTemplates\.Add'
+        $userDeviceSource | Should -Match 'Category "Imported Administrative Template"\s+-Items \$relevantPolicies\.ImportedAdministrativeTemplates'
+
+        $unassignedSource = Get-Content -Path (Join-Path $moduleRoot 'Public/Get-IntuneUnassignedPolicy.ps1') -Raw
+        $unassignedSource | Should -Match 'unassignedPolicies\.ImportedAdministrativeTemplates'
+        $unassignedSource | Should -Match 'Category "Imported Administrative Template"'
+
+        $emptyGroupSource = Get-Content -Path (Join-Path $moduleRoot 'Public/Get-IntuneEmptyGroup.ps1') -Raw
+        $emptyGroupSource | Should -Match 'emptyGroupAssignments\.ImportedAdministrativeTemplates'
+        $emptyGroupSource | Should -Match 'Category "Imported Administrative Template"'
+
+        $htmlSource = Get-Content -Path (Join-Path $moduleRoot 'html-export.ps1') -Raw
+        $htmlSource | Should -Match 'policies\.ImportedAdministrativeTemplates'
+        $htmlSource | Should -Match 'Platform\s+= "Windows"'
+        $htmlSource | Should -Match "Key = 'ImportedAdministrativeTemplates'; Name = 'Imported Administrative Templates'"
+        $htmlSource | Should -Match '\$\(\$policies\.ImportedAdministrativeTemplates\.Count\)'
+    }
+}
+
+Describe 'Imported Administrative Template assignments' {
+    BeforeEach {
+        Mock Write-Warning {}
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+    }
+
+    It 'uses the documented resource-path URI and follows assignment pagination' {
+        $script:expectedGroupId = '11111111-1111-1111-1111-111111111111'
+        $firstPage = 'https://graph.test/beta/deviceManagement/groupPolicyConfigurations/imported-1/assignments'
+        $nextPage = 'https://graph.test/imported-assignments-page-2'
+
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -eq $firstPage) {
+                return @{
+                    value = @(
+                        [PSCustomObject]@{
+                            target = [PSCustomObject]@{
+                                '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                                groupId = $script:expectedGroupId
+                            }
+                        }
+                    )
+                    '@odata.nextLink' = $nextPage
+                }
+            }
+            if ($Uri -eq $nextPage) {
+                return @{
+                    value = @(
+                        [PSCustomObject]@{
+                            target = [PSCustomObject]@{
+                                '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                                groupId = $script:expectedGroupId
+                            }
+                        }
+                    )
+                }
+            }
+            throw "Unexpected URI: $Uri"
+        }
+
+        $assignments = @(Get-IntuneAssignments -EntityType 'groupPolicyConfigurations' -EntityId 'imported-1')
+
+        $assignments.Reason | Should -Be @('Group Assignment', 'Group Exclusion')
+        $assignments.GroupId | Should -Be @($script:expectedGroupId, $script:expectedGroupId)
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter { $Uri -eq $firstPage -and $Method -eq 'Get' }
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter { $Uri -eq $nextPage -and $Method -eq 'Get' }
+    }
+
+    It 'preserves group filtering semantics for an imported template' {
+        $wantedGroup = '11111111-1111-1111-1111-111111111111'
+        Mock Invoke-MgGraphRequest {
+            @{
+                value = @(
+                    [PSCustomObject]@{ target = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $wantedGroup } }
+                    [PSCustomObject]@{ target = [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = 'other-group' } }
+                )
+            }
+        }
+
+        $assignments = @(Get-IntuneAssignments -EntityType 'groupPolicyConfigurations' -EntityId 'imported-2' -GroupIds @($wantedGroup))
+
+        $assignments | Should -HaveCount 1
+        $assignments[0].Reason | Should -BeExactly 'Direct Assignment'
+        $assignments[0].GroupId | Should -BeExactly $wantedGroup
+    }
+}

--- a/Tests/Unit/MobileAppScopeTags.Tests.ps1
+++ b/Tests/Unit/MobileAppScopeTags.Tests.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 7.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+BeforeAll {
+    $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
+    $modulePrivate = Join-Path $moduleRoot 'Private'
+
+    . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
+    . (Join-Path $modulePrivate 'Add-ExportData.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
+    . (Join-Path $moduleRoot 'Public/Get-IntuneUnassignedPolicy.ps1')
+
+    function Get-IntuneEntities { param([string]$EntityType) @() }
+    function Get-IntuneAssignments { param([string]$EntityType, [string]$EntityId) @() }
+    function Get-AppProtectionAssignmentUri { param($Policy) $null }
+    function Add-IntentTemplateFamilyInfo { param($IntentPolicies) }
+    function Invoke-MgGraphRequest { param([string]$Uri, [string]$Method) @{ value = @() } }
+    function Filter-ByScopeTag { param($Items) $Items }
+    function Export-ResultsIfRequested {
+        param(
+            [System.Collections.ArrayList]$ExportData,
+            [string]$DefaultFileName,
+            [switch]$ForceExport,
+            [string]$CustomExportPath,
+            [switch]$ExportToCSV,
+            [switch]$ParameterMode
+        )
+    }
+
+    $script:GraphEndpoint = 'https://graph.test'
+}
+
+Describe 'Mobile application scope tags' {
+    BeforeEach {
+        $script:ScopeTagLookup = @{ '0' = 'Default'; 'tag-finance' = 'Finance' }
+        $script:capturedExport = $null
+
+        Mock Write-Host
+        Mock Get-IntuneEntities { @() }
+        Mock Get-IntuneAssignments { @() }
+        Mock Add-IntentTemplateFamilyInfo
+        Mock Invoke-MgGraphRequest {
+            if ($Uri -like '*deviceAppManagement/mobileApps?*isAssigned eq false*') {
+                return @{
+                    value = @(
+                        [PSCustomObject]@{
+                            id              = 'unassigned-app'
+                            displayName     = 'Unassigned App'
+                            isFeatured      = $false
+                            roleScopeTagIds = @('0', 'tag-finance')
+                            '@odata.type'   = '#microsoft.graph.win32LobApp'
+                        }
+                    )
+                }
+            }
+            @{ value = @() }
+        }
+        Mock Export-ResultsIfRequested {
+            $script:capturedExport = @($ExportData)
+        }
+    }
+
+    It 'requests roleScopeTagIds in every active mobile-app collection query' {
+        $relativePaths = @(
+            'Private/Invoke-IntuneCategoryScan.ps1'
+            'Public/Get-IntuneUnassignedPolicy.ps1'
+            'Public/Get-IntuneUserDeviceAssignment.ps1'
+            'html-export.ps1'
+        )
+
+        foreach ($relativePath in $relativePaths) {
+            $source = Get-Content -Path (Join-Path $moduleRoot $relativePath) -Raw
+            $source | Should -Match 'deviceAppManagement/mobileApps\?[^"\r\n]*\$select=[^"\r\n]*roleScopeTagIds'
+        }
+    }
+
+    It 'exports all scope tags for an unassigned application' {
+        Get-IntuneUnassignedPolicy -ExportToCSV
+
+        $appRow = $script:capturedExport | Where-Object { $_.Item -eq 'Unassigned App (ID: unassigned-app)' }
+        $appRow.ScopeTags | Should -BeExactly 'Default, Finance'
+        Should -Invoke Invoke-MgGraphRequest -Exactly 1 -ParameterFilter {
+            $Uri -like '*deviceAppManagement/mobileApps?*' -and
+            $Uri -match '\$select=[^&]*roleScopeTagIds'
+        }
+    }
+
+    It 'exports unassigned custom and mixed imported templates but never queries built-in-only assignments' {
+        Mock Get-IntuneEntities {
+            if ($EntityType -eq 'groupPolicyConfigurations') {
+                return @(
+                    [PSCustomObject]@{ id = 'iat-custom'; displayName = 'Imported Chrome'; policyConfigurationIngestionType = 'custom' }
+                    [PSCustomObject]@{ id = 'iat-mixed'; displayName = 'Imported Office'; policyConfigurationIngestionType = 'mixed' }
+                    [PSCustomObject]@{ id = 'iat-built-in'; displayName = 'Built-in Policy'; policyConfigurationIngestionType = 'builtIn' }
+                )
+            }
+            @()
+        }
+
+        Get-IntuneUnassignedPolicy -ExportToCSV
+
+        @($script:capturedExport | Where-Object { $_.Category -eq 'Imported Administrative Template' } | ForEach-Object { $_.Item }) |
+            Should -Be @('Imported Chrome (ID: iat-custom)', 'Imported Office (ID: iat-mixed)')
+        Should -Invoke Get-IntuneAssignments -Exactly 0 -ParameterFilter { $EntityId -eq 'iat-built-in' }
+    }
+}

--- a/Tests/Unit/TestGroupMembership.Tests.ps1
+++ b/Tests/Unit/TestGroupMembership.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
     $modulePrivate = Join-Path $moduleRoot 'Private'
 
+    . (Join-Path $modulePrivate 'ConvertTo-IntuneGroupInfo.ps1')
     . (Join-Path $modulePrivate 'Get-Separator.ps1')
     . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
     . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
@@ -12,6 +13,7 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Resolve-SimulatedAssignmentDelta.ps1')
     . (Join-Path $modulePrivate 'Add-ExportData.ps1')
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $moduleRoot 'Public/Test-IntuneGroupMembership.ps1')
@@ -289,16 +291,17 @@ Describe 'Test-IntuneGroupMembership' {
         Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly -ParameterFilter { $Uri -like '*mobileApps?*isAssigned*' }
     }
 
-    It 'emits the legacy 18-step progress lines' {
+    It 'emits the 19-step progress lines including Imported Administrative Templates' {
         Test-IntuneGroupMembership -UserPrincipalNames 'user1@contoso.com' -SimulateTargetGroup 'Target Group'
 
-        $script:hostLines | Should -Contain '[1/18] Fetching Device Configurations...'
-        $script:hostLines | Should -Contain '[6/18] Fetching Applications...'
-        $script:hostLines | Should -Contain '[9/18] Fetching Antivirus Policies...'
-        $script:hostLines | Should -Contain '[12/18] Fetching Endpoint Detection and Response Policies...'
-        $script:hostLines | Should -Contain '[15/18] Fetching Autopilot Deployment Profiles...'
-        $script:hostLines | Should -Contain '[16/18] Fetching Enrollment Status Page Profiles...'
-        $script:hostLines | Should -Contain '[18/18] Fetching Windows 365 Cloud PC User Settings...'
+        $script:hostLines | Should -Contain '[1/19] Fetching Device Configurations...'
+        $script:hostLines | Should -Contain '[2/19] Fetching Imported Administrative Templates...'
+        $script:hostLines | Should -Contain '[7/19] Fetching Applications...'
+        $script:hostLines | Should -Contain '[10/19] Fetching Antivirus Policies...'
+        $script:hostLines | Should -Contain '[13/19] Fetching Endpoint Detection and Response Policies...'
+        $script:hostLines | Should -Contain '[16/19] Fetching Autopilot Deployment Profiles...'
+        $script:hostLines | Should -Contain '[17/19] Fetching Enrollment Status Page Profiles...'
+        $script:hostLines | Should -Contain '[19/19] Fetching Windows 365 Cloud PC User Settings...'
     }
 
     It 'escapes single quotes in the group name OData filter (F9)' {
@@ -312,7 +315,7 @@ Describe 'Test-IntuneGroupMembership' {
 
         $expectedOrder = @(
             'Simulation Info',
-            'NEW: Device Configuration', 'NEW: Settings Catalog Policy', 'NEW: Compliance Policy',
+            'NEW: Device Configuration', 'NEW: Imported Administrative Template', 'NEW: Settings Catalog Policy', 'NEW: Compliance Policy',
             'NEW: App Protection Policy', 'NEW: App Configuration Policy',
             'NEW: Required App', 'NEW: Available App', 'NEW: Uninstall App',
             'NEW: Platform Script', 'NEW: Proactive Remediation Script',

--- a/Tests/Unit/TestGroupRemoval.Tests.ps1
+++ b/Tests/Unit/TestGroupRemoval.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     $moduleRoot = Join-Path $PSScriptRoot '../../Module/IntuneAssignmentChecker'
     $modulePrivate = Join-Path $moduleRoot 'Private'
 
+    . (Join-Path $modulePrivate 'ConvertTo-IntuneGroupInfo.ps1')
     . (Join-Path $modulePrivate 'Get-Separator.ps1')
     . (Join-Path $modulePrivate 'Get-ScopeTagNames.ps1')
     . (Join-Path $modulePrivate 'Format-AssignmentFilter.ps1')
@@ -12,6 +13,7 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Resolve-SimulatedAssignmentDelta.ps1')
     . (Join-Path $modulePrivate 'Add-ExportData.ps1')
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $moduleRoot 'Public/Test-IntuneGroupRemoval.ps1')
@@ -265,14 +267,15 @@ Describe 'Test-IntuneGroupRemoval' {
             $row.Item | Should -Be 'AP AllDev (ID: ap-alldev)'
         }
 
-        It 'walks the 18 categories in the legacy order' {
-            $headers = @($script:hostLines | Where-Object { $_ -match '^\[\d+/18\] Fetching ' })
-            $headers | Should -HaveCount 18
-            $headers[0] | Should -Be '[1/18] Fetching Device Configurations...'
-            $headers[5] | Should -Be '[6/18] Fetching Applications...'
-            $headers[8] | Should -Be '[9/18] Fetching Antivirus Policies...'
-            $headers[14] | Should -Be '[15/18] Fetching Autopilot Deployment Profiles...'
-            $headers[17] | Should -Be '[18/18] Fetching Windows 365 Cloud PC User Settings...'
+        It 'walks the 19 categories including Imported Administrative Templates' {
+            $headers = @($script:hostLines | Where-Object { $_ -match '^\[\d+/19\] Fetching ' })
+            $headers | Should -HaveCount 19
+            $headers[0] | Should -Be '[1/19] Fetching Device Configurations...'
+            $headers[1] | Should -Be '[2/19] Fetching Imported Administrative Templates...'
+            $headers[6] | Should -Be '[7/19] Fetching Applications...'
+            $headers[9] | Should -Be '[10/19] Fetching Antivirus Policies...'
+            $headers[15] | Should -Be '[16/19] Fetching Autopilot Deployment Profiles...'
+            $headers[18] | Should -Be '[19/19] Fetching Windows 365 Cloud PC User Settings...'
         }
 
         It 'skips unlicensed Windows 365 categories without failing the run' {

--- a/Tests/Unit/UserAssignment.Tests.ps1
+++ b/Tests/Unit/UserAssignment.Tests.ps1
@@ -14,6 +14,7 @@ BeforeAll {
     . (Join-Path $modulePrivate 'Add-ExportData.ps1')
     . (Join-Path $modulePrivate 'Add-CategoryExportData.ps1')
     . (Join-Path $modulePrivate 'Get-AppProtectionAssignmentUri.ps1')
+    . (Join-Path $modulePrivate 'Test-ImportedAdministrativeTemplate.ps1')
     . (Join-Path $modulePrivate 'Get-IntuneCategoryDefinition.ps1')
     . (Join-Path $modulePrivate 'Invoke-IntuneCategoryScan.ps1')
     . (Join-Path $moduleRoot 'Public/Get-IntuneUserAssignment.ps1')


### PR DESCRIPTION
## Summary

Release IntuneAssignmentChecker 4.3.2 with broader assignment coverage and reporting improvements:

- Recognize Microsoft 365 (Unified) groups as Intune assignment targets and include group type, membership mode, and mail metadata in group exports.
- Add Imported Administrative Template coverage across assignment checks, simulations, search, CSV output, and HTML reports.
- Honor an explicit application/client ID during delegated interactive authentication, with optional tenant selection.
- Return all application scope tags by explicitly selecting `roleScopeTagIds`.
- Add a stable, formula-safe CSV companion to HTML reports, with custom destination and HTML-only options.
- Include assigned applications regardless of the unrelated `isFeatured` flag.

## Microsoft Graph validation

The Graph-dependent response contracts were verified read-only through Lokka MCP against the Microsoft Graph beta endpoint, including:

- Microsoft 365 group classification properties
- group not-found error shape
- Group Policy Configuration resources and assignments
- assigned mobile-app type and scope-tag properties
- mobile-app assignment intent and target shapes
- Intune role scope tags

The active validation tenant did not contain tagged/featured app fixtures or imported custom templates, so those exact cases are covered by regression tests rather than tenant mutation.

## Validation

- Module manifest and imported module version: `4.3.2`
- Exported commands: 19 functions and 1 alias
- Pester: 216 passed, 0 failed
- `git diff --check`: clean
- PSScriptAnalyzer: no new warnings or errors in release-modified core files
- Individual issue reviews and complete branch review by Claude Opus 5: PASS, with no remaining actionable findings

Closes #128
Closes #129
Closes #130
Closes #131
Closes #132
Closes #134
